### PR TITLE
Add Orchestrate model settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,8 @@ without touching your real threads.
 `--open-latest`, `--open-diff`, `--open-settings`, `--open-palette`,
 `--open-draft <project>`; and for screenshots, `--debug-compose <text>`,
 `--debug-image <path>`, `--debug-live`, `--debug-send <text>`,
-`--debug-palette <query>`, `--debug-settings-section <general|providers|archived>`,
+`--debug-palette <query>`,
+`--debug-settings-section <general|providers|orchestrate|archived>`,
 `--debug-queue "msg1|msg2"`, `--debug-edit-open`.
 
 `--debug-edit-resend "<text>"` exercises **Edit & resend** end to end (rewind the

--- a/assets/orchestrate/claude.md
+++ b/assets/orchestrate/claude.md
@@ -1,6 +1,6 @@
 # Orchestrate — you plan and verify, child threads execute
 
-You are the orchestrator of this session. tcode has just connected a tool server named `tcode_orchestrate` to you; it lets you dispatch work to child threads (separate agent sessions running Codex or Claude), watch their progress, and collect results. Your leverage is judgment — understanding the problem, decomposing it, defining "done", routing, verifying — not typing. Delegate execution when a cheaper model is adequate; keep the parts where your intelligence or taste is the actual bottleneck.
+tcode has just connected a tool server named `tcode_orchestrate` to you; it lets you dispatch work to child threads, watch their progress, and collect results. The current role identity and allowed child-model fleet are supplied below by Settings → Orchestrate.
 
 ## Tools
 
@@ -13,10 +13,6 @@ You are the orchestrator of this session. tcode has just connected a tool server
 ## The callback contract — do not poll, do not self-schedule
 
 When a child thread finishes a turn, **tcode itself will send you a message** tagged `[orchestrate]` with the thread id, status, and final output. You do not need to poll `status` in a loop, schedule wake-ups, or keep your turn alive waiting. Dispatch, then end your turn; you will be woken. Use `status` only for an on-demand snapshot (e.g. when the user asks, or before deciding whether to add work).
-
-## Routing
-
-Default execution model: **codex / gpt-5.6-sol at medium effort** — bulk implementation against a written brief, closed-form debugging with a repro, reviews, sweeps. Reserve **max effort** for problems that genuinely reward depth or tenacity (gnarly bugs, long grinds, open-ended polish); its price is latency. Use **claude children** (sonnet for glue, opus for taste-critical UI/copy) when the work rewards judgment or design taste over grind. Escalate without asking when output misses the bar; judge the output, not the price tag.
 
 ## Discipline
 

--- a/assets/orchestrate/codex.md
+++ b/assets/orchestrate/codex.md
@@ -1,6 +1,6 @@
 # Orchestrate mode — you are the lead; child threads do the typing
 
-tcode has connected a tool server named `tcode_orchestrate` to this session. It dispatches work to child threads (separate agent sessions — Codex or Claude), tracks their progress, and returns their results. Operate as the lead engineer: decompose, brief, verify, integrate. Do not implement anything a child can implement to spec.
+tcode has connected a tool server named `tcode_orchestrate` to this session. It dispatches work to child threads, tracks their progress, and returns their results. Operate as the lead engineer: decompose, brief, verify, integrate. The current role identity and allowed child-model fleet are supplied below by Settings → Orchestrate.
 
 ## Tools
 
@@ -13,13 +13,6 @@ tcode has connected a tool server named `tcode_orchestrate` to this session. It 
 ## Callbacks — never poll, never busy-wait
 
 When a child finishes, **tcode sends you a `[orchestrate]` message** with the id, status and output. Dispatch, end your turn, get woken. `status` is for on-demand snapshots only. Never loop on `status`; never try to keep your turn alive waiting for a child.
-
-## Routing
-
-- Bulk implementation to spec, closed-form debugging, reviews, migrations → **codex child at medium effort** (default; effectively free).
-- Genuinely deep or grinding problems (repro'd hard bugs, long autonomous passes) → codex child at **max** — expect latency; keep it off the critical path.
-- Taste-critical surfaces (user-facing UI, copy, API shape) → **claude child** (opus tier if available) or do it yourself.
-- Output below the bar → escalate model/effort or take it over. No permission needed.
 
 ## Operating rules
 

--- a/assets/orchestrate/generic.md
+++ b/assets/orchestrate/generic.md
@@ -1,0 +1,25 @@
+# Orchestrate — lead the work; child threads execute
+
+tcode has connected a tool server named `tcode_orchestrate` to this session. It dispatches work to separate child tcode threads, tracks their progress, and returns their results. Operate as the lead: understand, decompose, brief, verify, and integrate. The current role identity and allowed child-model fleet are supplied below by Settings → Orchestrate.
+
+## Tools
+
+- `dispatch {provider, model?, effort?, title, brief, cwd?}` → creates a child thread and sends `brief` as its first message. The child is visible in the user's sidebar.
+- `status {thread_id?}` → running/completed/failed plus the latest output tail. Omit `thread_id` for all children.
+- `send {thread_id, message}` → follow-up to a child with useful context.
+- `result {thread_id}` → completed child's final message.
+- `cancel {thread_id}` → stop a child.
+
+## Callbacks — do not poll
+
+When a child finishes, tcode sends a message tagged `[orchestrate]` with its id, status, and output. Dispatch, end the turn, and wait to be woken. Use `status` only for an on-demand snapshot; never busy-wait.
+
+## Operating rules
+
+1. Read the judgment-critical context yourself before delegating.
+2. Define executable acceptance criteria before dispatching.
+3. Make every brief self-contained: context, objective, file scope, constraints, acceptance criteria, and a report format that distinguishes checks actually run from claims.
+4. Parallelize only disjoint scopes.
+5. Verify child output independently. Reports are claims; the diff and checks are facts.
+6. After one focused retry, a repeated failure means the brief or plan needs revision.
+7. Run the integrated gates, report against the original criteria, and stop when they pass.

--- a/crates/agent/src/codex.rs
+++ b/crates/agent/src/codex.rs
@@ -79,9 +79,14 @@ pub async fn list_models(
     let (mut child, mut stdin, lines, mut stderr_tail) =
         spawn_server(binary_path.as_deref(), &[], &launch_env)?;
     let result = collect_models(&mut stdin, &lines).await;
-    // Status is read before `stop_child` so a self-exited child's code is not
-    // masked by our kill.
-    let status = child.try_wait().ok().flatten();
+    // The stdout reader can observe EOF a few milliseconds before the process
+    // becomes waitable. Give a self-exiting child time to publish its real
+    // status so `stop_child` does not replace it with a kill status.
+    let status = result
+        .is_err()
+        .then(|| settle_child_exit(&mut child))
+        .flatten()
+        .or_else(|| child.try_wait().ok().flatten());
     stop_child(&mut child, stdin);
     result.map_err(|err| enrich_startup_error(err, status, &mut stderr_tail))
 }
@@ -413,9 +418,9 @@ async fn run_actor(
     let (thread_id, model, next_id, provider_commands) = match startup {
         Ok(value) => value,
         Err(err) => {
-            // Status is read before `stop_child` so a self-exited child's code
-            // is not masked by our kill.
-            let status = child.try_wait().ok().flatten();
+            // As in model discovery, stdout EOF may beat process termination
+            // by a scheduling tick. Preserve the provider's natural status.
+            let status = settle_child_exit(&mut child);
             stop_child(&mut child, stdin);
             let err = enrich_startup_error(err, status, &mut stderr_tail);
             let _ = ready.send(Err(err)).await;
@@ -988,6 +993,20 @@ fn stop_child(child: &mut Child, stdin: BufWriter<ChildStdin>) {
         let _ = child.kill();
     }
     let _ = child.wait();
+}
+
+/// Wait briefly for a child that has already closed stdout to become waitable.
+/// Startup failures are rare, and preserving the real exit code is worth this
+/// bounded delay. A child that remains alive is still killed by `stop_child`.
+fn settle_child_exit(child: &mut Child) -> Option<std::process::ExitStatus> {
+    for _ in 0..50 {
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status),
+            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(10)),
+            Err(_) => return None,
+        }
+    }
+    None
 }
 
 impl Actor {

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -155,6 +155,169 @@ impl ProviderSettings {
     }
 }
 
+/// A model-specific identity override for an orchestrator. Models without an
+/// entry here remain fully eligible for `/orchestrate`; they inherit
+/// [`OrchestrateSettings::generic_identity`] instead.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OrchestratorIdentity {
+    pub provider: ProviderKind,
+    pub model: String,
+    pub identity: String,
+}
+
+/// One model the orchestrator may dispatch work to. Profiles stay in this list
+/// while paused so their editable routing definition is preserved; `enabled`
+/// is the actual allow-list decision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OrchestrateChildModel {
+    pub provider: ProviderKind,
+    pub model: String,
+    /// Disabled profiles retain all routing preferences but cannot receive a
+    /// dispatch and are omitted from the lead model's available-fleet table.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Effort used when a dispatch omits one. Callers may still explicitly pick
+    /// another effort supported by the model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_effort: Option<String>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+}
+
+const DEFAULT_ORCHESTRATOR_IDENTITY: &str = "You are the primary decision model and technical lead for this session. Your leverage is judgment: understand the problem, frame it well, decompose it, define done, route work to the cheapest adequate child model, and verify the result independently. Keep architecture, ambiguous tradeoffs, and final acceptance for yourself; delegate execution when a child can complete it from a precise brief.";
+
+const DEFAULT_FABLE_IDENTITY: &str = "You are Fable 5, the scarcest judgment resource in this fleet: a wise owl—thoughtful, discerning, and exceptionally strong at framing, architecture, taste, and clear communication. Spend that judgment on understanding, delegation, review, and final acceptance rather than routine typing. Use high effort by default; deeper tiers usually consume more of the fleet's bottleneck without improving your decisions.";
+
+const DEFAULT_GPT_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better): cost efficiency 9, intelligence 8, taste 6. Recommended effort: medium. Default execution model for bulk implementation, closed-form debugging, reviews, migrations, computer use, and token-heavy sweeps. Escalate effort only after a concrete miss.";
+const DEFAULT_SONNET_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better): cost efficiency 5, intelligence 5, taste 7. Recommended effort: high. Cheap glue work, wrappers, chores, and context gathering that does not require top-tier judgment.";
+const DEFAULT_OPUS_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better): cost efficiency 4, intelligence 7, taste 8. Recommended effort: high. Best for taste-critical UI, copy, API design, and implementation review where judgment matters more than grinding depth.";
+const DEFAULT_FABLE_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better): cost efficiency 2, intelligence 9, taste 9. Recommended effort: high. Highest-judgment escalation for framing, architecture, ambiguous tradeoffs, and final review.";
+
+/// Settings for tcode's built-in orchestration layer.
+///
+/// There is deliberately no main-model allow list. Every model may orchestrate;
+/// only its identity text changes through the generic fallback and optional
+/// per-model overrides. Child models, by contrast, are an explicit allow list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OrchestrateSettings {
+    #[serde(default = "default_orchestrator_identity")]
+    pub generic_identity: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub model_identities: Vec<OrchestratorIdentity>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub child_models: Vec<OrchestrateChildModel>,
+}
+
+fn default_orchestrator_identity() -> String {
+    DEFAULT_ORCHESTRATOR_IDENTITY.to_string()
+}
+
+impl Default for OrchestrateSettings {
+    fn default() -> Self {
+        Self {
+            generic_identity: default_orchestrator_identity(),
+            model_identities: vec![OrchestratorIdentity {
+                provider: ProviderKind::ClaudeCode,
+                model: "claude-fable-5".into(),
+                identity: DEFAULT_FABLE_IDENTITY.into(),
+            }],
+            child_models: vec![
+                OrchestrateChildModel {
+                    provider: ProviderKind::Codex,
+                    model: "gpt-5.6-sol".into(),
+                    enabled: true,
+                    default_effort: Some("medium".into()),
+                    description: DEFAULT_GPT_CHILD_DEFINITION.into(),
+                },
+                OrchestrateChildModel {
+                    provider: ProviderKind::ClaudeCode,
+                    model: "claude-sonnet-5".into(),
+                    enabled: false,
+                    default_effort: Some("high".into()),
+                    description: DEFAULT_SONNET_CHILD_DEFINITION.into(),
+                },
+                OrchestrateChildModel {
+                    provider: ProviderKind::ClaudeCode,
+                    model: "claude-opus-4-8".into(),
+                    enabled: false,
+                    default_effort: Some("high".into()),
+                    description: DEFAULT_OPUS_CHILD_DEFINITION.into(),
+                },
+                OrchestrateChildModel {
+                    provider: ProviderKind::ClaudeCode,
+                    model: "claude-fable-5".into(),
+                    enabled: false,
+                    default_effort: Some("high".into()),
+                    description: DEFAULT_FABLE_CHILD_DEFINITION.into(),
+                },
+            ],
+        }
+    }
+}
+
+impl OrchestrateSettings {
+    pub fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+
+    /// Resolve a model's dedicated identity, falling back to the generic one.
+    /// `None` (the provider's default model) also uses the generic identity.
+    pub fn identity_for(&self, provider: ProviderKind, model: Option<&str>) -> &str {
+        model
+            .and_then(|model| {
+                self.model_identities
+                    .iter()
+                    .find(|entry| entry.provider == provider && entry.model == model)
+            })
+            .map(|entry| entry.identity.as_str())
+            .unwrap_or(&self.generic_identity)
+    }
+
+    pub fn builtin_generic_identity() -> &'static str {
+        DEFAULT_ORCHESTRATOR_IDENTITY
+    }
+
+    /// Factory text for a dedicated identity editor. Models without a bundled
+    /// specialization reset to the factory generic identity.
+    pub fn builtin_identity_for(provider: ProviderKind, model: &str) -> &'static str {
+        match (provider, model) {
+            (ProviderKind::ClaudeCode, "claude-fable-5") => DEFAULT_FABLE_IDENTITY,
+            _ => DEFAULT_ORCHESTRATOR_IDENTITY,
+        }
+    }
+
+    /// Factory definition for a bundled child-model preset. Custom models have
+    /// no product-authored definition and therefore reset to an empty editor.
+    pub fn builtin_child_definition(provider: ProviderKind, model: &str) -> Option<&'static str> {
+        match (provider, model) {
+            (ProviderKind::Codex, "gpt-5.6-sol") => Some(DEFAULT_GPT_CHILD_DEFINITION),
+            (ProviderKind::ClaudeCode, "claude-sonnet-5") => Some(DEFAULT_SONNET_CHILD_DEFINITION),
+            (ProviderKind::ClaudeCode, "claude-opus-4-8") => Some(DEFAULT_OPUS_CHILD_DEFINITION),
+            (ProviderKind::ClaudeCode, "claude-fable-5") => Some(DEFAULT_FABLE_CHILD_DEFINITION),
+            _ => None,
+        }
+    }
+
+    pub fn child_model(
+        &self,
+        provider: ProviderKind,
+        model: &str,
+    ) -> Option<&OrchestrateChildModel> {
+        self.child_models
+            .iter()
+            .find(|entry| entry.provider == provider && entry.model == model)
+    }
+
+    pub fn enabled_child_model(
+        &self,
+        provider: ProviderKind,
+        model: &str,
+    ) -> Option<&OrchestrateChildModel> {
+        self.child_model(provider, model)
+            .filter(|entry| entry.enabled)
+    }
+}
+
 // `Eq` is intentionally absent: `acp_agents` holds `AcpLaunch`, which the
 // agent crate derives only `PartialEq` for.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -196,6 +359,9 @@ pub struct Settings {
     /// on) even for legacy settings files that lack the field.
     #[serde(default)]
     pub provider_update_checks_disabled: bool,
