### PR TITLE
Fix scrolling across dynamic UI surfaces

### DIFF
--- a/crates/ui/src/acp_panel.rs
+++ b/crates/ui/src/acp_panel.rs
@@ -395,6 +395,7 @@ impl AcpPanel {
         if let Some(error) = error.filter(|_| empty) {
             rows = rows.child(
                 div()
+                    .flex_none()
                     .p_3()
                     .text_size(px(12.))
                     .text_color(cx.theme().danger)
@@ -403,6 +404,7 @@ impl AcpPanel {
         } else if empty && loading {
             rows = rows.child(
                 div()
+                    .flex_none()
                     .p_3()
                     .text_size(px(12.))
                     .text_color(cx.theme().muted_foreground)
@@ -413,6 +415,7 @@ impl AcpPanel {
             rows = rows.child(
                 v_flex()
                     .w_full()
+                    .flex_none()
                     .when(index > 0, |row| row.border_t_1().border_color(border))
                     .child(self.render_market_row(agent, cx)),
             );
@@ -422,14 +425,14 @@ impl AcpPanel {
             .gap_3()
             .child(Input::new(&self.search).small())
             .child(
-                v_flex()
+                div()
                     .w_full()
-                    .max_h(px(360.))
+                    .h(px(360.))
                     .overflow_y_scrollbar()
                     .rounded(cx.theme().radius)
                     .border_1()
                     .border_color(border)
-                    .child(rows),
+                    .child(div().size_full().child(rows)),
             )
             .child(
                 h_flex()

--- a/crates/ui/src/add_project_dialog.rs
+++ b/crates/ui/src/add_project_dialog.rs
@@ -24,6 +24,8 @@ use tcode_runtime::ui_facade::{
 };
 
 const RECENT_LIMIT: usize = 15;
+const RECENT_ROW_HEIGHT_ESTIMATE: f32 = 64.;
+const RECENT_VIEWPORT_MAX_HEIGHT: f32 = 390.;
 
 enum RecentState {
     Loading,
@@ -182,20 +184,20 @@ impl AddProjectDialog {
                 .child(tcode_i18n::tr!("sidebar.recent_empty"))
                 .into_any_element(),
             RecentState::Ready(recent) => {
-                let mut list = v_flex()
-                    .id("recent-directory-list")
-                    .max_h(px(390.))
-                    .gap_1()
-                    .overflow_y_scrollbar();
+                // Keep the viewport and the flex column separate. Putting the
+                // max height on the column itself lets flexbox shrink every row
+                // until there is no overflow left for the wheel to scroll.
+                let mut rows = v_flex().w_full().gap_1();
                 for (index, recent) in recent.iter().take(RECENT_LIMIT).enumerate() {
                     let selected = recent.clone();
                     let name = directory_name(&recent.path);
                     let path = middle_truncate(&recent.path, 76);
                     let ago = humanize_ago(now_secs().saturating_sub(recent.last_active_ms / 1000));
                     let counts = tool_counts(&recent.threads);
-                    list = list.child(
+                    rows = rows.child(
                         v_flex()
                             .id(format!("recent-directory-{index}"))
+                            .flex_none()
                             .gap_1()
                             .px_3()
                             .py_2()
@@ -233,7 +235,16 @@ impl AddProjectDialog {
                             ),
                     );
                 }
-                list.into_any_element()
+                let visible_rows = recent.len().min(RECENT_LIMIT) as f32;
+                let viewport_height =
+                    px((visible_rows * RECENT_ROW_HEIGHT_ESTIMATE).min(RECENT_VIEWPORT_MAX_HEIGHT));
+                div()
+                    .id("recent-directory-list")
+                    .w_full()
+                    .h(viewport_height)
+                    .overflow_y_scrollbar()
+                    .child(div().size_full().child(rows))
+                    .into_any_element()
             }
         }
     }
@@ -468,5 +479,110 @@ fn humanize_ago(secs: u64) -> String {
         tcode_i18n::tr!("time.hours_ago", count = secs / 3600).into_owned()
     } else {
         tcode_i18n::tr!("time.days_ago", count = secs / 86_400).into_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{ScrollDelta, ScrollWheelEvent, TestAppContext, VisualTestContext, point, size};
+
+    struct RecentListScrollProbe;
+
+    struct MaxHeightRawScrollProbe;
+
+    impl Render for RecentListScrollProbe {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            let mut rows = v_flex().w_full().gap_1();
+
+            for index in 0..5 {
+                rows = rows.child(
+                    v_flex()
+                        .h(px(40.))
+                        .flex_none()
+                        .when(index == 4, |row| {
+                            row.debug_selector(|| "recent-last-row".into())
+                        })
+                        .child("project")
+                        .child("/path/to/project"),
+                );
+            }
+            div()
+                .w(px(240.))
+                .h(px(100.))
+                .debug_selector(|| "recent-scroll-viewport".into())
+                .overflow_y_scrollbar()
+                .child(div().size_full().child(rows))
+        }
+    }
+
+    impl Render for MaxHeightRawScrollProbe {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            let mut rows = v_flex().w_full().gap_1();
+            for index in 0..5 {
+                rows = rows.child(div().h(px(40.)).flex_none().when(index == 4, |row| {
+                    row.debug_selector(|| "raw-max-last-row".into())
+                }));
+            }
+            div()
+                .id("raw-max-scroll")
+                .w(px(240.))
+                .max_h(px(100.))
+                .overflow_y_scroll()
+                .child(rows)
+        }
+    }
+
+    fn draw(cx: &mut VisualTestContext) {
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+    }
+
+    #[gpui::test]
+    fn recent_list_scrolls_when_its_content_exceeds_the_viewport(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let (_, cx) = cx.add_window_view(|_, _| RecentListScrollProbe);
+        let cx: &mut VisualTestContext = cx;
+        cx.simulate_resize(size(px(320.), px(240.)));
+        draw(cx);
+
+        let viewport = cx.debug_bounds("recent-scroll-viewport").unwrap();
+        let initial = cx.debug_bounds("recent-last-row").unwrap();
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(20.), px(20.)),
+            delta: ScrollDelta::Pixels(point(px(0.), px(-60.))),
+            ..Default::default()
+        });
+        draw(cx);
+
+        let scrolled = cx.debug_bounds("recent-last-row").unwrap();
+        assert!(
+            scrolled.origin.y < initial.origin.y,
+            "recent list did not move after scrolling: viewport={viewport:?}, initial={initial:?}, scrolled={scrolled:?}"
+        );
+    }
+
+    #[gpui::test]
+    fn max_height_raw_viewport_scrolls_dynamic_content(cx: &mut TestAppContext) {
+        let (_, cx) = cx.add_window_view(|_, _| MaxHeightRawScrollProbe);
+        let cx: &mut VisualTestContext = cx;
+        cx.simulate_resize(size(px(320.), px(240.)));
+        draw(cx);
+
+        let initial_y = cx.debug_bounds("raw-max-last-row").unwrap().origin.y;
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(20.), px(20.)),
+            delta: ScrollDelta::Pixels(point(px(0.), px(-60.))),
+            ..Default::default()
+        });
+        draw(cx);
+
+        let scrolled_y = cx.debug_bounds("raw-max-last-row").unwrap().origin.y;
+        assert!(
+            scrolled_y < initial_y,
+            "max-height raw viewport did not move after scrolling"
+        );
     }
 }

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -1457,6 +1457,7 @@ impl Composer {
         if rows.is_empty() {
             list = list.child(
                 div()
+                    .flex_none()
                     .px_3()
                     .py_2p5()
                     .text_size(px(12.))
@@ -1480,6 +1481,7 @@ impl Composer {
                     last_group = Some(group);
                     list = list.child(
                         div()
+                            .flex_none()
                             .px_2()
                             .pt_1p5()
                             .pb_0p5()
@@ -1499,6 +1501,7 @@ impl Composer {
                 list = list.child(
                     h_flex()
                         .id(("menu-row", index))
+                        .flex_none()
                         .w_full()
                         .px_2()
                         .py_1p5()
@@ -1578,24 +1581,18 @@ impl Composer {
         }
 
         let muted = cx.theme().muted_foreground;
-        let mut strip = v_flex()
-            .w_full()
-            .gap_1()
-            .p_2()
-            .rounded(px(12.))
-            .border_1()
-            .border_color(cx.theme().border)
-            .bg(cx.theme().secondary.opacity(0.5))
-            .child(
-                div()
-                    .px_1()
-                    .text_xs()
-                    .text_color(muted)
-                    .child(tcode_i18n::tr!(
-                        "composer.queued_count",
-                        count = queued.len()
-                    )),
-            );
+        let mut strip =
+            v_flex()
+                .w_full()
+                .gap_1()
+                .p_2()
+                .rounded(px(12.))
+                .border_1()
+                .border_color(cx.theme().border)
+                .bg(cx.theme().secondary.opacity(0.5))
+                .child(div().flex_none().px_1().text_xs().text_color(muted).child(
+                    tcode_i18n::tr!("composer.queued_count", count = queued.len()),
+                ));
 
         for message in queued {
             let id = message.id;
@@ -1606,6 +1603,7 @@ impl Composer {
             };
             strip = strip.child(
                 h_flex()
+                    .flex_none()
                     .w_full()
                     .gap_1()
                     .items_center()
@@ -1646,7 +1644,15 @@ impl Composer {
                     ),
             );
         }
-        Some(strip.into_any_element())
+        Some(
+            div()
+                .id("queued-messages-scroll")
+                .w_full()
+                .max_h(px(180.))
+                .overflow_y_scroll()
+                .child(strip)
+                .into_any_element(),
+        )
     }
 
     fn render_image_strip(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
@@ -2065,7 +2071,7 @@ impl Composer {
             });
 
         // Option rows.
-        let mut options = v_flex().w_full().gap_1();
+        let mut options_content = v_flex().w_full().gap_1();
         for (opt_index, option) in question.options.iter().enumerate() {
             let is_selected = selected.iter().any(|l| l == &option.label);
             let label = option.label.clone();
@@ -2093,9 +2099,10 @@ impl Composer {
             } else {
                 div().size(px(14.)).into_any_element()
             };
-            options = options.child(
+            options_content = options_content.child(
                 h_flex()
                     .id(("ui-opt", opt_index))
+                    .flex_none()
                     .w_full()
                     .px_2()
                     .py_1p5()
@@ -2142,6 +2149,12 @@ impl Composer {
                     })),
             );
         }
+        let options = div()
+            .id("user-input-options-scroll")
+            .w_full()
+            .max_h(px(240.))
+            .overflow_y_scroll()
+            .child(options_content);
 
         // Actions row.
         let is_last = index + 1 >= total;
@@ -2381,15 +2394,11 @@ impl Composer {
                     let current = current.clone();
                     let popover = cx.entity();
                     let muted = cx.theme().muted_foreground;
-                    let mut col = v_flex()
-                        .w(px(220.))
-                        .max_h(px(280.))
-                        .overflow_hidden()
-                        .p_1()
-                        .gap_0p5();
+                    let mut col = v_flex().w_full().p_1().gap_0p5();
                     if worktree_mode {
                         col = col.child(
                             div()
+                                .flex_none()
                                 .px_2()
                                 .py_1()
                                 .text_size(px(11.))
@@ -2401,6 +2410,7 @@ impl Composer {
                     if branches.is_empty() {
                         col = col.child(
                             div()
+                                .flex_none()
                                 .px_2()
                                 .py_1p5()
                                 .text_size(px(13.))
@@ -2416,6 +2426,7 @@ impl Composer {
                             col = col.child(
                                 h_flex()
                                     .id(("branch-row", index))
+                                    .flex_none()
                                     .w_full()
                                     .px_2()
                                     .py_1p5()
@@ -2459,7 +2470,13 @@ impl Composer {
                             );
                         }
                     }
-                    col.into_any_element()
+                    div()
+                        .id("branch-list")
+                        .w(px(220.))
+                        .max_h(px(280.))
+                        .overflow_y_scroll()
+                        .child(col)
+                        .into_any_element()
                 })
                 .into_any_element()
         };
@@ -2724,7 +2741,10 @@ impl Composer {
             .when(expanded, |this| {
                 this.child(
                     div()
+                        .id("approval-detail-scroll")
                         .w_full()
+                        .max_h(px(240.))
+                        .overflow_y_scroll()
                         .p_2()
                         .rounded(px(8.))
                         .bg(cx.theme().muted)
@@ -3149,6 +3169,7 @@ fn render_model_pane(
         let composer = composer.clone();
         div()
             .id(id)
+            .flex_none()
             .size(px(28.))
             .flex()
             .items_center()
@@ -3172,12 +3193,10 @@ fn render_model_pane(
     };
 
     let mut rail_col = v_flex()
-        .flex_none()
+        .w_full()
         .py_2()
         .px_1p5()
         .gap_1()
-        .border_r_1()
-        .border_color(cx.theme().border)
         .child(rail_icon(
             "rail-fav".into(),
             Icon::new(IconName::Star),
@@ -3209,6 +3228,15 @@ fn render_model_pane(
             cx,
         ));
     }
+    let rail = div()
+        .id("model-provider-rail")
+        .flex_none()
+        .w(px(44.))
+        .h_full()
+        .border_r_1()
+        .border_color(cx.theme().border)
+        .overflow_y_scroll()
+        .child(rail_col);
 
     // Main pane: search + rows.
     let mut list = v_flex().w_full().min_h_0().gap_0p5().px_1().py_1();
@@ -3220,6 +3248,7 @@ fn render_model_pane(
     if rows.is_empty() {
         list = list.child(
             div()
+                .flex_none()
                 .px_3()
                 .py_4()
                 .text_size(px(13.))
@@ -3235,6 +3264,7 @@ fn render_model_pane(
     let mut pane = v_flex()
         .flex_1()
         .min_w_0()
+        .min_h_0()
         .child(
             div()
                 .px_3()
@@ -3244,7 +3274,14 @@ fn render_model_pane(
                 .border_color(cx.theme().border)
                 .child(Input::new(model_search).appearance(false)),
         )
-        .child(list);
+        .child(
+            div()
+                .id("model-picker-list")
+                .flex_1()
+                .min_h_0()
+                .overflow_y_scroll()
+                .child(list),
+        );
     if pending_restart {
         pane = pane.child(
             div()
@@ -3265,6 +3302,7 @@ fn render_model_pane(
 
     h_flex()
         .w(px(360.))
+        .h(px(360.))
         .items_stretch()
         .rounded(px(12.))
         .overflow_hidden()
@@ -3281,7 +3319,7 @@ fn render_model_pane(
                 popover_key.update(cx, |st, cx| st.dismiss(window, cx));
             }
         })
-        .child(rail_col)
+        .child(rail)
         .child(pane)
         .into_any_element()
 }
@@ -3309,6 +3347,7 @@ fn render_model_row(
 
     h_flex()
         .id(("model-row", index))
+        .flex_none()
         .w_full()
         .px_2()
         .py_1p5()
@@ -3501,6 +3540,7 @@ fn render_traits_pane(
 
     let section_header = |label: &str, cx: &mut Context<PopoverState>| -> AnyElement {
         div()
+            .flex_none()
             .px_2()
             .pt_2()
             .pb_1()
@@ -3511,7 +3551,7 @@ fn render_traits_pane(
             .into_any_element()
     };
 
-    let mut pane = v_flex().w(px(280.)).p_1().gap_0p5();
+    let mut pane = v_flex().w_full().p_1().gap_0p5();
 
     for descriptor in &spec.options {
         match descriptor {
@@ -3526,6 +3566,7 @@ fn render_traits_pane(
                 if is_reasoning && locked {
                     pane = pane.child(
                         div()
+                            .flex_none()
                             .px_2()
                             .py_1p5()
                             .text_size(px(12.))
@@ -3556,6 +3597,7 @@ fn render_traits_pane(
                     pane = pane.child(
                         h_flex()
                             .id(("trait-opt", index * 31 + descriptor_hash(id)))
+                            .flex_none()
                             .w_full()
                             .px_2()
                             .py_1p5()
@@ -3607,6 +3649,7 @@ fn render_traits_pane(
                     pane = pane.child(
                         h_flex()
                             .id(("trait-bool", index * 61 + descriptor_hash(id)))
+                            .flex_none()
                             .w_full()
                             .px_2()
                             .py_1p5()
@@ -3639,6 +3682,7 @@ fn render_traits_pane(
     if pending_restart {
         pane = pane.child(
             div()
+                .flex_none()
                 .px_2()
                 .py_1p5()
                 .border_t_1()
@@ -3648,7 +3692,13 @@ fn render_traits_pane(
                 .child(tcode_i18n::tr!("composer.restart_note")),
         );
     }
-    pane.into_any_element()
+    div()
+        .id("traits-options-scroll")
+        .w(px(280.))
+        .max_h(px(360.))
+        .overflow_y_scroll()
+        .child(pane)
+        .into_any_element()
 }
 
 /// A tiny stable hash of a descriptor id, to keep row element ids unique across

--- a/crates/ui/src/diff_panel.rs
+++ b/crates/ui/src/diff_panel.rs
@@ -1017,6 +1017,7 @@ impl DiffPanel {
                         let session = session_for.clone();
                         h_flex()
                             .id(id)
+                            .flex_none()
                             .w_full()
                             .px_2()
                             .py_1()
@@ -1046,8 +1047,8 @@ impl DiffPanel {
                             })
                     };
                 let mut list = v_flex()
+                    .w_full()
                     .p_1()
-                    .min_w(px(190.))
                     .gap_0p5()
                     .child(scope_row(
                         "diff-scope-working",
@@ -1063,6 +1064,7 @@ impl DiffPanel {
                     ))
                     .child(
                         div()
+                            .flex_none()
                             .px_2()
                             .pt_2()
                             .pb_1()
@@ -1079,6 +1081,7 @@ impl DiffPanel {
                     list = list.child(
                         h_flex()
                             .id(("diff-turn-item", turn))
+                            .flex_none()
                             .w_full()
                             .px_2()
                             .py_1()
@@ -1111,7 +1114,12 @@ impl DiffPanel {
                             }),
                     );
                 }
-                list
+                div()
+                    .id("diff-turn-list")
+                    .min_w(px(190.))
+                    .max_h(px(320.))
+                    .overflow_y_scroll()
+                    .child(list)
             });
 
         let wrap_on = self.wrap;
@@ -1203,7 +1211,7 @@ impl DiffPanel {
                 .icon(IconName::ChevronDown);
             toolbar = toolbar.child(Popover::new("diff-base-popover").trigger(trigger).content(
                 move |_, _, cx| {
-                    let mut list = v_flex().p_1().min_w(px(180.)).gap_0p5();
+                    let mut list = v_flex().w_full().p_1().gap_0p5();
                     for (branch_index, branch) in branches.clone().into_iter().enumerate() {
                         let panel = panel.clone();
                         let session = session_base.clone();
@@ -1212,6 +1220,7 @@ impl DiffPanel {
                         list = list.child(
                             h_flex()
                                 .id(("diff-base-item", branch_index))
+                                .flex_none()
                                 .w_full()
                                 .px_2()
                                 .py_1()
@@ -1237,7 +1246,12 @@ impl DiffPanel {
                                 }),
                         );
                     }
-                    list
+                    div()
+                        .id("diff-base-list")
+                        .min_w(px(180.))
+                        .max_h(px(280.))
+                        .overflow_y_scroll()
+                        .child(list)
                 },
             ));
         }

--- a/crates/ui/src/palette.rs
+++ b/crates/ui/src/palette.rs
@@ -399,18 +399,12 @@ impl Render for CommandPalette {
         let muted = cx.theme().muted_foreground;
 
         // Build the result list, tracking a running flat index for highlight.
-        let mut list = v_flex()
-            .id("palette-list")
-            .flex_1()
-            .min_h_0()
-            .overflow_y_scroll()
-            .px_2()
-            .py_2()
-            .gap_1();
+        let mut list_content = v_flex().w_full().px_2().py_2().gap_1();
         let mut flat = 0usize;
         for group in &groups {
-            list = list.child(
+            list_content = list_content.child(
                 div()
+                    .flex_none()
                     .px_2()
                     .pt_1()
                     .text_size(px(11.))
@@ -423,9 +417,10 @@ impl Render for CommandPalette {
                 flat += 1;
                 let is_sel = index == self.selected;
                 let action = item.action.clone();
-                list = list.child(
+                list_content = list_content.child(
                     h_flex()
                         .id(("palette-row", index))
+                        .flex_none()
                         .w_full()
                         .h(px(38.))
                         .px_2()
@@ -481,8 +476,9 @@ impl Render for CommandPalette {
             }
         }
         if total == 0 {
-            list = list.child(
+            list_content = list_content.child(
                 div()
+                    .flex_none()
                     .px_2()
                     .py_4()
                     .text_size(px(13.))
@@ -490,6 +486,12 @@ impl Render for CommandPalette {
                     .child(tcode_i18n::tr!("palette.no_matches")),
             );
         }
+        let list = div()
+            .id("palette-list")
+            .flex_1()
+            .min_h_0()
+            .overflow_y_scroll()
+            .child(list_content);
 
         // Centered modal card, anchored ~15% from the top over a dim backdrop.
         let card = v_flex()

--- a/crates/ui/src/provider_model_picker.rs
+++ b/crates/ui/src/provider_model_picker.rs
@@ -205,6 +205,7 @@ impl Render for ProviderModelPicker {
                 if available.is_empty() {
                     rows = rows.child(
                         div()
+                            .flex_none()
                             .p_4()
                             .text_size(px(12.))
                             .text_color(cx.theme().muted_foreground)
@@ -220,6 +221,7 @@ impl Render for ProviderModelPicker {
                         rows = rows.child(
                             h_flex()
                                 .id(("settings-model-option", index))
+                                .flex_none()
                                 .w_full()
                                 .px_2()
                                 .py_1p5()
@@ -299,11 +301,11 @@ impl Render for ProviderModelPicker {
                 }
 
                 v_flex().w(px(390.)).child(tabs).child(
-                    v_flex()
+                    div()
                         .w_full()
                         .h(px(300.))
                         .overflow_y_scrollbar()
-                        .child(rows),
+                        .child(div().size_full().child(rows)),
                 )
             })
     }

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -1156,16 +1156,10 @@ impl Render for SessionsSidebar {
             (state.grouped_sessions(), active_id, turn_running)
         };
 
-        let mut list = v_flex()
-            .flex_1()
-            .min_h_0()
-            .overflow_y_scrollbar()
-            .px_2()
-            .pb_2()
-            .gap(px(2.));
+        let mut list_content = v_flex().w_full().px_2().pb_2().gap(px(2.));
 
         if groups.is_empty() {
-            list = list.child(
+            list_content = list_content.child(
                 div()
                     .px_2()
                     .py_3()
@@ -1175,9 +1169,21 @@ impl Render for SessionsSidebar {
             );
         } else {
             for group in &groups {
-                list = list.child(self.render_group(group, active_id.as_deref(), turn_running, cx));
+                list_content = list_content.child(self.render_group(
+                    group,
+                    active_id.as_deref(),
+                    turn_running,
+                    cx,
+                ));
             }
         }
+
+        let list = div()
+            .id("sidebar-project-list")
+            .flex_1()
+            .min_h_0()
+            .overflow_y_scrollbar()
+            .child(div().size_full().child(list_content));
 
         v_flex()
             .size_full()

--- a/crates/ui/src/toast.rs
+++ b/crates/ui/src/toast.rs
@@ -321,8 +321,9 @@ impl ToastCenter {
                     .when(expanded, |this| {
                         this.child(
                             div()
+                                .id(("toast-detail-scroll", id as usize))
                                 .max_h(px(160.))
-                                .overflow_hidden()
+                                .overflow_y_scroll()
                                 .p_2()
                                 .rounded(px(6.))
                                 .bg(cx.theme().muted)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -58,6 +58,18 @@ Canonical values live in `themes/tcode.json` (embedded at build time).
   row ≈44px.
 - Sidebar thread rows ≈30px, 13px text, 4px-radius hover bg.
 
+## Scrolling contract
+
+Potentially unbounded content always has its own resolved-height viewport and a
+separate, non-shrinking content column. Headers, search fields, footers and
+actions stay outside that viewport. This applies to the sidebar project list,
+Settings content, command-palette results, Add Project recents (capped at
+390px), ACP/model catalogs, model traits, branch and diff-scope selectors,
+queued messages, user-input options, approval details and expanded toast
+details. A bounded flex column with `overflow` on the same node is not an
+acceptable substitute: flexbox can shrink its rows until no scrollable overflow
+remains.
+
 ## Surface anatomy
 
 ### Sidebar


### PR DESCRIPTION
## Summary
- fix the Add Project recent-activity list and the same GPUI flex/overflow failure mode across dynamic views
- add bounded scrolling to model, branch, diff-scope, queue, user-input, approval, and toast surfaces
- document the scrolling layout contract and add GPUI wheel-event regressions

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo build
- cargo test --workspace