### PR TITLE
Run blocking work on gpui's executor, not smol's pool

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1209,7 +1209,10 @@ impl AppState {
         self.git_status_generation += 1;
         let generation = self.git_status_generation;
         cx.spawn(async move |this, cx| {
-            let status = smol::unblock(move || crate::git::read_status(&cwd)).await;
+            let status = crate::blocking::unblock(cx.background_executor(), move || {
+                crate::git::read_status(&cwd)
+            })
+            .await;
             let _ = this.update(cx, |state, cx| {
                 if state.git_status_generation == generation
                     && state.active_session_id().map(str::to_string) == session_id
@@ -1275,18 +1278,15 @@ impl AppState {
         };
         let binary = self.settings.provider(ProviderKind::ClaudeCode).binary_path;
         cx.background_executor().spawn(async move {
-            smol::unblock(move || {
-                let (stat, patch) = crate::git::commit_diff_context(&cwd, included.as_deref());
-                let prompt = crate::git::build_commit_prompt(&stat, &patch);
-                let raw = crate::git::run_claude_headless(binary.as_deref(), &cwd, &prompt)?;
-                let message = crate::git::sanitize_commit_message(&raw);
-                if message.is_empty() {
-                    Err("model returned an empty commit message".to_string())
-                } else {
-                    Ok(message)
-                }
-            })
-            .await
+            let (stat, patch) = crate::git::commit_diff_context(&cwd, included.as_deref());
+            let prompt = crate::git::build_commit_prompt(&stat, &patch);
+            let raw = crate::git::run_claude_headless(binary.as_deref(), &cwd, &prompt)?;
+            let message = crate::git::sanitize_commit_message(&raw);
+            if message.is_empty() {
+                Err("model returned an empty commit message".to_string())
+            } else {
+                Ok(message)
+            }
         })
     }
 
@@ -1332,7 +1332,7 @@ impl AppState {
         let retry_feature = feature_branch.clone();
 
         cx.spawn(async move |this, cx| {
-            let result = smol::unblock(move || {
+            let result = crate::blocking::unblock(cx.background_executor(), move || {
                 crate::git::perform_action(
                     &cwd,
                     action,
@@ -1477,7 +1477,10 @@ impl AppState {
             self.acp_registry = Some(cached);
         }
         cx.spawn(async move |this, cx| {
-            let result = smol::unblock(move || crate::acp_registry::load(&data_dir)).await;
+            let result = crate::blocking::unblock(cx.background_executor(), move || {
+                crate::acp_registry::load(&data_dir)
+            })
+            .await;
             let _ = this.update(cx, |state, cx| {
                 state.acp_registry_loading = false;
                 match result {
@@ -1532,7 +1535,7 @@ impl AppState {
         let data_dir = self.store.root().clone();
         let name = agent.name.clone();
         cx.spawn(async move |this, cx| {
-            let result = smol::unblock(move || {
+            let result = crate::blocking::unblock(cx.background_executor(), move || {
                 crate::acp_registry::install(&agent, &data_dir, |_done, _total| {})
             })
             .await;
@@ -1574,8 +1577,8 @@ impl AppState {
         let _ = self.settings_store.save(&settings);
         let data_dir = self.store.root().clone();
         let id = id.to_string();
-        cx.spawn(async move |_this, _cx| {
-            let _ = smol::unblock(move || {
+        cx.spawn(async move |_this, cx| {
+            crate::blocking::unblock(cx.background_executor(), move || {
                 if let Err(err) = crate::acp_registry::uninstall(&data_dir, &id) {
                     log::warn!("could not remove ACP agent {id}: {err}");
                 }
@@ -2655,7 +2658,7 @@ impl AppState {
         let path_for_task = path.clone();
         let branch_for_task = branch.clone();
         cx.spawn(async move |this, cx| {
-            let result = smol::unblock(move || {
+            let result = crate::blocking::unblock(cx.background_executor(), move || {
                 create_git_worktree(
                     &root_for_task,
                     &path_for_task,
@@ -3592,7 +3595,9 @@ impl AppState {
         let cwd = active.meta.cwd.clone();
         let session_id = active.meta.id.clone();
         cx.spawn(async move |this, cx| {
-            let branches = smol::unblock(move || list_git_branches(&cwd)).await;
+            let branches =
+                crate::blocking::unblock(cx.background_executor(), move || list_git_branches(&cwd))
+                    .await;
             let _ = this.update(cx, |state, cx| {
                 if let Some(active) = state.active.as_mut()
                     && active.meta.id == session_id
@@ -3619,7 +3624,10 @@ impl AppState {
         let session_id = active.meta.id.clone();
         let branch_for_task = branch.clone();
         cx.spawn(async move |this, cx| {
-            let result = smol::unblock(move || checkout_if_clean(&cwd, &branch_for_task)).await;
+            let result = crate::blocking::unblock(cx.background_executor(), move || {
+                checkout_if_clean(&cwd, &branch_for_task)
+            })
+            .await;
             let _ = this.update(cx, |state, cx| {
                 match result {
                     Ok(()) => {
@@ -4211,10 +4219,9 @@ async fn probe_provider(
                 .clone()
                 .or_else(|| dirs::home_dir().map(|home| home.join(".codex")));
             let path = home.map(|home| home.join("auth.json"));
-            let json = match path {
-                Some(path) => smol::unblock(move || std::fs::read_to_string(path).ok()).await,
-                None => None,
-            };
+            // A few KB of local JSON: read it inline rather than bouncing off a
+            // thread pool (see `crate::blocking`).
+            let json = path.and_then(|path| std::fs::read_to_string(path).ok());
             json.as_deref()
                 .and_then(crate::provider_status::parse_codex_auth)
         }

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1,0 +1,71 @@
+//! Blocking work, run off the main thread on **gpui's** executor.
+//!
+//! The tempting alternative, `smol::unblock`, is a trap here. A gpui task is a
+//! *local* task: gpui asserts that its runnable is only ever polled and dropped
+//! by the thread that spawned it. Await a `smol::unblock` future inside one and
+//! the wake — and, if the task is dropped while suspended, the drop — comes from
+//! a thread in smol's global blocking pool. gpui's test scheduler catches that
+//! ("local task dropped by a thread that didn't spawn it") and panics from a
+//! pool thread, which aborts the whole process: it took down the Windows CI run
+//! with a bare `STATUS_STACK_BUFFER_OVERRUN` and no test name attached.
+//!
+//! gpui's background executor is the one its scheduler owns — deterministic
+//! under test, a real thread pool in production — so blocking work goes there.
+
+use gpui::{BackgroundExecutor, Task};
+
+/// Run `f` on gpui's background executor.
+///
+/// ```ignore
+/// let status = blocking::unblock(cx.background_executor(), move || read_status(&cwd)).await;
+/// ```
+pub fn unblock<R, F>(executor: &BackgroundExecutor, f: F) -> Task<R>
+where
+    R: Send + 'static,
+    F: FnOnce() -> R + Send + 'static,
+{
+    executor.spawn(async move { f() })
+}
+
+#[cfg(test)]
+mod tests {
+    /// Guard: no `smol::unblock` anywhere in the app. See the module docs — from
+    /// inside a gpui task it aborts the process. Use [`super::unblock`].
+    #[test]
+    fn no_smol_unblock_outside_this_module() {
+        let mut offenders = Vec::new();
+        visit(std::path::Path::new("src"), &mut offenders);
+        assert!(
+            offenders.is_empty(),
+            "smol::unblock inside a gpui task drops local tasks on a foreign \
+             thread and aborts; use crate::blocking::unblock: {offenders:#?}"
+        );
+    }
+
+    fn visit(dir: &std::path::Path, offenders: &mut Vec<String>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                visit(&path, offenders);
+                continue;
+            }
+            if path.extension().is_none_or(|ext| ext != "rs") {
+                continue;
+            }
+            if path.file_name().is_some_and(|name| name == "blocking.rs") {
+                continue;
+            }
+            let Ok(source) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            for (idx, line) in source.lines().enumerate() {
+                if line.contains("smol::unblock") && !line.trim_start().starts_with("//") {
+                    offenders.push(format!("{}:{}", path.display(), idx + 1));
+                }
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 mod acp_registry;
 mod app;
 mod assets;
+mod blocking;
 mod checkpoints;
 mod git;
 mod process;

--- a/src/ui/composer.rs
+++ b/src/ui/composer.rs
@@ -643,7 +643,8 @@ impl Composer {
         cx.spawn(async move |this, cx| {
             let walked = {
                 let cwd = cwd.clone();
-                smol::unblock(move || list_workspace(&cwd)).await
+                crate::blocking::unblock(cx.background_executor(), move || list_workspace(&cwd))
+                    .await
             };
             let _ = this.update(cx, |this, cx| {
                 this.workspace = Some((cwd, walked));

--- a/src/ui/diff_panel.rs
+++ b/src/ui/diff_panel.rs
@@ -873,7 +873,10 @@ impl DiffPanel {
         }
         self.loading_key = Some(key.clone());
         cx.spawn(async move |this, cx| {
-            let result = smol::unblock(move || load_git_diff(&cwd, scope, base.as_deref())).await;
+            let result = crate::blocking::unblock(cx.background_executor(), move || {
+                load_git_diff(&cwd, scope, base.as_deref())
+            })
+            .await;
             let _ = this.update(cx, |panel, cx| {
                 if panel.loading_key.as_ref() == Some(&key) {
                     panel.git_preview = Some(GitPreview {


### PR DESCRIPTION
Fixes the Windows CI abort: a gpui local task suspended on `smol::unblock` was being dropped by a smol pool thread, tripping gpui's scheduler assertion and aborting the test binary. All blocking work now runs on gpui's background executor; a guard test keeps `smol::unblock` out of `src/`.