### PR TITLE
Bump GitHub Actions (checkout v7, upload/download-artifact, gh-release v3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       TCODE_LIVE_TESTS: 0
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
       RELEASE_TAG: ${{ needs.setup.outputs.tag }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.setup.outputs.tag }}
 
@@ -206,7 +206,7 @@ jobs:
         run: ls -lh dist
 
       - name: Upload packaged artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: package-${{ matrix.platform }}-${{ matrix.arch }}
           path: |
@@ -222,7 +222,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download all packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: package-*
           path: dist
@@ -232,7 +232,7 @@ jobs:
         run: ls -lh dist
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.setup.outputs.tag }}
           prerelease: ${{ needs.setup.outputs.prerelease }}


### PR DESCRIPTION
Batches dependabot #2-#5 onto current main. Their individual runs were red only because they branched before the clippy/fmt cleanup.