### PR TITLE
Bump gpui to zed 65e1c5a (dependabot #6, rebased)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,7 +733,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2030,7 +2030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2788,7 +2788,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.62.2",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -3013,7 +3013,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#76c93968da5b8b8809bdd72e4ad9e7d0e946bad0"
+source = "git+https://github.com/zed-industries/zed#65e1c5af258d4c80036467d583691f3f9ded0897"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -3064,7 +3064,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#76c93968da5b8b8809bdd72e4ad9e7d0e946bad0"
+source = "git+https://github.com/zed-industries/zed#65e1c5af258d4c80036467d583691f3f9ded0897"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -3122,7 +3122,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#76c93968da5b8b8809bdd72e4ad9e7d0e946bad0"
+source = "git+https://github.com/zed-industries/zed#65e1c5af258d4c80036467d583691f3f9ded0897"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -3155,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#76c93968da5b8b8809bdd72e4ad9e7d0e946bad0"
+source = "git+https://github.com/zed-industries/zed#65e1c5af258d4c80036467d583691f3f9ded0897"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#76c93968da5b8b8809bdd72e4ad9e7d0e946bad0"
+source = "git+https://github.com/zed-industries/zed#65e1c5af258d4c80036467d583691f3f9ded0897"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3208,7 +3208,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#76c93968da5b8b8809bdd72e4ad9e7d0e946bad0"
+source = "git+https://github.com/zed-industries/zed#65e1c5af258d4c80036467d583691f3f9ded0897"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3613,7 +3613,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -4926,7 +4926,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -6079,7 +6079,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6717,7 +6717,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6730,7 +6730,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7180,7 +7180,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 5.0.1",
 ]
 
 [[package]]
@@ -7825,7 +7825,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9517,7 +9517,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Rebased #6 onto current main. Local: build + 223 tests + clippy + smoke all green. CI decides Windows/Linux.