### PR TITLE
Fix Orchestrate settings input layout

### DIFF
--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -427,7 +427,10 @@ impl SettingsPage {
                     .justify_center()
                     .px_6()
                     .py_6()
-                    .child(column.w_full().max_w(px(CONTENT_MAX_WIDTH))),
+                    // Keep this width definite before capping it. Reversing
+                    // these constraints makes nested multiline inputs resolve
+                    // their percentage width to zero when the cap applies.
+                    .child(column.w(px(CONTENT_MAX_WIDTH)).max_w_full()),
             )
             .into_any_element()
     }


### PR DESCRIPTION
## Summary

- keep the Settings content column at a definite width before capping it to the viewport
- prevent nested multiline Orchestrate inputs from resolving to zero width
- restore visible editing and restore-default feedback

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tcode-ui` (91 passed)
- `cargo check --workspace`