+    /// Built-in orchestration identities and child-model routing table.
+    #[serde(default, skip_serializing_if = "OrchestrateSettings::is_default")]
+    pub orchestrate: OrchestrateSettings,
     /// Ids of project groups the user has collapsed in the sidebar.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub collapsed_projects: Vec<String>,
@@ -335,6 +501,64 @@ mod tests {
         };
         assert_eq!(settings.effective_home(), Some(PathBuf::from("/b")));
     }
+
+    #[test]
+    fn orchestrator_identity_uses_model_override_then_generic_fallback() {
+        let settings = OrchestrateSettings::default();
+        assert!(
+            settings
+                .identity_for(ProviderKind::ClaudeCode, Some("claude-fable-5"))
+                .contains("wise owl")
+        );
+        assert_eq!(
+            settings.identity_for(ProviderKind::ClaudeCode, Some("claude-opus-4-8")),
+            settings.generic_identity
+        );
+        assert_eq!(
+            settings.identity_for(ProviderKind::Codex, Some("claude-fable-5")),
+            settings.generic_identity,
+            "the provider is part of a model's identity key"
+        );
+        assert_eq!(
+            settings.identity_for(ProviderKind::Acp, None),
+            settings.generic_identity,
+            "provider-default and ACP models remain eligible through the fallback"
+        );
+    }
+
+    #[test]
+    fn orchestrate_defaults_round_trip_and_legacy_files_get_defaults() {
+        let legacy: Settings = serde_json::from_str(r#"{"theme_mode":"system"}"#).unwrap();
+        assert_eq!(legacy.orchestrate, OrchestrateSettings::default());
+        assert!(
+            legacy
+                .orchestrate
+                .enabled_child_model(ProviderKind::Codex, "gpt-5.6-sol")
+                .is_some()
+        );
+        assert!(
+            legacy
+                .orchestrate
+                .child_model(ProviderKind::ClaudeCode, "claude-opus-4-8")
+                .is_some(),
+            "disabled presets retain their preferences"
+        );
+        assert!(
+            legacy
+                .orchestrate
+                .enabled_child_model(ProviderKind::ClaudeCode, "claude-opus-4-8")
+                .is_none(),
+            "the default dispatch fleet is GPT-only"
+        );
+
+        let mut settings = Settings::default();
+        settings.orchestrate.generic_identity = "Custom lead identity".into();
+        settings.orchestrate.model_identities.clear();
+        let json = serde_json::to_string(&settings).unwrap();
+        let back: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.orchestrate, settings.orchestrate);
+    }
+
     #[test]
     fn sidebar_collapsed_round_trips_and_defaults_to_expanded() {
         let legacy: Settings = serde_json::from_str(r#"{"theme_mode":"system"}"#).unwrap();

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -5541,7 +5541,7 @@ mod tests {
             &settings,
             "Ship it",
         );
-        assert!(first.starts_with(CLAUDE_ORCHESTRATE_GUIDANCE));
+        assert!(first.starts_with(CLAUDE_ORCHESTRATE_GUIDANCE.trim()));
         assert!(first.contains("wise owl"));
         assert!(first.contains("#### `codex` / `gpt-5.6-sol`"));
         assert!(first.contains("cost efficiency 9, intelligence 8, taste 6"));
@@ -5564,7 +5564,7 @@ mod tests {
 
         let codex =
             compose_orchestrate_text(ProviderKind::Codex, None, true, &settings, "Implement");
-        assert!(codex.starts_with(CODEX_ORCHESTRATE_GUIDANCE));
+        assert!(codex.starts_with(CODEX_ORCHESTRATE_GUIDANCE.trim()));
         assert!(codex.ends_with("\n\nImplement"));
         assert!(codex.contains("Generic lead"));
 
@@ -5575,7 +5575,7 @@ mod tests {
             &settings,
             "Coordinate",
         );
-        assert!(acp.starts_with(GENERIC_ORCHESTRATE_GUIDANCE));
+        assert!(acp.starts_with(GENERIC_ORCHESTRATE_GUIDANCE.trim()));
         assert!(acp.contains("Generic lead"));
     }
 

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -28,7 +28,7 @@ use tcode_core::session::{
 };
 #[cfg(test)]
 use tcode_core::settings::EnvVar;
-use tcode_core::settings::{ProjectSort, ProviderSettings, Settings};
+use tcode_core::settings::{OrchestrateSettings, ProjectSort, ProviderSettings, Settings};
 use tcode_services::acp_registry::{
     Registry, RegistryAgent, cached, install, load, platform_key, resolve_recipe, uninstall,
     visible_agents,
@@ -808,12 +808,16 @@ impl AppState {
             return;
         };
         let provider = active.meta.provider;
+        let model = active.meta.model.clone();
         let enabling = !active.meta.orchestrate_enabled;
         let session_id = active.meta.id.clone();
-        let Some(text) = compose_orchestrate_text(provider, enabling, &text) else {
-            self.report_error(RuntimeError::OrchestrateUnsupported, cx);
-            return;
-        };
+        let text = compose_orchestrate_text(
+            provider,
+            model.as_deref(),
+            enabling,
+            &self.settings.orchestrate,
+            &text,
+        );
 
         if enabling {
             if let Err(message) = self.enable_orchestrate(&session_id, cx) {
@@ -936,15 +940,16 @@ impl AppState {
                 brief,
                 cwd,
             } => {
-                let provider = match provider.as_str() {
-                    "claude" => ProviderKind::ClaudeCode,
-                    "codex" => ProviderKind::Codex,
-                    _ => return Err(format!("unknown provider: {provider}")),
-                };
+                let (provider, model, effort) = resolve_orchestrate_dispatch(
+                    &self.settings.orchestrate,
+                    &provider,
+                    model.as_deref(),
+                    effort.as_deref(),
+                )?;
                 let id = self.create_child_session(
                     &parent_id,
                     provider,
-                    model,
+                    Some(model),
                     effort,
                     title,
                     cwd.map(PathBuf::from),
@@ -5061,29 +5066,129 @@ impl AppState {
 
 const CLAUDE_ORCHESTRATE_GUIDANCE: &str = include_str!("../../../assets/orchestrate/claude.md");
 const CODEX_ORCHESTRATE_GUIDANCE: &str = include_str!("../../../assets/orchestrate/codex.md");
+const GENERIC_ORCHESTRATE_GUIDANCE: &str = include_str!("../../../assets/orchestrate/generic.md");
 
 fn compose_orchestrate_text(
     provider: ProviderKind,
+    model: Option<&str>,
     enabling: bool,
+    settings: &OrchestrateSettings,
     user_text: &str,
-) -> Option<String> {
-    if !enabling {
-        return (provider != ProviderKind::Acp).then(|| user_text.to_string());
-    }
-    let guidance = match provider {
+) -> String {
+    let base_guidance = match provider {
         ProviderKind::ClaudeCode => CLAUDE_ORCHESTRATE_GUIDANCE,
         ProviderKind::Codex => CODEX_ORCHESTRATE_GUIDANCE,
-        ProviderKind::Acp => return None,
+        ProviderKind::Acp => GENERIC_ORCHESTRATE_GUIDANCE,
     };
-    if user_text.is_empty() {
-        Some(guidance.to_string())
+    let configuration = render_orchestrate_configuration(settings, provider, model);
+    let mut sections = Vec::with_capacity(3);
+    if enabling {
+        sections.push(base_guidance.trim());
+    }
+    sections.push(configuration.trim());
+    if !user_text.is_empty() {
+        sections.push(user_text);
+    }
+    sections.join("\n\n")
+}
+
+fn render_orchestrate_configuration(
+    settings: &OrchestrateSettings,
+    provider: ProviderKind,
+    model: Option<&str>,
+) -> String {
+    let identity = settings.identity_for(provider, model).trim();
+    let mut text = String::from("## Current orchestrator configuration\n\n### Your role\n\n");
+    if identity.is_empty() {
+        text.push_str("No additional model-specific identity is configured.");
     } else {
-        let separator = if guidance.ends_with('\n') {
-            "\n"
-        } else {
-            "\n\n"
+        text.push_str(identity);
+    }
+    text.push_str(
+        "\n\n### Allowed child models\n\nOnly dispatch to models listed below. Their definitions are configured by the user and may include ratings, strengths, caveats, and routing preferences. If a dispatch omits `model`, tcode selects the first enabled model for that provider. If it omits `effort`, tcode applies the model's stored default.\n",
+    );
+    if !settings.child_models.iter().any(|child| child.enabled) {
+        text.push_str("No child models are enabled. Work without dispatching until the user enables one in Settings → Orchestrate.");
+        return text;
+    }
+    for child in settings.child_models.iter().filter(|child| child.enabled) {
+        let provider = match child.provider {
+            ProviderKind::Codex => "codex",
+            ProviderKind::ClaudeCode => "claude",
+            ProviderKind::Acp => "acp",
         };
-        Some(format!("{guidance}{separator}{user_text}"))
+        let effort = child
+            .default_effort
+            .as_deref()
+            .unwrap_or("provider default");
+        text.push_str(&format!(
+            "\n#### `{}` / `{}`\n\nDefault dispatch effort: `{}`.\n\n{}\n",
+            escape_markdown_inline(provider),
+            escape_markdown_inline(&child.model),
+            escape_markdown_inline(effort),
+            child.description.trim(),
+        ));
+    }
+    text
+}
+
+fn escape_markdown_inline(value: &str) -> String {
+    value.replace('`', "\\`").replace(['\r', '\n'], " ")
+}
+
+/// Validate an MCP dispatch against the configured child-model allow list and
+/// fill in its model/default effort. The main model is unrestricted; this gate
+/// applies only to newly-created child sessions.
+fn resolve_orchestrate_dispatch(
+    settings: &OrchestrateSettings,
+    provider: &str,
+    model: Option<&str>,
+    effort: Option<&str>,
+) -> Result<(ProviderKind, String, Option<String>), String> {
+    let provider = match provider.trim().to_ascii_lowercase().as_str() {
+        "claude" | "claude_code" | "claude-code" => ProviderKind::ClaudeCode,
+        "codex" => ProviderKind::Codex,
+        "acp" => {
+            return Err(
+                "ACP child dispatch is not available yet; configure a Codex or Claude child model"
+                    .into(),
+            );
+        }
+        other => return Err(format!("unknown provider: {other}")),
+    };
+    let requested_model = model.map(str::trim).filter(|model| !model.is_empty());
+    let profile = match requested_model {
+        Some(model) => settings.enabled_child_model(provider, model),
+        None => settings
+            .child_models
+            .iter()
+            .find(|entry| {
+                entry.enabled && entry.provider == provider && !entry.model.trim().is_empty()
+            }),
+    }
+    .ok_or_else(|| match requested_model {
+        Some(model) => format!(
+            "model {model} is not enabled for orchestrate child dispatch under {}",
+            provider_name(provider)
+        ),
+        None => format!(
+            "no orchestrate child model is enabled for {}; choose an enabled provider or update Settings → Orchestrate",
+            provider_name(provider)
+        ),
+    })?;
+    let effort = effort
+        .map(str::trim)
+        .filter(|effort| !effort.is_empty())
+        .map(str::to_string)
+        .or_else(|| profile.default_effort.clone());
+    Ok((provider, profile.model.clone(), effort))
+}
+
+fn provider_name(provider: ProviderKind) -> &'static str {
+    match provider {
+        ProviderKind::Codex => "codex",
+        ProviderKind::ClaudeCode => "claude",
+        ProviderKind::Acp => "acp",
     }
 }
 
@@ -5424,25 +5529,109 @@ mod tests {
     }
 
     #[test]
-    fn orchestrate_guidance_is_prepended_only_when_enabling() {
-        let first = compose_orchestrate_text(ProviderKind::ClaudeCode, true, "Ship it").unwrap();
-        assert!(first.starts_with(CLAUDE_ORCHESTRATE_GUIDANCE));
-        assert!(first.ends_with("\n\nShip it"));
-        assert_eq!(
-            compose_orchestrate_text(ProviderKind::ClaudeCode, false, "Follow up"),
-            Some("Follow up".into())
+    fn orchestrate_guidance_and_current_configuration_are_composed() {
+        let settings = OrchestrateSettings {
+            generic_identity: "Generic lead".into(),
+            ..Default::default()
+        };
+        let first = compose_orchestrate_text(
+            ProviderKind::ClaudeCode,
+            Some("claude-fable-5"),
+            true,
+            &settings,
+            "Ship it",
         );
+        assert!(first.starts_with(CLAUDE_ORCHESTRATE_GUIDANCE));
+        assert!(first.contains("wise owl"));
+        assert!(first.contains("#### `codex` / `gpt-5.6-sol`"));
+        assert!(first.contains("cost efficiency 9, intelligence 8, taste 6"));
+        assert!(
+            !first.contains("#### `claude` / `claude-opus-4-8`"),
+            "disabled presets must not be advertised to the lead model"
+        );
+        assert!(first.ends_with("\n\nShip it"));
+        let follow_up = compose_orchestrate_text(
+            ProviderKind::ClaudeCode,
+            Some("claude-opus-4-8"),
+            false,
+            &settings,
+            "Follow up",
+        );
+        assert!(!follow_up.contains(CLAUDE_ORCHESTRATE_GUIDANCE));
+        assert!(follow_up.starts_with("## Current orchestrator configuration"));
+        assert!(follow_up.contains("Generic lead"));
+        assert!(follow_up.ends_with("\n\nFollow up"));
 
-        let codex = compose_orchestrate_text(ProviderKind::Codex, true, "Implement").unwrap();
+        let codex =
+            compose_orchestrate_text(ProviderKind::Codex, None, true, &settings, "Implement");
         assert!(codex.starts_with(CODEX_ORCHESTRATE_GUIDANCE));
         assert!(codex.ends_with("\n\nImplement"));
-        assert_eq!(
-            compose_orchestrate_text(ProviderKind::Acp, true, "No"),
-            None
+        assert!(codex.contains("Generic lead"));
+
+        let acp = compose_orchestrate_text(
+            ProviderKind::Acp,
+            Some("gemini-3-pro"),
+            true,
+            &settings,
+            "Coordinate",
         );
+        assert!(acp.starts_with(GENERIC_ORCHESTRATE_GUIDANCE));
+        assert!(acp.contains("Generic lead"));
+    }
+
+    #[test]
+    fn orchestrate_dispatch_enforces_child_allow_list_and_defaults() {
+        let mut settings = OrchestrateSettings::default();
         assert_eq!(
-            compose_orchestrate_text(ProviderKind::Acp, false, "No"),
-            None
+            resolve_orchestrate_dispatch(&settings, "codex", None, None).unwrap(),
+            (
+                ProviderKind::Codex,
+                "gpt-5.6-sol".into(),
+                Some("medium".into())
+            )
+        );
+        assert!(
+            resolve_orchestrate_dispatch(
+                &settings,
+                "claude_code",
+                Some("claude-opus-4-8"),
+                Some("max")
+            )
+            .unwrap_err()
+            .contains("not enabled"),
+            "disabled profiles must retain preferences without allowing dispatch"
+        );
+        settings
+            .child_models
+            .iter_mut()
+            .find(|entry| entry.model == "claude-opus-4-8")
+            .unwrap()
+            .enabled = true;
+        assert_eq!(
+            resolve_orchestrate_dispatch(
+                &settings,
+                "claude_code",
+                Some("claude-opus-4-8"),
+                Some("max")
+            )
+            .unwrap(),
+            (
+                ProviderKind::ClaudeCode,
+                "claude-opus-4-8".into(),
+                Some("max".into())
+            )
+        );
+        let denied =
+            resolve_orchestrate_dispatch(&settings, "claude", Some("claude-haiku-4-5"), None)
+                .unwrap_err();
+        assert!(denied.contains("not enabled"));
+
+        let mut empty = settings;
+        empty.child_models.clear();
+        assert!(
+            resolve_orchestrate_dispatch(&empty, "codex", None, None)
+                .unwrap_err()
+                .contains("no orchestrate child model")
         );
     }
 

--- a/crates/runtime/src/event.rs
+++ b/crates/runtime/src/event.rs
@@ -68,7 +68,6 @@ pub enum RuntimeToast {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RuntimeError {
     External(String),
-    OrchestrateUnsupported,
     PersistSettings { error: String },
     UpdateUnknown { provider: ProviderKind },
     UpdateFailed { provider: ProviderKind },

--- a/crates/services/src/settings.rs
+++ b/crates/services/src/settings.rs
@@ -171,6 +171,7 @@ mod tests {
             skip_delete_confirmation: true,
             auto_open_task_panel: true,
             provider_update_checks_disabled: true,
+            orchestrate: Default::default(),
             collapsed_projects: vec!["proj-a".into(), "proj-b".into()],
             favorite_models: vec!["opus".into()],
             project_sort: ProjectSort::NameAsc,

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -9,6 +9,7 @@ mod composer_trigger;
 mod context_meter;
 mod diff_panel;
 pub mod git;
+mod orchestrate_settings;
 mod palette;
 mod plan_panel;
 mod preview_panel;

--- a/crates/ui/src/orchestrate_settings.rs
+++ b/crates/ui/src/orchestrate_settings.rs
@@ -1,0 +1,1014 @@
+//! Settings → Orchestrate: lead-model identities and the child-model routing
+//! allow list. Every main model is eligible; only child dispatch is gated.
+
+use gpui::{
+    AnyElement, App, AppContext as _, Context, Entity, InteractiveElement as _, IntoElement,
+    ParentElement as _, Render, StatefulInteractiveElement as _, Styled as _, Subscription, Window,
+    div, prelude::FluentBuilder as _, px,
+};
+use gpui_component::{
+    ActiveTheme as _, Icon, IconName, Sizable as _, StyledExt as _,
+    button::{Button, ButtonVariants as _},
+    h_flex,
+    input::{Input, InputEvent, InputState},
+    popover::Popover,
+    scroll::ScrollableElement as _,
+    switch::Switch,
+    v_flex,
+};
+
+use agent::{OptionDescriptor, ProviderKind};
+use tcode_runtime::app::AppState;
+
+use crate::provider_card::provider_glyph;
+use crate::settings::{
+    OrchestrateChildModel, OrchestrateSettings, OrchestratorIdentity, Settings, provider_label,
+};
+
+#[derive(Clone)]
+struct ModelOption {
+    provider: ProviderKind,
+    id: String,
+    name: String,
+    default_effort: Option<String>,
+}
+
+struct IdentityRowState {
+    provider: ProviderKind,
+    model: String,
+    identity: Entity<InputState>,
+}
+
+struct ChildRowState {
+    provider: ProviderKind,
+    model: String,
+    description: Entity<InputState>,
+}
+
+#[derive(Clone, Copy)]
+enum AddKind {
+    Identity,
+    Child,
+}
+
+pub struct OrchestrateSettingsPanel {
+    app_state: Entity<AppState>,
+    generic_identity: Entity<InputState>,
+    identity_rows: Vec<IdentityRowState>,
+    child_rows: Vec<ChildRowState>,
+    identity_picker_provider: ProviderKind,
+    child_picker_provider: ProviderKind,
+    _subscriptions: Vec<Subscription>,
+    input_subscriptions: Vec<Subscription>,
+}
+
+impl OrchestrateSettingsPanel {
+    pub fn new(app_state: Entity<AppState>, window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let generic_value = app_state
+            .read(cx)
+            .settings
+            .orchestrate
+            .generic_identity
+            .clone();
+        let generic_identity = cx.new(|cx| {
+            InputState::new(window, cx)
+                .multi_line(true)
+                .auto_grow(4, 14)
+                .placeholder(tcode_i18n::tr!("orchestrate.generic_identity.placeholder"))
+                .default_value(generic_value)
+        });
+        let subscriptions = vec![cx.observe(&app_state, |_, _, cx| cx.notify())];
+        let mut panel = Self {
+            app_state,
+            generic_identity,
+            identity_rows: Vec::new(),
+            child_rows: Vec::new(),
+            identity_picker_provider: ProviderKind::Codex,
+            child_picker_provider: ProviderKind::Codex,
+            _subscriptions: subscriptions,
+            input_subscriptions: Vec::new(),
+        };
+        let generic = panel.generic_identity.clone();
+        panel
+            .input_subscriptions
+            .push(cx.subscribe(&generic, |this, _, event, cx| {
+                if matches!(event, InputEvent::Change) {
+                    this.commit_generic_identity(cx);
+                }
+            }));
+        panel.rebuild_rows(window, cx);
+        panel
+    }
+
+    fn update_settings(&self, mutate: impl FnOnce(&mut Settings), cx: &mut Context<Self>) {
+        self.app_state.update(cx, |state, cx| {
+            let mut settings = state.settings.clone();
+            mutate(&mut settings);
+            state.update_settings(settings, cx);
+        });
+    }
+
+    fn commit_generic_identity(&self, cx: &mut Context<Self>) {
+        let identity = self.generic_identity.read(cx).value().to_string();
+        self.update_settings(
+            move |settings| settings.orchestrate.generic_identity = identity,
+            cx,
+        );
+    }
+
+    fn rebuild_rows(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        // Preserve the generic input subscription at index zero.
+        self.input_subscriptions.truncate(1);
+        self.identity_rows.clear();
+        self.child_rows.clear();
+        let orchestrate = self.app_state.read(cx).settings.orchestrate.clone();
+
+        for entry in orchestrate.model_identities {
+            let identity = cx.new(|cx| {
+                InputState::new(window, cx)
+                    .multi_line(true)
+                    .auto_grow(3, 10)
+                    .placeholder(tcode_i18n::tr!("orchestrate.model_identity.placeholder"))
+                    .default_value(entry.identity)
+            });
+            let provider = entry.provider;
+            let model = entry.model.clone();
+            self.input_subscriptions
+                .push(cx.subscribe(&identity, move |this, _, event, cx| {
+                    if matches!(event, InputEvent::Change) {
+                        this.commit_model_identity(provider, &model, cx);
+                    }
+                }));
+            self.identity_rows.push(IdentityRowState {
+                provider: entry.provider,
+                model: entry.model,
+                identity,
+            });
+        }
+
+        for entry in orchestrate.child_models {
+            let description = cx.new(|cx| {
+                InputState::new(window, cx)
+                    .multi_line(true)
+                    .auto_grow(3, 9)
+                    .placeholder(tcode_i18n::tr!(
+                        "orchestrate.children.description_placeholder"
+                    ))
+                    .default_value(entry.description)
+            });
+            let provider = entry.provider;
+            let model = entry.model.clone();
+            self.input_subscriptions
+                .push(cx.subscribe(&description, move |this, _, event, cx| {
+                    if matches!(event, InputEvent::Change) {
+                        this.commit_child_definition(provider, &model, cx);
+                    }
+                }));
+            self.child_rows.push(ChildRowState {
+                provider: entry.provider,
+                model: entry.model,
+                description,
+            });
+        }
+    }
+
+    fn commit_model_identity(&self, provider: ProviderKind, model: &str, cx: &mut Context<Self>) {
+        let Some(row) = self
+            .identity_rows
+            .iter()
+            .find(|row| row.provider == provider && row.model == model)
+        else {
+            return;
+        };
+        let value = row.identity.read(cx).value().to_string();
+        let model = model.to_string();
+        self.update_settings(
+            move |settings| {
+                if let Some(entry) = settings
+                    .orchestrate
+                    .model_identities
+                    .iter_mut()
+                    .find(|entry| entry.provider == provider && entry.model == model)
+                {
+                    entry.identity = value;
+                }
+            },
+            cx,
+        );
+    }
+
+    fn commit_child_definition(&self, provider: ProviderKind, model: &str, cx: &mut Context<Self>) {
+        let Some(row) = self
+            .child_rows
+            .iter()
+            .find(|row| row.provider == provider && row.model == model)
+        else {
+            return;
+        };
+        let description = row.description.read(cx).value().to_string();
+        let model = model.to_string();
+        self.update_settings(
+            move |settings| {
+                if let Some(entry) = settings
+                    .orchestrate
+                    .child_models
+                    .iter_mut()
+                    .find(|entry| entry.provider == provider && entry.model == model)
+                {
+                    entry.description = description;
+                }
+            },
+            cx,
+        );
+    }
+
+    fn add_identity(&mut self, option: &ModelOption, window: &mut Window, cx: &mut Context<Self>) {
+        let provider = option.provider;
+        let model = option.id.clone();
+        let identity = self
+            .app_state
+            .read(cx)
+            .settings
+            .orchestrate
+            .generic_identity
+            .clone();
+        self.update_settings(
+            move |settings| {
+                if !settings
+                    .orchestrate
+                    .model_identities
+                    .iter()
+                    .any(|entry| entry.provider == provider && entry.model == model)
+                {
+                    settings
+                        .orchestrate
+                        .model_identities
+                        .push(OrchestratorIdentity {
+                            provider,
+                            model,
+                            identity,
+                        });
+                }
+            },
+            cx,
+        );
+        self.rebuild_rows(window, cx);
+        cx.notify();
+    }
+
+    fn remove_identity(
+        &mut self,
+        provider: ProviderKind,
+        model: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let model = model.to_string();
+        self.update_settings(
+            move |settings| {
+                settings
+                    .orchestrate
+                    .model_identities
+                    .retain(|entry| !(entry.provider == provider && entry.model == model));
+            },
+            cx,
+        );
+        self.rebuild_rows(window, cx);
+        cx.notify();
+    }
+
+    fn add_child(&mut self, option: &ModelOption, window: &mut Window, cx: &mut Context<Self>) {
+        let profile = OrchestrateChildModel {
+            provider: option.provider,
+            model: option.id.clone(),
+            enabled: true,
+            default_effort: option.default_effort.clone(),
+            description: OrchestrateSettings::builtin_child_definition(option.provider, &option.id)
+                .unwrap_or_default()
+                .to_string(),
+        };
+        self.update_settings(
+            move |settings| {
+                if !settings
+                    .orchestrate
+                    .child_models
+                    .iter()
+                    .any(|entry| entry.provider == profile.provider && entry.model == profile.model)
+                {
+                    settings.orchestrate.child_models.push(profile);
+                }
+            },
+            cx,
+        );
+        self.rebuild_rows(window, cx);
+        cx.notify();
+    }
+
+    fn remove_child(
+        &mut self,
+        provider: ProviderKind,
+        model: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let model = model.to_string();
+        self.update_settings(
+            move |settings| {
+                settings
+                    .orchestrate
+                    .child_models
+                    .retain(|entry| !(entry.provider == provider && entry.model == model));
+            },
+            cx,
+        );
+        self.rebuild_rows(window, cx);
+        cx.notify();
+    }
+
+    fn set_child_enabled(
+        &self,
+        provider: ProviderKind,
+        model: &str,
+        enabled: bool,
+        cx: &mut Context<Self>,
+    ) {
+        let model = model.to_string();
+        self.update_settings(
+            move |settings| {
+                if let Some(entry) = settings
+                    .orchestrate
+                    .child_models
+                    .iter_mut()
+                    .find(|entry| entry.provider == provider && entry.model == model)
+                {
+                    entry.enabled = enabled;
+                }
+            },
+            cx,
+        );
+    }
+
+    fn reset_generic_identity(&self, window: &mut Window, cx: &mut Context<Self>) {
+        let value = OrchestrateSettings::builtin_generic_identity().to_string();
+        let persisted = value.clone();
+        self.update_settings(
+            move |settings| settings.orchestrate.generic_identity = persisted,
+            cx,
+        );
+        self.generic_identity
+            .update(cx, |input, cx| input.set_value(value, window, cx));
+    }
+
+    fn reset_model_identity(
+        &self,
+        provider: ProviderKind,
+        model: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let value = OrchestrateSettings::builtin_identity_for(provider, model).to_string();
+        let persisted = value.clone();
+        let model_key = model.to_string();
+        self.update_settings(
+            move |settings| {
+                if let Some(entry) = settings
+                    .orchestrate
+                    .model_identities
+                    .iter_mut()
+                    .find(|entry| entry.provider == provider && entry.model == model_key)
+                {
+                    entry.identity = persisted;
+                }
+            },
+            cx,
+        );
+        if let Some(row) = self
+            .identity_rows
+            .iter()
+            .find(|row| row.provider == provider && row.model == model)
+        {
+            row.identity
+                .update(cx, |input, cx| input.set_value(value, window, cx));
+        }
+    }
+
+    fn reset_child_definition(
+        &self,
+        provider: ProviderKind,
+        model: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let value = OrchestrateSettings::builtin_child_definition(provider, model)
+            .unwrap_or_default()
+            .to_string();
+        let persisted = value.clone();
+        let model_key = model.to_string();
+        self.update_settings(
+            move |settings| {
+                if let Some(entry) = settings
+                    .orchestrate
+                    .child_models
+                    .iter_mut()
+                    .find(|entry| entry.provider == provider && entry.model == model_key)
+                {
+                    entry.description = persisted;
+                }
+            },
+            cx,
+        );
+        if let Some(row) = self
+            .child_rows
+            .iter()
+            .find(|row| row.provider == provider && row.model == model)
+        {
+            row.description
+                .update(cx, |input, cx| input.set_value(value, window, cx));
+        }
+    }
+
+    fn model_options(&self, cx: &App) -> Vec<ModelOption> {
+        let state = self.app_state.read(cx);
+        let mut options = Vec::new();
+        for provider in [ProviderKind::Codex, ProviderKind::ClaudeCode] {
+            let catalog = state.models_for(provider);
+            for model in state.resolved_models(provider) {
+                let default_effort = catalog
+                    .iter()
+                    .find(|spec| spec.id == model.id)
+                    .and_then(default_reasoning_effort);
+                options.push(ModelOption {
+                    provider,
+                    id: model.id,
+                    name: model.name,
+                    default_effort,
+                });
+            }
+        }
+
+        // Keep configured rows manageable while offline or after a provider
+        // removes a model from its latest catalog.
+        for (provider, model) in state
+            .settings
+            .orchestrate
+            .model_identities
+            .iter()
+            .map(|entry| (entry.provider, entry.model.as_str()))
+            .chain(
+                state
+                    .settings
+                    .orchestrate
+                    .child_models
+                    .iter()
+                    .map(|entry| (entry.provider, entry.model.as_str())),
+            )
+        {
+            if matches!(provider, ProviderKind::Acp) || model.trim().is_empty() {
+                continue;
+            }
+            if !options
+                .iter()
+                .any(|option| option.provider == provider && option.id == model)
+            {
+                options.push(ModelOption {
+                    provider,
+                    id: model.to_string(),
+                    name: model.to_string(),
+                    default_effort: None,
+                });
+            }
+        }
+        options
+    }
+
+    fn model_name(&self, provider: ProviderKind, model: &str, cx: &App) -> String {
+        self.model_options(cx)
+            .into_iter()
+            .find(|option| option.provider == provider && option.id == model)
+            .map(|option| option.name)
+            .unwrap_or_else(|| model.to_string())
+    }
+
+    fn render_intro(&self, cx: &mut Context<Self>) -> AnyElement {
+        v_flex()
+            .w_full()
+            .gap_1()
+            .p_3()
+            .rounded(cx.theme().radius)
+            .border_1()
+            .border_color(cx.theme().border)
+            .bg(cx.theme().muted)
+            .child(
+                h_flex()
+                    .gap_2()
+                    .items_center()
+                    .child(Icon::new(IconName::Info).small())
+                    .child(
+                        div()
+                            .text_size(px(13.))
+                            .font_medium()
+                            .child(tcode_i18n::tr!("orchestrate.all_models.title")),
+                    ),
+            )
+            .child(
+                div()
+                    .pl_6()
+                    .text_size(px(12.))
+                    .text_color(cx.theme().muted_foreground)
+                    .child(tcode_i18n::tr!("orchestrate.all_models.description")),
+            )
+            .into_any_element()
+    }
+
+    fn section_heading(
+        &self,
+        title: impl Into<gpui::SharedString>,
+        description: impl Into<gpui::SharedString>,
+        action: Option<AnyElement>,
+        cx: &Context<Self>,
+    ) -> AnyElement {
+        h_flex()
+            .w_full()
+            .items_end()
+            .gap_3()
+            .child(
+                v_flex()
+                    .flex_1()
+                    .min_w_0()
+                    .gap_0p5()
+                    .child(div().text_size(px(15.)).font_semibold().child(title.into()))
+                    .child(
+                        div()
+                            .text_size(px(12.))
+                            .text_color(cx.theme().muted_foreground)
+                            .child(description.into()),
+                    ),
+            )
+            .when_some(action, |this, action| this.child(action))
+            .into_any_element()
+    }
+
+    fn render_model_picker(&self, kind: AddKind, cx: &mut Context<Self>) -> AnyElement {
+        let options = self.model_options(cx);
+        let configured: Vec<(ProviderKind, String)> = match kind {
+            AddKind::Identity => self
+                .identity_rows
+                .iter()
+                .map(|row| (row.provider, row.model.clone()))
+                .collect(),
+            AddKind::Child => self
+                .child_rows
+                .iter()
+                .map(|row| (row.provider, row.model.clone()))
+                .collect(),
+        };
+        let panel = cx.entity();
+        let label = match kind {
+            AddKind::Identity => tcode_i18n::tr!("orchestrate.model_identity.add"),
+            AddKind::Child => tcode_i18n::tr!("orchestrate.children.add"),
+        };
+        let popover_id = match kind {
+            AddKind::Identity => "orchestrate-add-identity-popover",
+            AddKind::Child => "orchestrate-add-child-popover",
+        };
+        let trigger_id = match kind {
+            AddKind::Identity => "orchestrate-add-identity",
+            AddKind::Child => "orchestrate-add-child",
+        };
+        Popover::new(popover_id)
+            .trigger(
+                Button::new(trigger_id)
+                    .outline()
+                    .small()
+                    .icon(IconName::Plus)
+                    .label(label),
+            )
+            .content(move |_, _, cx| {
+                let panel = panel.clone();
+                let selected_provider = {
+                    let panel = panel.read(cx);
+                    match kind {
+                        AddKind::Identity => panel.identity_picker_provider,
+                        AddKind::Child => panel.child_picker_provider,
+                    }
+                };
+                let available: Vec<_> = options
+                    .iter()
+                    .filter(|option| {
+                        option.provider == selected_provider
+                            && !configured.iter().any(|(provider, model)| {
+                                *provider == option.provider && model == &option.id
+                            })
+                    })
+                    .cloned()
+                    .collect();
+                let mut rows = v_flex().w_full().p_1().gap_0p5();
+                if available.is_empty() {
+                    rows = rows.child(
+                        div()
+                            .p_4()
+                            .text_size(px(12.))
+                            .text_color(cx.theme().muted_foreground)
+                            .child(tcode_i18n::tr!("orchestrate.no_more_models")),
+                    );
+                } else {
+                    for (index, option) in available.into_iter().enumerate() {
+                        let selected = option.clone();
+                        let panel = panel.clone();
+                        let popover = cx.entity();
+                        rows = rows.child(
+                            h_flex()
+                                .id(("orchestrate-model-option", index))
+                                .w_full()
+                                .px_2()
+                                .py_1p5()
+                                .gap_2()
+                                .items_center()
+                                .rounded(px(6.))
+                                .cursor_pointer()
+                                .hover(|style| style.bg(cx.theme().accent))
+                                .child(provider_glyph(option.provider).small())
+                                .child(
+                                    v_flex()
+                                        .flex_1()
+                                        .min_w_0()
+                                        .child(div().text_size(px(13.)).child(option.name))
+                                        .child(
+                                            div()
+                                                .font_family("monospace")
+                                                .text_size(px(11.))
+                                                .text_color(cx.theme().muted_foreground)
+                                                .child(option.id),
+                                        ),
+                                )
+                                .on_click(move |_, window, cx| {
+                                    panel.update(cx, |panel, cx| match kind {
+                                        AddKind::Identity => {
+                                            panel.add_identity(&selected, window, cx)
+                                        }
+                                        AddKind::Child => panel.add_child(&selected, window, cx),
+                                    });
+                                    popover.update(cx, |state, cx| state.dismiss(window, cx));
+                                }),
+                        );
+                    }
+                }
+                let mut tabs = h_flex()
+                    .w_full()
+                    .p_1()
+                    .gap_1()
+                    .border_b_1()
+                    .border_color(cx.theme().border);
+                for (tab_index, provider) in [ProviderKind::Codex, ProviderKind::ClaudeCode]
+                    .into_iter()
+                    .enumerate()
+                {
+                    let selected = provider == selected_provider;
+                    let panel = panel.clone();
+                    let popover = cx.entity();
+                    tabs = tabs.child(
+                        h_flex()
+                            .id(("orchestrate-provider-tab", tab_index))
+                            .flex_1()
+                            .h(px(30.))
+                            .items_center()
+                            .justify_center()
+                            .gap_1p5()
+                            .rounded(px(6.))
+                            .cursor_pointer()
+                            .when(selected, |tab| tab.bg(cx.theme().accent).font_medium())
+                            .hover(|tab| tab.bg(cx.theme().accent))
+                            .child(provider_glyph(provider).xsmall())
+                            .child(div().text_size(px(12.)).child(provider_label(provider)))
+                            .on_click(move |_, _, cx| {
+                                panel.update(cx, |panel, cx| {
+                                    match kind {
+                                        AddKind::Identity => {
+                                            panel.identity_picker_provider = provider
+                                        }
+                                        AddKind::Child => panel.child_picker_provider = provider,
+                                    }
+                                    cx.notify();
+                                });
+                                popover.update(cx, |_, cx| cx.notify());
+                            }),
+                    );
+                }
+                v_flex().w(px(390.)).child(tabs).child(
+                    v_flex()
+                        .w_full()
+                        .h(px(300.))
+                        .overflow_y_scrollbar()
+                        .child(rows),
+                )
+            })
+            .into_any_element()
+    }
+
+    fn render_identities(&self, cx: &mut Context<Self>) -> AnyElement {
+        let mut section =
+            v_flex()
+                .w_full()
+                .gap_3()
+                .child(self.section_heading(
+                    tcode_i18n::tr!("orchestrate.identity.title"),
+                    tcode_i18n::tr!("orchestrate.identity.description"),
+                    None,
+                    cx,
+                ))
+                .child(
+                    v_flex()
+                        .w_full()
+                        .gap_1p5()
+                        .p_3()
+                        .rounded(cx.theme().radius)
+                        .border_1()
+                        .border_color(cx.theme().border)
+                        .child(
+                            h_flex()
+                                .w_full()
+                                .items_center()
+                                .child(
+                                    div().flex_1().text_size(px(13.)).font_medium().child(
+                                        tcode_i18n::tr!("orchestrate.generic_identity.title"),
+                                    ),
+                                )
+                                .child(
+                                    Button::new("reset-generic-orchestrator-identity")
+                                        .ghost()
+                                        .xsmall()
+                                        .icon(IconName::Undo)
+                                        .label(tcode_i18n::tr!("orchestrate.restore_default"))
+                                        .on_click(cx.listener(|this, _, window, cx| {
+                                            this.reset_generic_identity(window, cx);
+                                        })),
+                                ),
+                        )
+                        .child(
+                            div()
+                                .text_size(px(12.))
+                                .text_color(cx.theme().muted_foreground)
+                                .child(tcode_i18n::tr!("orchestrate.generic_identity.description")),
+                        )
+                        .child(Input::new(&self.generic_identity)),
+                )
+                .child(self.section_heading(
+                    tcode_i18n::tr!("orchestrate.model_identity.title"),
+                    tcode_i18n::tr!("orchestrate.model_identity.description"),
+                    Some(self.render_model_picker(AddKind::Identity, cx)),
+                    cx,
+                ));
+
+        if self.identity_rows.is_empty() {
+            section = section.child(
+                div()
+                    .w_full()
+                    .p_4()
+                    .rounded(cx.theme().radius)
+                    .border_1()
+                    .border_color(cx.theme().border)
+                    .text_size(px(12.))
+                    .text_color(cx.theme().muted_foreground)
+                    .child(tcode_i18n::tr!("orchestrate.model_identity.empty")),
+            );
+        }
+        for (index, row) in self.identity_rows.iter().enumerate() {
+            let name = self.model_name(row.provider, &row.model, cx);
+            let provider = row.provider;
+            let model = row.model.clone();
+            let reset_model = row.model.clone();
+            section = section.child(
+                v_flex()
+                    .w_full()
+                    .gap_2()
+                    .p_3()
+                    .rounded(cx.theme().radius)
+                    .border_1()
+                    .border_color(cx.theme().border)
+                    .child(
+                        h_flex()
+                            .w_full()
+                            .gap_2()
+                            .items_center()
+                            .child(provider_glyph(provider).small())
+                            .child(
+                                v_flex()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .child(div().text_size(px(13.)).font_medium().child(name))
+                                    .child(
+                                        div()
+                                            .font_family("monospace")
+                                            .text_size(px(11.))
+                                            .text_color(cx.theme().muted_foreground)
+                                            .child(format!(
+                                                "{} · {}",
+                                                provider_label(provider),
+                                                row.model
+                                            )),
+                                    ),
+                            )
+                            .child(
+                                Button::new(("reset-orchestrator-identity", index))
+                                    .ghost()
+                                    .xsmall()
+                                    .icon(IconName::Undo)
+                                    .label(tcode_i18n::tr!("orchestrate.restore_default"))
+                                    .on_click(cx.listener(move |this, _, window, cx| {
+                                        this.reset_model_identity(
+                                            provider,
+                                            &reset_model,
+                                            window,
+                                            cx,
+                                        );
+                                    })),
+                            )
+                            .child(
+                                Button::new(("remove-orchestrator-identity", index))
+                                    .ghost()
+                                    .xsmall()
+                                    .icon(IconName::Delete)
+                                    .tooltip(tcode_i18n::tr!(
+                                        "orchestrate.model_identity.use_generic"
+                                    ))
+                                    .on_click(cx.listener(move |this, _, window, cx| {
+                                        this.remove_identity(provider, &model, window, cx);
+                                    })),
+                            ),
+                    )
+                    .child(Input::new(&row.identity)),
+            );
+        }
+        section.into_any_element()
+    }
+
+    fn render_children(&self, cx: &mut Context<Self>) -> AnyElement {
+        let settings = self.app_state.read(cx).settings.orchestrate.clone();
+        let mut section = v_flex().w_full().gap_3().child(self.section_heading(
+            tcode_i18n::tr!("orchestrate.children.title"),
+            tcode_i18n::tr!("orchestrate.children.description"),
+            Some(self.render_model_picker(AddKind::Child, cx)),
+            cx,
+        ));
+        if self.child_rows.is_empty() {
+            return section
+                .child(
+                    div()
+                        .w_full()
+                        .p_4()
+                        .rounded(cx.theme().radius)
+                        .border_1()
+                        .border_color(cx.theme().danger)
+                        .text_size(px(12.))
+                        .text_color(cx.theme().muted_foreground)
+                        .child(tcode_i18n::tr!("orchestrate.children.empty")),
+                )
+                .into_any_element();
+        }
+
+        if !settings.child_models.iter().any(|profile| profile.enabled) {
+            section = section.child(
+                div()
+                    .w_full()
+                    .p_3()
+                    .rounded(cx.theme().radius)
+                    .border_1()
+                    .border_color(cx.theme().warning)
+                    .text_size(px(12.))
+                    .text_color(cx.theme().muted_foreground)
+                    .child(tcode_i18n::tr!("orchestrate.children.none_enabled")),
+            );
+        }
+
+        let mut list = v_flex()
+            .w_full()
+            .rounded(cx.theme().radius)
+            .border_1()
+            .border_color(cx.theme().border)
+            .overflow_hidden();
+        for (index, row) in self.child_rows.iter().enumerate() {
+            let Some(profile) = settings.child_model(row.provider, &row.model) else {
+                continue;
+            };
+            let provider = row.provider;
+            let model = row.model.clone();
+            let toggle_model = row.model.clone();
+            let reset_model = row.model.clone();
+            let name = self.model_name(provider, &row.model, cx);
+            list = list.child(
+                v_flex()
+                    .w_full()
+                    .gap_2()
+                    .p_3()
+                    .when(index > 0, |this| {
+                        this.border_t_1().border_color(cx.theme().border)
+                    })
+                    .child(
+                        h_flex()
+                            .w_full()
+                            .gap_2()
+                            .items_center()
+                            .child(provider_glyph(provider).small())
+                            .child(
+                                v_flex()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .child(div().text_size(px(13.)).font_medium().child(name))
+                                    .child(
+                                        div()
+                                            .font_family("monospace")
+                                            .text_size(px(11.))
+                                            .text_color(cx.theme().muted_foreground)
+                                            .child(format!(
+                                                "{} · {}",
+                                                provider_label(provider),
+                                                row.model
+                                            )),
+                                    ),
+                            )
+                            .child(
+                                div()
+                                    .text_size(px(11.))
+                                    .text_color(cx.theme().muted_foreground)
+                                    .child(if profile.enabled {
+                                        tcode_i18n::tr!("orchestrate.children.enabled")
+                                    } else {
+                                        tcode_i18n::tr!("orchestrate.children.disabled")
+                                    }),
+                            )
+                            .child(
+                                Switch::new(("orchestrate-child-enabled", index))
+                                    .checked(profile.enabled)
+                                    .tooltip(if profile.enabled {
+                                        tcode_i18n::tr!("orchestrate.children.disable")
+                                    } else {
+                                        tcode_i18n::tr!("orchestrate.children.enable")
+                                    })
+                                    .on_click(cx.listener(move |this, checked: &bool, _, cx| {
+                                        this.set_child_enabled(
+                                            provider,
+                                            &toggle_model,
+                                            *checked,
+                                            cx,
+                                        );
+                                    })),
+                            )
+                            .child(
+                                Button::new(("reset-orchestrate-child", index))
+                                    .ghost()
+                                    .xsmall()
+                                    .icon(IconName::Undo)
+                                    .label(tcode_i18n::tr!("orchestrate.restore_default"))
+                                    .on_click(cx.listener(move |this, _, window, cx| {
+                                        this.reset_child_definition(
+                                            provider,
+                                            &reset_model,
+                                            window,
+                                            cx,
+                                        );
+                                    })),
+                            )
+                            .child(
+                                Button::new(("remove-orchestrate-child", index))
+                                    .ghost()
+                                    .xsmall()
+                                    .icon(IconName::Delete)
+                                    .tooltip(tcode_i18n::tr!("orchestrate.children.remove"))
+                                    .on_click(cx.listener(move |this, _, window, cx| {
+                                        this.remove_child(provider, &model, window, cx);
+                                    })),
+                            ),
+                    )
+                    .child(Input::new(&row.description).small()),
+            );
+        }
+        section.child(list).into_any_element()
+    }
+}
+
+impl Render for OrchestrateSettingsPanel {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .w_full()
+            .gap_6()
+            .child(
+                div()
+                    .text_size(px(11.))
+                    .font_medium()
+                    .text_color(cx.theme().muted_foreground)
+                    .child(tcode_i18n::tr!("settings.orchestrate_section")),
+            )
+            .child(self.render_intro(cx))
+            .child(self.render_identities(cx))
+            .child(self.render_children(cx))
+    }
+}
+
+fn default_reasoning_effort(spec: &agent::ModelSpec) -> Option<String> {
+    spec.options.iter().find_map(|option| match option {
+        OptionDescriptor::Select {
+            id, default_value, ..
+        } if id == "reasoningEffort" => default_value.clone(),
+        _ => None,
+    })
+}

--- a/crates/ui/src/runtime_event.rs
+++ b/crates/ui/src/runtime_event.rs
@@ -33,9 +33,6 @@ pub(super) fn present_runtime_event(event: &RuntimeEvent) -> PresentedRuntimeEve
                 RuntimeError::External(message) | RuntimeError::ProviderMessage(message) => {
                     message.clone()
                 }
-                RuntimeError::OrchestrateUnsupported => {
-                    tcode_i18n::tr!("composer.orchestrate_acp_unsupported").into_owned()
-                }
                 RuntimeError::PersistSettings { error } => {
                     tcode_i18n::tr!("errors.persist_settings", error = error).into_owned()
                 }
@@ -297,7 +294,6 @@ mod tests {
         let _locale_guard = crate::settings::TestLocaleGuard::acquire();
         let errors = vec![
             RuntimeError::External("external\0diagnostic".into()),
-            RuntimeError::OrchestrateUnsupported,
             RuntimeError::PersistSettings { error: "x".into() },
             RuntimeError::UpdateUnknown {
                 provider: ProviderKind::Codex,

--- a/crates/ui/src/settings.rs
+++ b/crates/ui/src/settings.rs
@@ -36,7 +36,8 @@ pub fn apply_locale(override_locale: Option<&str>) {
 }
 
 pub use tcode_core::settings::{
-    EnvVar, ProjectSort, ProviderSettings, Settings, ThemeMode, provider_key, provider_label,
+    EnvVar, OrchestrateChildModel, OrchestrateSettings, OrchestratorIdentity, ProjectSort,
+    ProviderSettings, Settings, ThemeMode, provider_key, provider_label,
 };
 /// The six accent presets offered by the provider card (T3 §2).
 pub const ACCENT_PRESETS: [&str; 6] = [

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -26,6 +26,7 @@ use agent::ProviderKind;
 use tcode_runtime::app::AppState;
 
 use crate::acp_panel::{AcpAgentCard, AcpPanel};
+use crate::orchestrate_settings::OrchestrateSettingsPanel;
 use crate::provider_card::ProviderCard;
 use crate::settings::{LANGUAGE_ENGLISH, LANGUAGE_SIMPLIFIED_CHINESE, Settings, ThemeMode};
 use crate::time::now_secs;
@@ -46,6 +47,7 @@ const CONTENT_MAX_WIDTH: f32 = 720.;
 enum Section {
     General,
     Providers,
+    Orchestrate,
     Archived,
 }
 
@@ -65,6 +67,8 @@ pub struct SettingsPage {
     provider_cards: Vec<(ProviderKind, Entity<ProviderCard>)>,
     /// Long-lived state for the modal ACP marketplace and custom form.
     acp_panel: Entity<AcpPanel>,
+    /// Editable main-model identities and child-model routing matrix.
+    orchestrate_panel: Entity<OrchestrateSettingsPanel>,
     /// Stable entities keep expanded state and lazily-created inputs across rerenders.
     acp_cards: Vec<(String, Entity<AcpAgentCard>)>,
     debug_acp_dialog_pending: bool,
@@ -79,15 +83,19 @@ impl SettingsPage {
         // Screenshot-only: `--debug-settings-section` opens a specific section.
         let section = match app_state.read(cx).debug_settings_section.as_deref() {
             Some("providers") => Section::Providers,
+            Some("orchestrate") => Section::Orchestrate,
             Some("archived") => Section::Archived,
             _ => Section::General,
         };
         let acp_panel = cx.new(|cx| AcpPanel::new(app_state.clone(), window, cx));
+        let orchestrate_panel =
+            cx.new(|cx| OrchestrateSettingsPanel::new(app_state.clone(), window, cx));
         let debug_acp_dialog_pending = app_state.read(cx).debug_acp_dialog;
         let mut page = Self {
             app_state,
             provider_cards: Vec::new(),
             acp_panel,
+            orchestrate_panel,
             acp_cards: Vec::new(),
             debug_acp_dialog_pending,
             section,
@@ -260,6 +268,14 @@ impl SettingsPage {
                     ))
                     .child(nav_item(
                         self,
+                        "settings-nav-orchestrate",
+                        IconName::Map,
+                        tcode_i18n::tr!("settings.orchestrate").into_owned().into(),
+                        Section::Orchestrate,
+                        cx,
+                    ))
+                    .child(nav_item(
+                        self,
                         "settings-nav-archived",
                         IconName::Inbox,
                         tcode_i18n::tr!("settings.archived").into_owned().into(),
@@ -349,6 +365,11 @@ impl SettingsPage {
                     app_state.update(cx, |state, cx| state.reset_settings(cx));
                     // Every provider card's inputs now hold stale overrides.
                     page.update(cx, |page, cx| page.build_provider_cards(window, cx));
+                    page.update(cx, |page, cx| {
+                        let app_state = page.app_state.clone();
+                        page.orchestrate_panel =
+                            cx.new(|cx| OrchestrateSettingsPanel::new(app_state, window, cx));
+                    });
                     apply_theme(ThemeMode::System, window, cx);
                     true
                 })
@@ -359,6 +380,7 @@ impl SettingsPage {
         let column = match self.section {
             Section::General => self.render_general(cx),
             Section::Providers => self.render_providers(window, cx),
+            Section::Orchestrate => v_flex().child(self.orchestrate_panel.clone()),
             Section::Archived => self.render_archived(cx),
         };
         div()

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -165,11 +165,22 @@ add/remove row tints + left accent bars, "N unmodified lines" muted separator
 rows between hunks.
 
 ### Settings (full-page route)
-Left nav (sidebar width): General / Providers + "← Back" pinned bottom. Header:
-"Settings" + "Restore defaults" bordered button (confirm). Rows: bold 14px
-title + 13px muted description left, control right (dropdown / toggle / text
-input), hairline separators. General: Theme (System/Light/Dark, live), Word
-wrap in diffs, Delete confirmation. Providers: claude / codex binary paths.
+Left nav (sidebar width): General / Providers / Orchestrate + "← Back" pinned
+bottom. Header: "Settings" + "Restore defaults" bordered button (confirm).
+Rows: bold 14px title + 13px muted description left, control right (dropdown /
+toggle / text input), hairline separators. General: Theme
+(System/Light/Dark, live), Word wrap in diffs, Delete confirmation. Providers:
+claude / codex binary paths.
+
+Orchestrate begins with an explicit built-in `/orchestrate` explanation. Every
+main model is eligible: the page exposes one multiline generic identity plus
+optional per-model multiline identity overrides, and models without an override
+inherit the generic text. Each editor has a compact "Restore default" action.
+Allowed child models are retained as provider/model profiles with one multiline
+routing-definition editor, an independent dispatch switch, restore and delete
+actions. Built-in ratings and recommended effort live inside the default text,
+not separate controls. Add-model popovers keep provider tabs fixed above a
+300px scrollable model list so large catalogs never grow past the viewport.
 
 ### Command palette (⌘K)
 Centered top-anchored modal over a dim backdrop: search input; grouped results

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -118,6 +118,7 @@ settings:
   title: "Settings"
   general: "General"
   providers: "Providers"
+  orchestrate: "Orchestrate"
   archived: "Archived Threads"
   archived_section: "ARCHIVED THREADS"
   archived_empty: "No archived threads"
@@ -129,10 +130,11 @@ settings:
   back: "Back"
   restore: "Restore defaults"
   restore_title: "Restore default settings?"
-  restore_description: "Reset language, theme, diff, and provider settings to their defaults. Your projects and conversations will not be changed."
+  restore_description: "Reset language, theme, diff, provider, and orchestrate settings to their defaults. Your projects and conversations will not be changed."
   cancel: "Cancel"
   general_section: "GENERAL"
   providers_section: "PROVIDERS"
+  orchestrate_section: "ORCHESTRATE"
   language:
     title: "Language"
     description: "Choose the language used across tcode."
@@ -157,6 +159,38 @@ settings:
   provider_updates:
     title: "Provider update checks"
     description: "Check for newer provider CLI versions on launch."
+orchestrate:
+  restore_default: "Restore default"
+  all_models:
+    title: "Built-in /orchestrate command"
+    description: "These settings control what tcode injects when you send /orchestrate: how the current model understands its lead role, and which configured child models the orchestration MCP may dispatch work to. Every main model can use the command; models without an override inherit the generic identity."
+  identity:
+    title: "Lead-model identity"
+    description: "This text becomes the primary decision model's self-concept on the next /orchestrate message."
+  generic_identity:
+    title: "Generic identity"
+    description: "Fallback instructions used by every model that has no dedicated override. Changes are injected on the next /orchestrate message."
+    placeholder: "Describe the lead model's role, strengths, and operating posture…"
+  model_identity:
+    title: "Model-specific overrides"
+    description: "Optional praise, self-concept, or model-specific guidance. Removing an override restores generic inheritance."
+    placeholder: "Describe this model's distinctive strengths and how it should lead…"
+    add: "Add override"
+    empty: "No dedicated overrides. Every model currently inherits the generic identity."
+    use_generic: "Remove override and use the generic identity"
+  children:
+    title: "Allowed child models"
+    description: "Keep a routing definition for each child model and switch it on only when /orchestrate may dispatch work to it. Built-in definitions include the default ratings and recommended effort as editable text."
+    add: "Add child model"
+    empty: "No child-model profiles are configured. /orchestrate remains available, but dispatch calls will be rejected until a child model is added."
+    none_enabled: "Every child-model profile is switched off. /orchestrate can still plan, but all dispatch calls will be rejected."
+    enabled: "Enabled"
+    disabled: "Paused"
+    enable: "Allow /orchestrate to dispatch to this model"
+    disable: "Pause dispatch while keeping this model's definition"
+    description_placeholder: "Define this model's ratings, strengths, best-fit tasks, caveats, recommended effort, and escalation role…"
+    remove: "Delete this child-model profile"
+  no_more_models: "All available provider models are already configured. Add custom model slugs under Providers to expose more choices."
 providers:
   # Section header (T3 §1)
   checked: "Checked %{when}"
@@ -341,7 +375,6 @@ composer:
   cmd_default_desc: "Switch this thread back to normal build mode"
   cmd_orchestrate_label: "orchestrate"
   cmd_orchestrate_desc: "Coordinate work through child tcode threads"
-  orchestrate_acp_unsupported: "Orchestrate mode is not available for ACP sessions yet."
   group_builtin: "Built-in"
   group_provider: "Provider"
   group_skills: "Skills"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -118,6 +118,7 @@ settings:
   title: "设置"
   general: "通用"
   providers: "提供商"
+  orchestrate: "Orchestrate"
   archived: "已归档对话"
   archived_section: "已归档对话"
   archived_empty: "没有已归档的对话"
@@ -129,10 +130,11 @@ settings:
   back: "返回"
   restore: "恢复默认设置"
   restore_title: "恢复默认设置？"
-  restore_description: "将语言、主题、diff 和提供商设置恢复为默认值。项目和对话不会受到影响。"
+  restore_description: "将语言、主题、diff、提供商和 Orchestrate 设置恢复为默认值。项目和对话不会受到影响。"
   cancel: "取消"
   general_section: "通用"
   providers_section: "提供商"
+  orchestrate_section: "ORCHESTRATE"
   language:
     title: "语言"
     description: "选择 tcode 的界面语言。"
@@ -157,6 +159,38 @@ settings:
   provider_updates:
     title: "提供方更新检查"
     description: "启动时检查更新的提供方 CLI 版本。"
+orchestrate:
+  restore_default: "恢复默认"
+  all_models:
+    title: "内建 /orchestrate 命令"
+    description: "这里控制发送 /orchestrate 时 tcode 注入的内容：当前模型如何理解自己的主决策角色，以及编排 MCP 可以把任务派发给哪些子模型。所有主模型都能使用该命令；没有专属覆盖时会继承通用自我认知。"
+  identity:
+    title: "主决策模型的自我认知"
+    description: "这些文本会在下一条 /orchestrate 消息中成为主决策模型对自身角色的理解。"
+  generic_identity:
+    title: "通用自我认知"
+    description: "所有没有专属覆盖的模型都会使用这段回退指令。修改会在下一条 /orchestrate 消息中注入。"
+    placeholder: "描述主决策模型的角色、优势和工作方式…"
+  model_identity:
+    title: "模型专属覆盖"
+    description: "可选的夸赞、自我定位或模型专属指引；删除覆盖后会重新继承通用自我认知。"
+    placeholder: "描述这个模型独特的优势，以及它应当如何领导工作…"
+    add: "添加专属覆盖"
+    empty: "目前没有专属覆盖，所有模型都继承通用自我认知。"
+    use_generic: "删除专属覆盖并使用通用自我认知"
+  children:
+    title: "允许派发的子模型"
+    description: "为每个子模型保留一段路由定义，只在允许 /orchestrate 派发给它时打开开关。内置定义已用可编辑文本写入默认评分和推荐 effort。"
+    add: "添加子模型"
+    empty: "目前没有配置任何子模型。/orchestrate 仍然可用，但在添加子模型前，派发调用会被拒绝。"
+    none_enabled: "所有子模型配置都已关闭。/orchestrate 仍可进行规划，但所有派发调用都会被拒绝。"
+    enabled: "已启用"
+    disabled: "已暂停"
+    enable: "允许 /orchestrate 向这个模型派发任务"
+    disable: "暂停派发，但保留这个模型的定义"
+    description_placeholder: "定义该模型的评分、优势、适合任务、注意事项、推荐 effort 和升级定位…"
+    remove: "删除这个子模型配置"
+  no_more_models: "所有可用的提供商模型都已配置。可先在“提供商”中添加自定义模型标识。"
 providers:
   checked: "已于%{when}检查"
   refresh: "刷新提供方状态"
@@ -334,7 +368,6 @@ composer:
   cmd_default_desc: "将此会话切换回普通构建模式"
   cmd_orchestrate_label: "orchestrate"
   cmd_orchestrate_desc: "通过 tcode 子会话协调工作"
-  orchestrate_acp_unsupported: "编排模式暂不支持 ACP 会话。"
   group_builtin: "内置"
   group_provider: "提供方"
   group_skills: "技能"


### PR DESCRIPTION
## Summary

- add a dedicated Orchestrate settings page that explicitly configures the built-in `/orchestrate` command
- let every provider model act as the lead, with a generic identity fallback and optional model-specific identity text
- add editable child-model profiles with independent dispatch switches, text-only definitions, per-text default restoration, and GPT-only enabled defaults
- add Codex/Claude tabs and a bounded scroll area to the add-model popovers
- inject current settings into every orchestrated turn and enforce the enabled child-model allow list at dispatch time
- support ACP sessions as lead orchestrators through generic guidance
- update bilingual copy and the design contract
- preserve a naturally exiting Codex process's real startup status after CI exposed an existing stdout/exit race

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build`
- `cargo test --workspace`
- Codex startup-failure regression test repeated 20 times
- isolated native startup with `--open-settings --debug-settings-section orchestrate`
