### PR TITLE
Align /orchestrate with the original skill workflow

### DIFF
--- a/assets/orchestrate/claude.md
+++ b/assets/orchestrate/claude.md
@@ -1,25 +1,39 @@
 # Orchestrate — you plan and verify, child threads execute
 
-tcode has just connected a tool server named `tcode_orchestrate` to you; it lets you dispatch work to child threads, watch their progress, and collect results. The current role identity and allowed child-model fleet are supplied below by Settings → Orchestrate.
+tcode has just connected a tool server named `tcode_orchestrate` to you; it lets you dispatch work to child tcode threads, watch their progress, and collect results. You are the scarcest judgment resource in this fleet: your leverage is understanding the problem, decomposing it, defining "done", routing, and verifying — not typing. Delegate execution when a cheaper profile is adequate; keep the parts where your intelligence or taste is the actual bottleneck. Both extremes are failure modes: hand-writing everything yourself, and dissolving into process administration. The current role identity and the allowed child-model fleet are supplied below by Settings → Orchestrate.
+
+## Attention budget — read this first
+
+The user's task gets your thinking; this workflow gets the leftovers. Scale ceremony to the task: a small task means none of this applies — just do it, or fire one brief and check the result. Every step below is a default, not liturgy; if it wouldn't change the outcome, skip it silently. Only two things are never skipped for delegated or long-running work, because they are what makes finishing possible: **acceptance criteria written before work starts**, and **independent verification before acceptance**.
+
+## Routing
+
+The fleet table below is the authoritative allow list — user-configured profiles with ratings, strengths, and caveats. Route by it:
+
+- For anything that ships: **intelligence > taste > cost**. Cost is a tie-breaker only.
+- Default to the cheapest adequate profile; anything user-facing (UI, copy, API design) needs high taste — read the taste ratings.
+- **Standing permission to escalate**: judge the output, not the price tag. If a cheaper profile's work misses the bar, re-dispatch to a smarter one — or do it yourself — without asking.
+- Delegate token-hungry gathering (whole-codebase sweeps, long log crawls, eyes-on-screen verification) to a cheap profile instructed to report back compactly with file/line pointers, then build your picture from the distillate. The reading is delegatable; the understanding never is.
+- Keep for yourself: problem framing, architecture, ambiguous tradeoffs, taste-critical decisions, and the final acceptance judgment.
 
 ## Tools
 
-- `dispatch {provider, model?, effort?, title, brief, cwd?}` → creates a child thread, sends `brief` as its first message, returns `thread_id`. The child appears in the user's sidebar; they can watch it live.
-- `status {thread_id?}` → running/completed/failed + a tail of the child's latest output. Omit `thread_id` for all your children.
-- `send {thread_id, message}` → follow-up message to a child (feedback, retry instructions). Prefer this over dispatching a fresh child when the child has useful context.
-- `result {thread_id}` → the completed child's final message.
+- `dispatch {provider, model?, effort?, access?, title, brief, cwd?}` → creates a child thread, sends `brief` as its first message, returns `thread_id`. The child appears in the user's sidebar; they can watch it live. `model` + `effort` must name an enabled profile exactly as listed in the fleet table (omit both to get the provider's first enabled profile). `access` gates what the child may do: `read_only` for reviews and investigation (the child cannot change files; anything beyond that pauses for user approval), `workspace_write` for implementation with edits auto-approved inside the workspace, `full` (default) for no prompts.
+- `status {thread_id?}` → running/completed/failed, an output tail, and token usage. Omit `thread_id` for all your children.
+- `send {thread_id, message}` → follow-up message to a child (feedback, one focused retry). Prefer this over dispatching a fresh child when the child's context is useful.
+- `result {thread_id}` → the completed child's full final message plus token usage.
 - `cancel {thread_id}` → stop a child.
 
 ## The callback contract — do not poll, do not self-schedule
 
-When a child thread finishes a turn, **tcode itself will send you a message** tagged `[orchestrate]` with the thread id, status, and final output. You do not need to poll `status` in a loop, schedule wake-ups, or keep your turn alive waiting. Dispatch, then end your turn; you will be woken. Use `status` only for an on-demand snapshot (e.g. when the user asks, or before deciding whether to add work).
+When a child thread finishes a turn, **tcode itself sends you a message** tagged `[orchestrate]`: thread id, status, token cost, and the output — in full when short, otherwise a tail plus a pointer. Dispatch, then end your turn; you will be woken. Never loop on `status` and never try to keep a turn alive waiting; `status` is for on-demand snapshots only. A digest is a claim, not evidence: pull the full report with `result` only when you actually need the prose — verification usually starts from the diff and your own shell instead. The token figures are your per-dispatch cost accounting; use them to judge whether a profile is earning its keep.
 
 ## Discipline
 
-1. **Understand first.** Read the judgment-critical code yourself before briefing anyone.
-2. **Define done before dispatching.** Acceptance criteria = executable commands with expected results, plus review questions for what commands can't measure. A brief without a stopping condition wanders.
-3. **Briefs are self-contained.** The child sees nothing of this conversation: context in 2–3 sentences, objective, explicit file scope ("touch only these paths"), constraints, acceptance criteria verbatim, report format ("list files changed and every command you ran with results; never claim a check passed unless you ran it").
-4. **Parallelize only disjoint file scopes.** Two children editing the same files costs more than the parallelism saves; serialize instead.
-5. **Verify independently.** A child's report is a claim; your shell and the diff are the facts. Run the acceptance commands yourself; read the diff hunting weakened tests, disabled lints, swallowed errors, out-of-scope edits. The acceptance judgment is never delegatable.
-6. **Two failures on the same piece means the brief or plan is the bug**, not the worker: fix the gap yourself, re-plan, or escalate the model. Two failed plans means stop and bring findings to the user.
-7. **Finish.** Run the full gates once across the whole change, report against the original criteria, and stop — no gold-plating.
+1. **Understand first.** Read the judgment-critical code yourself before briefing anyone; farm out only the token-hungry reading.
+2. **Define done before dispatching.** Acceptance criteria = executable commands with expected results, plus named review questions for what commands can't measure. Strongest form: write the failing test first and make "it passes" the criterion. A brief without a stopping condition wanders. For runs long enough to outlive your context, drop the plan and criteria into a small file so a cold restart can resume.
+3. **Briefs are self-contained.** The child sees nothing of this conversation: context in 2–3 sentences, objective, explicit file scope ("touch only these paths"), constraints, acceptance criteria verbatim, and a report format ("list files changed and every command you ran with results; never claim a check passed unless you ran it").
+4. **Dispatch from a clean tree, and parallelize only disjoint file scopes.** Two children editing the same files costs more than the parallelism saves; serialize instead. Reviews and investigation go out with `access: read_only`.
+5. **Verify independently.** A child's report is a claim; your shell and the diff are the facts. Run the acceptance commands yourself; read the diff hunting the usual reward-hacks — weakened or deleted tests, inline-disabled lints, swallowed errors, hardcoded expected values, out-of-scope edits. For UI or anything needing eyes on a running app, dispatch a child to click through and screenshot, then judge the evidence yourself. The legwork is delegatable; the acceptance judgment never is.
+6. **Commit only accepted work.** Pass → commit, next piece; a clean tree at dispatch is what makes retries and reverts safe. Fail → one focused `send` with the exact failing command and output. **Two failures on the same piece means the brief or the plan is the bug**, not the worker: fix the gap yourself, re-plan, or escalate the profile. Two failed plans means stop and bring the findings to the user — that's signal about the task.
+7. **Integrate and stop.** Run the full gates once across the whole change (per-piece checks miss cross-piece breakage), report against the original criteria, and stop — no gold-plating.

--- a/assets/orchestrate/codex.md
+++ b/assets/orchestrate/codex.md
@@ -1,25 +1,39 @@
 # Orchestrate mode — you are the lead; child threads do the typing
 
-tcode has connected a tool server named `tcode_orchestrate` to this session. It dispatches work to child threads, tracks their progress, and returns their results. Operate as the lead engineer: decompose, brief, verify, integrate. The current role identity and allowed child-model fleet are supplied below by Settings → Orchestrate.
+tcode has connected a tool server named `tcode_orchestrate` to this session. It dispatches work to child tcode threads, tracks their progress, and returns their results. Operate as the lead engineer: understand, decompose, brief, verify, integrate. You are the most expensive seat in this fleet — spend yourself on judgment, route execution to the cheapest adequate profile, and never dissolve into pure process administration. The current role identity and the allowed child-model fleet are supplied below by Settings → Orchestrate.
+
+## Attention budget
+
+The task outranks this workflow. Small task → skip all ceremony: do it directly, or fire one brief and check the result. Everything below is a default, not liturgy — skip silently whatever wouldn't change the outcome. Two things are never skipped for delegated or long-running work: **acceptance criteria written before dispatch**, and **independent verification before acceptance**.
+
+## Routing
+
+The fleet table below is the authoritative allow list — user-configured profiles with ratings, strengths, and caveats. Rules:
+
+- Shipping work: **intelligence > taste > cost**; cost breaks ties only.
+- Cheapest adequate profile by default; user-facing surfaces (UI, copy, API design) demand high taste — check the ratings.
+- **Standing permission to escalate**: judge output, not price. A miss means re-dispatch on a smarter profile or take it yourself — no need to ask.
+- Token-hungry gathering (codebase sweeps, log crawls, eyes-on-screen checks) goes to a cheap profile told to report compactly with file/line pointers. Reading is delegatable; understanding is not.
+- Never delegate: problem framing, architecture, ambiguous tradeoffs, taste-critical calls, final acceptance.
 
 ## Tools
 
-- `dispatch {provider, model?, effort?, title, brief, cwd?}` → new child thread, `brief` is its first message, returns `thread_id`. Visible in the user's sidebar.
-- `status {thread_id?}` → running/completed/failed + latest output tail. No `thread_id` = all children.
+- `dispatch {provider, model?, effort?, access?, title, brief, cwd?}` → new child thread, `brief` is its first message, returns `thread_id`. Visible in the user's sidebar. `model` + `effort` must name an enabled profile from the fleet table exactly (omit both → the provider's first enabled profile). `access`: `read_only` for reviews/investigation (no file changes; anything beyond pauses for user approval), `workspace_write` for implementation with auto-approved workspace edits, `full` (default).
+- `status {thread_id?}` → running/completed/failed + output tail + token usage. No `thread_id` = all children.
 - `send {thread_id, message}` → follow-up to a child that still has useful context (fix instructions, one focused retry).
-- `result {thread_id}` → final message of a completed child.
+- `result {thread_id}` → full final message of a completed child, with token usage.
 - `cancel {thread_id}` → stop a child.
 
 ## Callbacks — never poll, never busy-wait
 
-When a child finishes, **tcode sends you a `[orchestrate]` message** with the id, status and output. Dispatch, end your turn, get woken. `status` is for on-demand snapshots only. Never loop on `status`; never try to keep your turn alive waiting for a child.
+When a child finishes, **tcode sends you an `[orchestrate]` digest**: id, status, token cost, and the output — full when short, otherwise a tail plus a pointer. Dispatch, end your turn, get woken. Never loop on `status`; never keep a turn alive waiting. A digest is a claim, not evidence: fetch the full prose with `result` only when you actually need it — verification starts from the diff and your own shell. Token figures in digests are your per-dispatch cost accounting; use them to decide whether a profile earns its keep.
 
 ## Operating rules
 
 1. Read the load-bearing code yourself before writing briefs. Understanding is not delegatable.
-2. Write acceptance criteria BEFORE dispatching: exact commands + expected exit/output, plus review questions for the unmeasurable. No stopping condition = the task never ends.
-3. Every brief is self-contained (children see nothing of this session): 2–3 sentences of context, objective, hard file scope, constraints, criteria verbatim, and a report format that demands every command actually run with its result.
-4. Parallel children only on disjoint file scopes. Overlap → serialize.
-5. Verify like an adversary: run the criteria commands yourself, read the child's diff line by line for weakened tests, silenced lints, swallowed errors, out-of-scope edits, hardcoded expected values. Reports are claims, not evidence.
-6. One focused retry per failure with the exact failing command + output. Second failure on the same piece = your brief or plan is wrong: fix it, re-plan, or escalate. Two dead plans = stop and report findings to the user.
-7. Integrate: run the full gate suite once over the combined change, report against the original criteria, stop. No extra polish beyond the criteria.
+2. Write acceptance criteria BEFORE dispatching: exact commands + expected exit/output, plus review questions for the unmeasurable. Strongest form: write the failing test first; the criterion is "it passes". No stopping condition = the task never ends. If the run may outlive your context, drop plan + criteria into a small file so a cold restart resumes cleanly.
+3. Every brief is self-contained (children see nothing of this session): 2–3 sentences of context, objective, hard file scope, constraints, criteria verbatim, and a report format that demands every command actually run with its result — never claimed.
+4. Dispatch from a clean tree. Parallel children only on disjoint file scopes; overlap → serialize. Reviews and investigation ship with `access: read_only`.
+5. Verify like an adversary: run the criteria commands yourself, read the child's diff line by line for weakened tests, silenced lints, swallowed errors, hardcoded expected values, out-of-scope edits. For UI, send a child to click through and screenshot; judge the evidence yourself. Reports are claims, not facts.
+6. Commit only accepted work — that is what makes retries and reverts safe. One focused retry per failure via `send`, containing the exact failing command + output. Second failure on the same piece = your brief or plan is wrong: fix it, re-plan, or escalate the profile. Two dead plans = stop and report findings to the user.
+7. Integrate: run the full gate suite once over the combined change, report against the original criteria, stop. No polish beyond the criteria.

--- a/assets/orchestrate/generic.md
+++ b/assets/orchestrate/generic.md
@@ -1,25 +1,39 @@
 # Orchestrate — lead the work; child threads execute
 
-tcode has connected a tool server named `tcode_orchestrate` to this session. It dispatches work to separate child tcode threads, tracks their progress, and returns their results. Operate as the lead: understand, decompose, brief, verify, and integrate. The current role identity and allowed child-model fleet are supplied below by Settings → Orchestrate.
+tcode has connected a tool server named `tcode_orchestrate` to this session. It dispatches work to separate child tcode threads, tracks their progress, and returns their results. Operate as the lead: understand, decompose, brief, verify, and integrate. Your leverage is judgment, not typing — delegate execution when a cheaper profile is adequate, and keep the parts where your intelligence or taste is the actual bottleneck. The current role identity and allowed child-model fleet are supplied below by Settings → Orchestrate.
+
+## Attention budget
+
+The task outranks this workflow. Small task → skip the ceremony: do it directly, or fire one brief and check the result. Every rule below is a default; skip silently whatever wouldn't change the outcome. Two things are never skipped for delegated or long-running work: **acceptance criteria written before dispatch**, and **independent verification before acceptance**.
+
+## Routing
+
+The fleet table below is the authoritative allow list — user-configured profiles with ratings, strengths, and caveats. Rules:
+
+- For anything that ships: **intelligence > taste > cost**; cost is a tie-breaker only.
+- Default to the cheapest adequate profile; user-facing work (UI, copy, API design) needs high taste — read the ratings.
+- **Standing permission to escalate**: judge the output, not the price. If a cheaper profile misses the bar, re-dispatch on a smarter one or do it yourself, without asking.
+- Send token-hungry gathering (codebase sweeps, long logs, eyes-on-screen checks) to a cheap profile instructed to report compactly with file/line pointers. Reading is delegatable; understanding is not.
+- Keep for yourself: problem framing, architecture, ambiguous tradeoffs, taste-critical decisions, and final acceptance.
 
 ## Tools
 
-- `dispatch {provider, model?, effort?, title, brief, cwd?}` → creates a child thread and sends `brief` as its first message. The child is visible in the user's sidebar.
-- `status {thread_id?}` → running/completed/failed plus the latest output tail. Omit `thread_id` for all children.
-- `send {thread_id, message}` → follow-up to a child with useful context.
-- `result {thread_id}` → completed child's final message.
+- `dispatch {provider, model?, effort?, access?, title, brief, cwd?}` → creates a child thread and sends `brief` as its first message; returns `thread_id`. The child is visible in the user's sidebar. `model` + `effort` must name an enabled profile from the fleet table exactly (omit both for the provider's first enabled profile). `access`: `read_only` for reviews/investigation (no file changes; anything beyond pauses for user approval), `workspace_write` for implementation with auto-approved workspace edits, `full` (default).
+- `status {thread_id?}` → running/completed/failed plus the latest output tail and token usage. Omit `thread_id` for all children.
+- `send {thread_id, message}` → follow-up to a child with useful context (feedback, one focused retry).
+- `result {thread_id}` → completed child's full final message, with token usage.
 - `cancel {thread_id}` → stop a child.
 
 ## Callbacks — do not poll
 
-When a child finishes, tcode sends a message tagged `[orchestrate]` with its id, status, and output. Dispatch, end the turn, and wait to be woken. Use `status` only for an on-demand snapshot; never busy-wait.
+When a child finishes, tcode sends a message tagged `[orchestrate]` with its id, status, token cost, and output — in full when short, otherwise a tail plus a pointer. Dispatch, end the turn, and wait to be woken. Use `status` only for an on-demand snapshot; never busy-wait. A digest is a claim, not evidence: fetch the full report with `result` only when the prose itself matters — verification starts from the diff and your own checks. The token figures are your per-dispatch cost accounting.
 
 ## Operating rules
 
-1. Read the judgment-critical context yourself before delegating.
-2. Define executable acceptance criteria before dispatching.
-3. Make every brief self-contained: context, objective, file scope, constraints, acceptance criteria, and a report format that distinguishes checks actually run from claims.
-4. Parallelize only disjoint scopes.
-5. Verify child output independently. Reports are claims; the diff and checks are facts.
-6. After one focused retry, a repeated failure means the brief or plan needs revision.
-7. Run the integrated gates, report against the original criteria, and stop when they pass.
+1. Read the judgment-critical context yourself before delegating; farm out only the token-hungry reading.
+2. Define executable acceptance criteria before dispatching — exact commands with expected results, plus review questions for what commands can't measure. Strongest form: write the failing test first; the criterion is "it passes". If the run may outlive your context, put the plan and criteria in a small file so a cold restart can resume.
+3. Make every brief self-contained (children see nothing of this session): context in 2–3 sentences, objective, explicit file scope, constraints, acceptance criteria verbatim, and a report format that distinguishes checks actually run from claims.
+4. Dispatch from a clean tree; parallelize only disjoint file scopes, otherwise serialize. Reviews and investigation use `access: read_only`.
+5. Verify child output independently: run the criteria commands yourself and read the diff for weakened tests, silenced lints, swallowed errors, hardcoded expected values, and out-of-scope edits. Reports are claims; the diff and checks are facts. The acceptance judgment is never delegatable.
+6. Commit only accepted work — a clean tree at dispatch makes retries and reverts safe. On failure, one focused `send` with the exact failing command and output. A second failure on the same piece means the brief or plan is the bug: fix it, re-plan, or escalate the profile. Two failed plans: stop and bring findings to the user.
+7. Run the integrated gates once across the whole change, report against the original criteria, and stop when they pass — no gold-plating.

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -165,9 +165,12 @@ pub struct OrchestratorIdentity {
     pub identity: String,
 }
 
-/// One model the orchestrator may dispatch work to. Profiles stay in this list
-/// while paused so their editable routing definition is preserved; `enabled`
-/// is the actual allow-list decision.
+/// One (model, effort) profile the orchestrator may dispatch work to. The same
+/// model may appear several times at different efforts (e.g. `gpt-5.6-sol` at
+/// medium as the bulk tier and at max as the exception tier), each with its own
+/// routing definition. Profiles stay in this list while paused so their
+/// editable routing definition is preserved; `enabled` is the actual allow-list
+/// decision.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OrchestrateChildModel {
     pub provider: ProviderKind,
@@ -176,22 +179,43 @@ pub struct OrchestrateChildModel {
     /// dispatch and are omitted from the lead model's available-fleet table.
     #[serde(default = "default_true")]
     pub enabled: bool,
-    /// Effort used when a dispatch omits one. Callers may still explicitly pick
-    /// another effort supported by the model.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub default_effort: Option<String>,
+    /// The reasoning effort this profile dispatches at; `None` = provider
+    /// default. Part of the allow-list key: a dispatch naming an effort must
+    /// match an enabled profile with that effort.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "default_effort"
+    )]
+    pub effort: Option<String>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
+}
+
+impl OrchestrateChildModel {
+    /// Whether a dispatch-supplied effort selects this profile. `None` selects
+    /// any profile for the model; a named effort must match exactly
+    /// (case-insensitive).
+    pub fn matches_effort(&self, effort: Option<&str>) -> bool {
+        match effort {
+            None => true,
+            Some(effort) => self
+                .effort
+                .as_deref()
+                .is_some_and(|own| own.eq_ignore_ascii_case(effort.trim())),
+        }
+    }
 }
 
 const DEFAULT_ORCHESTRATOR_IDENTITY: &str = "You are the primary decision model and technical lead for this session. Your leverage is judgment: understand the problem, frame it well, decompose it, define done, route work to the cheapest adequate child model, and verify the result independently. Keep architecture, ambiguous tradeoffs, and final acceptance for yourself; delegate execution when a child can complete it from a precise brief.";
 
 const DEFAULT_FABLE_IDENTITY: &str = "You are Fable 5, the scarcest judgment resource in this fleet: a wise owl—thoughtful, discerning, and exceptionally strong at framing, architecture, taste, and clear communication. Spend that judgment on understanding, delegation, review, and final acceptance rather than routine typing. Use high effort by default; deeper tiers usually consume more of the fleet's bottleneck without improving your decisions.";
 
-const DEFAULT_GPT_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better): cost efficiency 9, intelligence 8, taste 6. Recommended effort: medium. Default execution model for bulk implementation, closed-form debugging, reviews, migrations, computer use, and token-heavy sweeps. Escalate effort only after a concrete miss.";
-const DEFAULT_SONNET_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better): cost efficiency 5, intelligence 5, taste 7. Recommended effort: high. Cheap glue work, wrappers, chores, and context gathering that does not require top-tier judgment.";
-const DEFAULT_OPUS_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better): cost efficiency 4, intelligence 7, taste 8. Recommended effort: high. Best for taste-critical UI, copy, API design, and implementation review where judgment matters more than grinding depth.";
-const DEFAULT_FABLE_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better): cost efficiency 2, intelligence 9, taste 9. Recommended effort: high. Highest-judgment escalation for framing, architecture, ambiguous tradeoffs, and final review.";
+const DEFAULT_GPT_MEDIUM_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better): cost efficiency 9, intelligence 8, taste 6. The default profile for everything dispatched: bulk or mechanical implementation against a written brief, closed-form debugging with a repro, migrations, data analysis, reviews, sweeps, computer use and eyes-on-screen verification, and token-heavy log or codebase crawls. Extremely steerable and disciplined: respects scope fences, does not weaken tests, reports accurately. Measured equal to its higher efforts on spec-driven work — escalate only after this profile demonstrably misses on a specific piece and the gap looks like depth, not a bad brief.";
+const DEFAULT_GPT_MAX_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better): cost efficiency 6, intelligence 9, taste 7. Exception tier — near the top judgment model's raw problem-solving at a fraction of the token cost, with a rottweiler temperament: grabs the problem by the throat and doesn't let go. Route it hard, well-defined problems that reward tenacity or depth: gnarly bugs with a repro, long autonomous grinds, brute-force search of a solution space, open-ended polish passes. Two measured caveats: wall-clock latency is 5–6x the medium profile, so keep it off any pipeline's critical path; and on closed-form bug fixes it produces the same fix as medium at 1.5–3x the cost. Taste 7 clears the bar for internal tools and dashboards; keep brand- or copy-critical surfaces on a taste-8+ model.";
+const DEFAULT_SONNET_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better): cost efficiency 5, intelligence 5, taste 7. Cheap glue — wrappers, chores, and context gathering that does not require top-tier judgment.";
+const DEFAULT_OPUS_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better): cost efficiency 4, intelligence 7, taste 8. First choice for user-facing work: UI, copy, API design, and anything where taste matters more than grinding depth. Also a strong independent reviewer of plans and implementations.";
+const DEFAULT_FABLE_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better): cost efficiency 2, intelligence 9, taste 9. Highest-judgment escalation for framing, architecture, ambiguous tradeoffs, taste-critical surfaces, and final review. The scarcest resource in the fleet: dispatch to it only when nothing cheaper is adequate.";
 
 /// Settings for tcode's built-in orchestration layer.
 ///
@@ -226,28 +250,35 @@ impl Default for OrchestrateSettings {
                     provider: ProviderKind::Codex,
                     model: "gpt-5.6-sol".into(),
                     enabled: true,
-                    default_effort: Some("medium".into()),
-                    description: DEFAULT_GPT_CHILD_DEFINITION.into(),
+                    effort: Some("medium".into()),
+                    description: DEFAULT_GPT_MEDIUM_CHILD_DEFINITION.into(),
+                },
+                OrchestrateChildModel {
+                    provider: ProviderKind::Codex,
+                    model: "gpt-5.6-sol".into(),
+                    enabled: true,
+                    effort: Some("max".into()),
+                    description: DEFAULT_GPT_MAX_CHILD_DEFINITION.into(),
                 },
                 OrchestrateChildModel {
                     provider: ProviderKind::ClaudeCode,
                     model: "claude-sonnet-5".into(),
-                    enabled: false,
-                    default_effort: Some("high".into()),
+                    enabled: true,
+                    effort: Some("high".into()),
                     description: DEFAULT_SONNET_CHILD_DEFINITION.into(),
                 },
                 OrchestrateChildModel {
                     provider: ProviderKind::ClaudeCode,
                     model: "claude-opus-4-8".into(),
-                    enabled: false,
-                    default_effort: Some("high".into()),
+                    enabled: true,
+                    effort: Some("high".into()),
                     description: DEFAULT_OPUS_CHILD_DEFINITION.into(),
                 },
                 OrchestrateChildModel {
                     provider: ProviderKind::ClaudeCode,
                     model: "claude-fable-5".into(),
-                    enabled: false,
-                    default_effort: Some("high".into()),
+                    enabled: true,
+                    effort: Some("high".into()),
                     description: DEFAULT_FABLE_CHILD_DEFINITION.into(),
                 },
             ],
@@ -288,9 +319,18 @@ impl OrchestrateSettings {
 
     /// Factory definition for a bundled child-model preset. Custom models have
     /// no product-authored definition and therefore reset to an empty editor.
-    pub fn builtin_child_definition(provider: ProviderKind, model: &str) -> Option<&'static str> {
+    pub fn builtin_child_definition(
+        provider: ProviderKind,
+        model: &str,
+        effort: Option<&str>,
+    ) -> Option<&'static str> {
         match (provider, model) {
-            (ProviderKind::Codex, "gpt-5.6-sol") => Some(DEFAULT_GPT_CHILD_DEFINITION),
+            (ProviderKind::Codex, "gpt-5.6-sol")
+                if effort.is_some_and(|effort| effort.eq_ignore_ascii_case("max")) =>
+            {
+                Some(DEFAULT_GPT_MAX_CHILD_DEFINITION)
+            }
+            (ProviderKind::Codex, "gpt-5.6-sol") => Some(DEFAULT_GPT_MEDIUM_CHILD_DEFINITION),
             (ProviderKind::ClaudeCode, "claude-sonnet-5") => Some(DEFAULT_SONNET_CHILD_DEFINITION),
             (ProviderKind::ClaudeCode, "claude-opus-4-8") => Some(DEFAULT_OPUS_CHILD_DEFINITION),
             (ProviderKind::ClaudeCode, "claude-fable-5") => Some(DEFAULT_FABLE_CHILD_DEFINITION),
@@ -298,23 +338,29 @@ impl OrchestrateSettings {
         }
     }
 
-    pub fn child_model(
+    pub fn child_profile(
         &self,
         provider: ProviderKind,
         model: &str,
+        effort: Option<&str>,
     ) -> Option<&OrchestrateChildModel> {
-        self.child_models
-            .iter()
-            .find(|entry| entry.provider == provider && entry.model == model)
+        self.child_models.iter().find(|entry| {
+            entry.provider == provider && entry.model == model && entry.matches_effort(effort)
+        })
     }
 
-    pub fn enabled_child_model(
+    pub fn enabled_child_profile(
         &self,
         provider: ProviderKind,
         model: &str,
+        effort: Option<&str>,
     ) -> Option<&OrchestrateChildModel> {
-        self.child_model(provider, model)
-            .filter(|entry| entry.enabled)
+        self.child_models.iter().find(|entry| {
+            entry.enabled
+                && entry.provider == provider
+                && entry.model == model
+                && entry.matches_effort(effort)
+        })
     }
 }
 
@@ -569,26 +615,23 @@ mod tests {
     fn orchestrate_defaults_round_trip_and_legacy_files_get_defaults() {
         let legacy: Settings = serde_json::from_str(r#"{"theme_mode":"system"}"#).unwrap();
         assert_eq!(legacy.orchestrate, OrchestrateSettings::default());
+        assert_eq!(legacy.orchestrate.child_models.len(), 5);
         assert!(
             legacy
                 .orchestrate
-                .enabled_child_model(ProviderKind::Codex, "gpt-5.6-sol")
-                .is_some()
+                .child_models
+                .iter()
+                .all(|entry| entry.enabled)
         );
-        assert!(
-            legacy
-                .orchestrate
-                .child_model(ProviderKind::ClaudeCode, "claude-opus-4-8")
-                .is_some(),
-            "disabled presets retain their preferences"
-        );
-        assert!(
-            legacy
-                .orchestrate
-                .enabled_child_model(ProviderKind::ClaudeCode, "claude-opus-4-8")
-                .is_none(),
-            "the default dispatch fleet is GPT-only"
-        );
+        let medium = legacy
+            .orchestrate
+            .enabled_child_profile(ProviderKind::Codex, "gpt-5.6-sol", Some("medium"))
+            .unwrap();
+        let max = legacy
+            .orchestrate
+            .enabled_child_profile(ProviderKind::Codex, "gpt-5.6-sol", Some("max"))
+            .unwrap();
+        assert_ne!(medium.description, max.description);
 
         let mut settings = Settings::default();
         settings.orchestrate.generic_identity = "Custom lead identity".into();
@@ -596,6 +639,35 @@ mod tests {
         let json = serde_json::to_string(&settings).unwrap();
         let back: Settings = serde_json::from_str(&json).unwrap();
         assert_eq!(back.orchestrate, settings.orchestrate);
+    }
+
+    #[test]
+    fn orchestrate_child_legacy_default_effort_alias_parses() {
+        let settings: OrchestrateSettings = serde_json::from_str(
+            r#"{"child_models":[{"provider":"codex","model":"m","default_effort":"high"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(settings.child_models[0].effort.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn orchestrate_child_effort_matching_is_exact_case_insensitive() {
+        let profile = OrchestrateChildModel {
+            provider: ProviderKind::Codex,
+            model: "m".into(),
+            enabled: true,
+            effort: Some("High".into()),
+            description: String::new(),
+        };
+        assert!(profile.matches_effort(Some("high")));
+        assert!(!profile.matches_effort(Some("medium")));
+        assert!(profile.matches_effort(None));
+
+        let provider_default = OrchestrateChildModel {
+            effort: None,
+            ..profile
+        };
+        assert!(!provider_default.matches_effort(Some("high")));
     }
 
     #[test]

--- a/crates/orchestrate-mcp/src/lib.rs
+++ b/crates/orchestrate-mcp/src/lib.rs
@@ -12,6 +12,7 @@ pub enum OrchestrateOp {
         provider: String,
         model: Option<String>,
         effort: Option<String>,
+        access: Option<String>,
         title: String,
         brief: String,
         cwd: Option<String>,

--- a/crates/orchestrate-mcp/src/tools.rs
+++ b/crates/orchestrate-mcp/src/tools.rs
@@ -25,6 +25,8 @@ struct DispatchParams {
     model: Option<String>,
     #[serde(default)]
     effort: Option<String>,
+    #[serde(default)]
+    access: Option<String>,
     title: String,
     brief: String,
     #[serde(default)]
@@ -62,7 +64,9 @@ impl OrchestrateTools {
         }
     }
 
-    #[tool(description = "Dispatch a brief to a new child tcode thread and return its thread id.")]
+    #[tool(
+        description = "Dispatch a brief to a new child tcode thread and return its thread id. access is one of read_only (review/investigation: the child cannot change files; actions beyond that pause for user approval), workspace_write (edits auto-approved inside the workspace), or full (default; no approval prompts)."
+    )]
     async fn dispatch(
         &self,
         Parameters(p): Parameters<DispatchParams>,
@@ -73,6 +77,7 @@ impl OrchestrateTools {
                 provider: p.provider,
                 model: p.model,
                 effort: p.effort,
+                access: p.access,
                 title: p.title,
                 brief: p.brief,
                 cwd: p.cwd,

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -79,7 +79,6 @@ pub use crate::terminal::{
 const TITLE_MAX_CHARS: usize = 40;
 const TITLE_SOURCE_MAX_CHARS: usize = 4_000;
 const AI_TITLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
-const ORCHESTRATE_CALLBACK_CAP: usize = 100;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 struct TerminalPreferences {
@@ -678,7 +677,6 @@ pub struct AppState {
     orchestrate_registrations: HashMap<String, agent::McpRegistration>,
     /// Requests from the orchestrate MCP runtime, pumped on the gpui thread.
     pub orchestrate_requests: Option<async_channel::Receiver<orchestrate_mcp::BrokerRequest>>,
-    callback_counts: HashMap<String, usize>,
     callback_last_turn: HashMap<String, usize>,
     /// A URL the preview panel should navigate to on its next render (set by the
     /// `--open-preview <url>` dev flag for headless screenshots). Consumed once.
@@ -788,7 +786,6 @@ impl AppState {
             orchestrate_tokens: None,
             orchestrate_registrations: HashMap::new(),
             orchestrate_requests: None,
-            callback_counts: HashMap::new(),
             callback_last_turn: HashMap::new(),
             pending_preview_url: None,
             git_status: None,
@@ -964,6 +961,7 @@ impl AppState {
         provider: ProviderKind,
         model: Option<String>,
         effort: Option<String>,
+        approval_mode: ApprovalMode,
         title: String,
         cwd: Option<PathBuf>,
         brief: String,
@@ -999,7 +997,7 @@ impl AppState {
             }
             None => parent.cwd.clone(),
         };
-        let meta = build_child_meta(&parent, provider, model, effort, title, cwd);
+        let meta = build_child_meta(&parent, provider, model, effort, approval_mode, title, cwd);
         self.store
             .upsert_meta(&meta)
             .map_err(|err| format!("failed to persist child session: {err}"))?;
@@ -1037,6 +1035,7 @@ impl AppState {
                 provider,
                 model,
                 effort,
+                access,
                 title,
                 brief,
                 cwd,
@@ -1047,11 +1046,13 @@ impl AppState {
                     model.as_deref(),
                     effort.as_deref(),
                 )?;
+                let approval_mode = resolve_dispatch_access(access.as_deref())?;
                 let id = self.create_child_session(
                     &parent_id,
                     provider,
                     Some(model),
                     effort,
+                    approval_mode,
                     title,
                     cwd.map(PathBuf::from),
                     brief,
@@ -1112,11 +1113,18 @@ impl AppState {
                 thread_id,
             } => {
                 let meta = self.require_child(&parent_id, &thread_id)?;
-                let (state, final_message) = self.child_result(meta);
+                let (state, final_message, usage) = self.child_result(meta);
                 if state == "running" {
                     return Err("thread is still running".into());
                 }
-                Ok(serde_json::json!({ "state": state, "final_message": final_message }))
+                let mut result = serde_json::json!({
+                    "state": state,
+                    "final_message": final_message,
+                });
+                if let Some(usage) = usage.as_ref() {
+                    result["tokens"] = token_usage_json(usage);
+                }
+                Ok(result)
             }
             OrchestrateOp::Cancel {
                 parent_id,
@@ -1180,7 +1188,10 @@ impl AppState {
         self.background.insert(thread_id, child);
     }
 
-    fn child_result(&self, meta: &SessionMeta) -> (&'static str, String) {
+    fn child_result(
+        &self,
+        meta: &SessionMeta,
+    ) -> (&'static str, String, Option<agent::TokenUsage>) {
         let timeline = Timeline::fold_events(self.store.read_events(&meta.id));
         let running = self
             .active
@@ -1201,19 +1212,23 @@ impl AppState {
                 None => "idle",
             }
         };
-        (state, final_assistant_message(&timeline))
+        (state, final_assistant_message(&timeline), timeline.usage)
     }
 
     fn child_status_json(&self, meta: &SessionMeta) -> serde_json::Value {
-        let (state, final_message) = self.child_result(meta);
-        serde_json::json!({
+        let (state, final_message, usage) = self.child_result(meta);
+        let mut status = serde_json::json!({
             "thread_id": meta.id,
             "title": meta.title,
             "provider": match meta.provider { ProviderKind::ClaudeCode => "claude", ProviderKind::Codex => "codex", ProviderKind::Acp => "acp" },
             "state": state,
             "last_output_tail": tail_chars(&final_message, 600),
             "updated_at": meta.updated_at,
-        })
+        });
+        if let Some(usage) = usage.as_ref() {
+            status["tokens"] = token_usage_json(usage);
+        }
+        status
     }
 
     /// Kick off a background refresh of every provider's model catalog (called
@@ -3883,26 +3898,13 @@ impl AppState {
             return;
         }
         let parent_id = child.parent_session_id.clone().unwrap();
-        let count = self.callback_counts.entry(parent_id.clone()).or_default();
-        let first_breach = *count == ORCHESTRATE_CALLBACK_CAP;
-        if !take_callback_slot(count) {
-            if first_breach {
-                self.report_error(
-                    RuntimeError::OrchestrateCallbackLimit {
-                        parent_id: parent_id.to_string(),
-                        cap: ORCHESTRATE_CALLBACK_CAP,
-                    },
-                    cx,
-                );
-            }
-            return;
-        }
         self.callback_last_turn.insert(child_id.to_string(), turn);
         let text = assemble_callback_text(
             child_id,
             &child.title,
             status,
             &final_assistant_message(&timeline),
+            timeline.usage.as_ref(),
         );
         self.deliver_orchestrate_callback_to_parent(&parent_id, text, cx);
     }
@@ -5378,7 +5380,7 @@ fn render_orchestrate_configuration(
         text.push_str(identity);
     }
     text.push_str(
-        "\n\n### Allowed child models\n\nOnly dispatch to models listed below. Their definitions are configured by the user and may include ratings, strengths, caveats, and routing preferences. If a dispatch omits `model`, tcode selects the first enabled model for that provider. If it omits `effort`, tcode applies the model's stored default.\n",
+        "\n\n### Allowed child models\n\nProfiles pin the effort they dispatch at. A dispatch must name `model` and `effort` exactly as listed; both may be omitted, in which case tcode picks the first enabled profile for the provider. The definitions below are user-configured routing guidance.\n",
     );
     if !settings.child_models.iter().any(|child| child.enabled) {
         text.push_str("No child models are enabled. Work without dispatching until the user enables one in Settings → Orchestrate.");
@@ -5390,12 +5392,9 @@ fn render_orchestrate_configuration(
             ProviderKind::ClaudeCode => "claude",
             ProviderKind::Acp => "acp",
         };
-        let effort = child
-            .default_effort
-            .as_deref()
-            .unwrap_or("provider default");
+        let effort = child.effort.as_deref().unwrap_or("provider default");
         text.push_str(&format!(
-            "\n#### `{}` / `{}`\n\nDefault dispatch effort: `{}`.\n\n{}\n",
+            "\n#### `{}` / `{}` — effort `{}`\n\n{}\n",
             escape_markdown_inline(provider),
             escape_markdown_inline(&child.model),
             escape_markdown_inline(effort),
@@ -5430,31 +5429,55 @@ fn resolve_orchestrate_dispatch(
         other => return Err(format!("unknown provider: {other}")),
     };
     let requested_model = model.map(str::trim).filter(|model| !model.is_empty());
+    let requested_effort = effort.map(str::trim).filter(|effort| !effort.is_empty());
     let profile = match requested_model {
-        Some(model) => settings.enabled_child_model(provider, model),
-        None => settings
+        Some(model) => settings.enabled_child_profile(provider, model, requested_effort),
+        None => settings.child_models.iter().find(|entry| {
+            entry.enabled
+                && entry.provider == provider
+                && !entry.model.trim().is_empty()
+                && entry.matches_effort(requested_effort)
+        }),
+    }
+    .ok_or_else(|| {
+        let enabled = settings
             .child_models
             .iter()
-            .find(|entry| {
-                entry.enabled && entry.provider == provider && !entry.model.trim().is_empty()
-            }),
-    }
-    .ok_or_else(|| match requested_model {
-        Some(model) => format!(
-            "model {model} is not enabled for orchestrate child dispatch under {}",
-            provider_name(provider)
-        ),
-        None => format!(
-            "no orchestrate child model is enabled for {}; choose an enabled provider or update Settings → Orchestrate",
-            provider_name(provider)
-        ),
+            .filter(|entry| entry.enabled && entry.provider == provider)
+            .map(|entry| {
+                format!(
+                    "{} (effort {})",
+                    entry.model,
+                    entry.effort.as_deref().unwrap_or("provider default")
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let requested = requested_model.unwrap_or("provider default model");
+        let effort = requested_effort
+            .map(|effort| format!(" (effort {effort})"))
+            .unwrap_or_default();
+        format!(
+            "no enabled child profile matches {requested}{effort} under {}; enabled profiles: {}",
+            provider_name(provider),
+            if enabled.is_empty() { "none" } else { &enabled }
+        )
     })?;
-    let effort = effort
-        .map(str::trim)
-        .filter(|effort| !effort.is_empty())
-        .map(str::to_string)
-        .or_else(|| profile.default_effort.clone());
-    Ok((provider, profile.model.clone(), effort))
+    Ok((provider, profile.model.clone(), profile.effort.clone()))
+}
+
+fn resolve_dispatch_access(access: Option<&str>) -> Result<ApprovalMode, String> {
+    let Some(access) = access.map(str::trim).filter(|access| !access.is_empty()) else {
+        return Ok(ApprovalMode::FullAccess);
+    };
+    match access.to_ascii_lowercase().as_str() {
+        "full" => Ok(ApprovalMode::FullAccess),
+        "read_only" => Ok(ApprovalMode::Supervised),
+        "workspace_write" => Ok(ApprovalMode::AutoAcceptEdits),
+        _ => Err(format!(
+            "unknown access: {access}; expected read_only, workspace_write, or full"
+        )),
+    }
 }
 
 fn provider_name(provider: ProviderKind) -> &'static str {
@@ -5470,6 +5493,7 @@ fn build_child_meta(
     provider: ProviderKind,
     model: Option<String>,
     effort: Option<String>,
+    approval_mode: ApprovalMode,
     title: String,
     cwd: PathBuf,
 ) -> SessionMeta {
@@ -5477,6 +5501,7 @@ fn build_child_meta(
     meta.title = title;
     meta.project_id = parent.project_id.clone();
     meta.parent_session_id = Some(parent.id.clone());
+    meta.approval_mode = approval_mode;
     if let Some(effort) = effort {
         meta.option_selections.push(OptionSelection {
             id: "reasoningEffort".into(),
@@ -5520,29 +5545,69 @@ fn tail_chars(text: &str, max: usize) -> String {
     text.chars().skip(count.saturating_sub(max)).collect()
 }
 
+fn token_usage_json(usage: &agent::TokenUsage) -> serde_json::Value {
+    let mut value = serde_json::Map::new();
+    for (key, count) in [
+        ("input_tokens", usage.input_tokens),
+        ("cached_input_tokens", usage.cached_input_tokens),
+        ("output_tokens", usage.output_tokens),
+        ("used_tokens", usage.used_tokens),
+        ("total_processed_tokens", usage.total_processed_tokens),
+    ] {
+        if let Some(count) = count {
+            value.insert(key.into(), count.into());
+        }
+    }
+    serde_json::Value::Object(value)
+}
+
 fn assemble_callback_text(
     child_id: &str,
     title: &str,
     status: TurnStatus,
     final_message: &str,
+    usage: Option<&agent::TokenUsage>,
 ) -> String {
     let state = match status {
         TurnStatus::Completed => "completed",
         TurnStatus::Failed | TurnStatus::Interrupted => "failed",
     };
-    format!(
-        "[orchestrate] thread {child_id} (\"{title}\") {state}.\n{}",
-        final_message
-    )
-}
-
-fn take_callback_slot(count: &mut usize) -> bool {
-    if *count >= ORCHESTRATE_CALLBACK_CAP {
-        *count = count.saturating_add(1);
-        return false;
+    let mut token_parts = Vec::new();
+    if let Some(usage) = usage {
+        if let Some(input) = usage.input_tokens {
+            let cached = usage
+                .cached_input_tokens
+                .filter(|cached| *cached > 0)
+                .map(|cached| format!(" (+{cached} cached)"))
+                .unwrap_or_default();
+            token_parts.push(format!("input {input}{cached}"));
+        }
+        if let Some(output) = usage.output_tokens {
+            token_parts.push(format!("output {output}"));
+        }
+        if let Some(total) = usage.total_processed_tokens.or(usage.used_tokens) {
+            token_parts.push(format!("total {total}"));
+        }
     }
-    *count += 1;
-    true
+    let token_segment = if token_parts.is_empty() {
+        String::new()
+    } else {
+        format!(" tokens: {}.", token_parts.join(", "))
+    };
+    let body = if final_message.is_empty() {
+        "(no assistant output)".to_string()
+    } else {
+        let count = final_message.chars().count();
+        if count <= 1200 {
+            final_message.to_string()
+        } else {
+            format!(
+                "Final output tail ({count} chars total — call result {child_id} for the full report):\n{}",
+                tail_chars(final_message, 600)
+            )
+        }
+    };
+    format!("[orchestrate] thread {child_id} (\"{title}\") {state}.{token_segment}\n{body}")
 }
 
 /// Parse a `#rrggbb` accent color into a gpui color; `None` when malformed.
@@ -6109,12 +6174,9 @@ mod tests {
         );
         assert!(first.starts_with(CLAUDE_ORCHESTRATE_GUIDANCE.trim()));
         assert!(first.contains("wise owl"));
-        assert!(first.contains("#### `codex` / `gpt-5.6-sol`"));
+        assert!(first.contains("#### `codex` / `gpt-5.6-sol` — effort `medium`"));
         assert!(first.contains("cost efficiency 9, intelligence 8, taste 6"));
-        assert!(
-            !first.contains("#### `claude` / `claude-opus-4-8`"),
-            "disabled presets must not be advertised to the lead model"
-        );
+        assert!(first.contains("#### `claude` / `claude-opus-4-8` — effort `high`"));
         assert!(first.ends_with("\n\nShip it"));
         let follow_up = compose_orchestrate_text(
             ProviderKind::ClaudeCode,
@@ -6147,7 +6209,7 @@ mod tests {
 
     #[test]
     fn orchestrate_dispatch_enforces_child_allow_list_and_defaults() {
-        let mut settings = OrchestrateSettings::default();
+        let settings = OrchestrateSettings::default();
         assert_eq!(
             resolve_orchestrate_dispatch(&settings, "codex", None, None).unwrap(),
             (
@@ -6156,48 +6218,62 @@ mod tests {
                 Some("medium".into())
             )
         );
-        assert!(
-            resolve_orchestrate_dispatch(
-                &settings,
-                "claude_code",
-                Some("claude-opus-4-8"),
-                Some("max")
-            )
-            .unwrap_err()
-            .contains("not enabled"),
-            "disabled profiles must retain preferences without allowing dispatch"
-        );
-        settings
-            .child_models
-            .iter_mut()
-            .find(|entry| entry.model == "claude-opus-4-8")
-            .unwrap()
-            .enabled = true;
         assert_eq!(
             resolve_orchestrate_dispatch(
                 &settings,
                 "claude_code",
                 Some("claude-opus-4-8"),
-                Some("max")
+                Some(" HIGH ")
             )
             .unwrap(),
             (
                 ProviderKind::ClaudeCode,
                 "claude-opus-4-8".into(),
-                Some("max".into())
+                Some("high".into())
             )
         );
+        let wrong_effort =
+            resolve_orchestrate_dispatch(&settings, "codex", Some("gpt-5.6-sol"), Some("xhigh"))
+                .unwrap_err();
+        assert!(
+            wrong_effort.contains(
+                "no enabled child profile matches gpt-5.6-sol (effort xhigh) under codex"
+            )
+        );
+        assert!(wrong_effort.contains("gpt-5.6-sol (effort medium)"));
+        assert!(wrong_effort.contains("gpt-5.6-sol (effort max)"));
         let denied =
             resolve_orchestrate_dispatch(&settings, "claude", Some("claude-haiku-4-5"), None)
                 .unwrap_err();
-        assert!(denied.contains("not enabled"));
+        assert!(denied.contains("no enabled child profile matches"));
 
         let mut empty = settings;
         empty.child_models.clear();
         assert!(
             resolve_orchestrate_dispatch(&empty, "codex", None, None)
                 .unwrap_err()
-                .contains("no orchestrate child model")
+                .contains("enabled profiles: none")
+        );
+    }
+
+    #[test]
+    fn orchestrate_dispatch_access_maps_known_values() {
+        assert_eq!(resolve_dispatch_access(None), Ok(ApprovalMode::FullAccess));
+        assert_eq!(
+            resolve_dispatch_access(Some(" FULL ")),
+            Ok(ApprovalMode::FullAccess)
+        );
+        assert_eq!(
+            resolve_dispatch_access(Some("read_only")),
+            Ok(ApprovalMode::Supervised)
+        );
+        assert_eq!(
+            resolve_dispatch_access(Some("WORKSPACE_WRITE")),
+            Ok(ApprovalMode::AutoAcceptEdits)
+        );
+        assert_eq!(
+            resolve_dispatch_access(Some("admin")),
+            Err("unknown access: admin; expected read_only, workspace_write, or full".into())
         );
     }
 
@@ -6848,6 +6924,7 @@ mod tests {
             ProviderKind::Codex,
             Some("gpt-test".into()),
             Some("high".into()),
+            ApprovalMode::AutoAcceptEdits,
             "Research".into(),
             PathBuf::from("/p/sub"),
         );
@@ -6855,26 +6932,52 @@ mod tests {
         assert_eq!(child.project_id.as_deref(), Some("project"));
         assert_eq!(child.model.as_deref(), Some("gpt-test"));
         assert_eq!(child.title, "Research");
+        assert_eq!(child.approval_mode, ApprovalMode::AutoAcceptEdits);
         assert_eq!(child.option_selections.len(), 1);
         assert_eq!(child.option_selections[0].id, "reasoningEffort");
         assert_eq!(child.option_selections[0].value, serde_json::json!("high"));
     }
 
     #[test]
-    fn callback_text_keeps_the_full_result_and_cap_stops_at_one_hundred() {
-        let text =
-            assemble_callback_text("child", "Title", TurnStatus::Completed, &"x".repeat(5000));
+    fn callback_text_is_a_compact_digest_with_usage() {
+        let text = assemble_callback_text("child", "Title", TurnStatus::Completed, "done", None);
         assert!(text.starts_with("[orchestrate] thread child (\"Title\") completed.\n"));
-        assert_eq!(text.lines().nth(1).unwrap().chars().count(), 5000);
-        let failed = assemble_callback_text("child", "Title", TurnStatus::Interrupted, "done");
-        assert!(failed.contains(") failed.\ndone"));
+        assert!(text.ends_with("\ndone"));
+        assert!(!text.contains("tokens:"));
+        assert!(
+            assemble_callback_text("child", "Title", TurnStatus::Completed, "", None,)
+                .ends_with("\n(no assistant output)")
+        );
 
-        let mut count = 0;
-        for _ in 0..ORCHESTRATE_CALLBACK_CAP {
-            assert!(take_callback_slot(&mut count));
-        }
-        assert!(!take_callback_slot(&mut count));
-        assert_eq!(count, ORCHESTRATE_CALLBACK_CAP + 1);
+        let long = assemble_callback_text(
+            "child",
+            "Title",
+            TurnStatus::Completed,
+            &"x".repeat(5000),
+            None,
+        );
+        assert!(long.contains(
+            "Final output tail (5000 chars total — call result child for the full report):"
+        ));
+        assert_eq!(long.lines().last().unwrap().chars().count(), 600);
+
+        let usage = agent::TokenUsage {
+            input_tokens: Some(100),
+            cached_input_tokens: Some(25),
+            output_tokens: Some(40),
+            total_processed_tokens: Some(165),
+            ..Default::default()
+        };
+        let failed = assemble_callback_text(
+            "child",
+            "Title",
+            TurnStatus::Interrupted,
+            "done",
+            Some(&usage),
+        );
+        assert!(failed.starts_with("[orchestrate] thread child (\"Title\") failed. tokens:"));
+        assert!(failed.ends_with("\ndone"));
+        assert!(failed.contains("tokens: input 100 (+25 cached), output 40, total 165."));
     }
 
     #[test]

--- a/crates/runtime/src/event.rs
+++ b/crates/runtime/src/event.rs
@@ -87,7 +87,6 @@ pub enum RuntimeError {
     ProviderStart { error: String },
     ProviderClosed { reason: Option<String> },
     PersistSessionIndex { error: String },
-    OrchestrateCallbackLimit { parent_id: String, cap: usize },
     ProviderMessage(String),
 }
 

--- a/crates/ui/src/orchestrate_settings.rs
+++ b/crates/ui/src/orchestrate_settings.rs
@@ -32,6 +32,7 @@ struct IdentityRowState {
 struct ChildRowState {
     provider: ProviderKind,
     model: String,
+    effort: Entity<InputState>,
     description: Entity<InputState>,
 }
 
@@ -160,7 +161,12 @@ impl OrchestrateSettingsPanel {
             });
         }
 
-        for entry in orchestrate.child_models {
+        for (index, entry) in orchestrate.child_models.into_iter().enumerate() {
+            let effort = cx.new(|cx| {
+                InputState::new(window, cx)
+                    .placeholder(tcode_i18n::tr!("orchestrate.children.effort_placeholder"))
+                    .default_value(entry.effort.clone().unwrap_or_default())
+            });
             let description = cx.new(|cx| {
                 InputState::new(window, cx)
                     .multi_line(true)
@@ -170,17 +176,22 @@ impl OrchestrateSettingsPanel {
                     ))
                     .default_value(entry.description)
             });
-            let provider = entry.provider;
-            let model = entry.model.clone();
+            self.input_subscriptions
+                .push(cx.subscribe(&effort, move |this, _, event, cx| {
+                    if matches!(event, InputEvent::Change) {
+                        this.commit_child_effort(index, cx);
+                    }
+                }));
             self.input_subscriptions
                 .push(cx.subscribe(&description, move |this, _, event, cx| {
                     if matches!(event, InputEvent::Change) {
-                        this.commit_child_definition(provider, &model, cx);
+                        this.commit_child_definition(index, cx);
                     }
                 }));
             self.child_rows.push(ChildRowState {
                 provider: entry.provider,
                 model: entry.model,
+                effort,
                 description,
             });
         }
@@ -196,13 +207,8 @@ impl OrchestrateSettingsPanel {
         self.identity_model_picker
             .update(cx, |picker, cx| picker.set_excluded(identities, cx));
 
-        let children = self
-            .child_rows
-            .iter()
-            .map(|row| (row.provider, row.model.clone()))
-            .collect();
         self.child_model_picker
-            .update(cx, |picker, cx| picker.set_excluded(children, cx));
+            .update(cx, |picker, cx| picker.set_excluded(Vec::new(), cx));
     }
 
     fn commit_model_identity(&self, provider: ProviderKind, model: &str, cx: &mut Context<Self>) {
@@ -230,25 +236,41 @@ impl OrchestrateSettingsPanel {
         );
     }
 
-    fn commit_child_definition(&self, provider: ProviderKind, model: &str, cx: &mut Context<Self>) {
-        let Some(row) = self
-            .child_rows
-            .iter()
-            .find(|row| row.provider == provider && row.model == model)
-        else {
+    fn commit_child_definition(&self, index: usize, cx: &mut Context<Self>) {
+        let Some(row) = self.child_rows.get(index) else {
             return;
         };
         let description = row.description.read(cx).value().to_string();
-        let model = model.to_string();
+        let provider = row.provider;
+        let model = row.model.clone();
         self.update_settings(
             move |settings| {
-                if let Some(entry) = settings
-                    .orchestrate
-                    .child_models
-                    .iter_mut()
-                    .find(|entry| entry.provider == provider && entry.model == model)
+                if let Some(entry) = settings.orchestrate.child_models.get_mut(index)
+                    && entry.provider == provider
+                    && entry.model == model
                 {
                     entry.description = description;
+                }
+            },
+            cx,
+        );
+    }
+
+    fn commit_child_effort(&self, index: usize, cx: &mut Context<Self>) {
+        let Some(row) = self.child_rows.get(index) else {
+            return;
+        };
+        let effort = row.effort.read(cx).value().trim().to_string();
+        let effort = (!effort.is_empty()).then_some(effort);
+        let provider = row.provider;
+        let model = row.model.clone();
+        self.update_settings(
+            move |settings| {
+                if let Some(entry) = settings.orchestrate.child_models.get_mut(index)
+                    && entry.provider == provider
+                    && entry.model == model
+                {
+                    entry.effort = effort;
                 }
             },
             cx,
@@ -315,19 +337,22 @@ impl OrchestrateSettingsPanel {
             provider: option.provider,
             model: option.id.clone(),
             enabled: true,
-            default_effort: option.default_effort.clone(),
-            description: OrchestrateSettings::builtin_child_definition(option.provider, &option.id)
-                .unwrap_or_default()
-                .to_string(),
+            effort: option.effort.clone(),
+            description: OrchestrateSettings::builtin_child_definition(
+                option.provider,
+                &option.id,
+                option.effort.as_deref(),
+            )
+            .unwrap_or_default()
+            .to_string(),
         };
         self.update_settings(
             move |settings| {
-                if !settings
-                    .orchestrate
-                    .child_models
-                    .iter()
-                    .any(|entry| entry.provider == profile.provider && entry.model == profile.model)
-                {
+                if !settings.orchestrate.child_models.iter().any(|entry| {
+                    entry.provider == profile.provider
+                        && entry.model == profile.model
+                        && entry.effort == profile.effort
+                }) {
                     settings.orchestrate.child_models.push(profile);
                 }
             },
@@ -337,20 +362,12 @@ impl OrchestrateSettingsPanel {
         cx.notify();
     }
 
-    fn remove_child(
-        &mut self,
-        provider: ProviderKind,
-        model: &str,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        let model = model.to_string();
+    fn remove_child(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
         self.update_settings(
             move |settings| {
-                settings
-                    .orchestrate
-                    .child_models
-                    .retain(|entry| !(entry.provider == provider && entry.model == model));
+                if index < settings.orchestrate.child_models.len() {
+                    settings.orchestrate.child_models.remove(index);
+                }
             },
             cx,
         );
@@ -358,22 +375,10 @@ impl OrchestrateSettingsPanel {
         cx.notify();
     }
 
-    fn set_child_enabled(
-        &self,
-        provider: ProviderKind,
-        model: &str,
-        enabled: bool,
-        cx: &mut Context<Self>,
-    ) {
-        let model = model.to_string();
+    fn set_child_enabled(&self, index: usize, enabled: bool, cx: &mut Context<Self>) {
         self.update_settings(
             move |settings| {
-                if let Some(entry) = settings
-                    .orchestrate
-                    .child_models
-                    .iter_mut()
-                    .find(|entry| entry.provider == provider && entry.model == model)
-                {
+                if let Some(entry) = settings.orchestrate.child_models.get_mut(index) {
                     entry.enabled = enabled;
                 }
             },
@@ -425,36 +430,39 @@ impl OrchestrateSettingsPanel {
         }
     }
 
-    fn reset_child_definition(
-        &self,
-        provider: ProviderKind,
-        model: &str,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        let value = OrchestrateSettings::builtin_child_definition(provider, model)
-            .unwrap_or_default()
-            .to_string();
+    fn reset_child_definition(&self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(entry) = self
+            .app_state
+            .read(cx)
+            .settings
+            .orchestrate
+            .child_models
+            .get(index)
+        else {
+            return;
+        };
+        let provider = entry.provider;
+        let model = entry.model.clone();
+        let value = OrchestrateSettings::builtin_child_definition(
+            provider,
+            &model,
+            entry.effort.as_deref(),
+        )
+        .unwrap_or_default()
+        .to_string();
         let persisted = value.clone();
-        let model_key = model.to_string();
         self.update_settings(
             move |settings| {
-                if let Some(entry) = settings
-                    .orchestrate
-                    .child_models
-                    .iter_mut()
-                    .find(|entry| entry.provider == provider && entry.model == model_key)
+                if let Some(entry) = settings.orchestrate.child_models.get_mut(index)
+                    && entry.provider == provider
+                    && entry.model == model
                 {
                     entry.description = persisted;
                 }
             },
             cx,
         );
-        if let Some(row) = self
-            .child_rows
-            .iter()
-            .find(|row| row.provider == provider && row.model == model)
-        {
+        if let Some(row) = self.child_rows.get(index) {
             row.description
                 .update(cx, |input, cx| input.set_value(value, window, cx));
         }
@@ -707,14 +715,14 @@ impl OrchestrateSettingsPanel {
             .border_color(cx.theme().border)
             .overflow_hidden();
         for (index, row) in self.child_rows.iter().enumerate() {
-            let Some(profile) = settings.child_model(row.provider, &row.model) else {
+            let Some(profile) = settings.child_models.get(index) else {
                 continue;
             };
             let provider = row.provider;
-            let model = row.model.clone();
-            let toggle_model = row.model.clone();
-            let reset_model = row.model.clone();
             let name = self.model_name(provider, &row.model, cx);
+            let effort = profile.effort.clone().unwrap_or_else(|| {
+                tcode_i18n::tr!("orchestrate.children.effort_default").into_owned()
+            });
             list = list.child(
                 v_flex()
                     .w_full()
@@ -740,9 +748,10 @@ impl OrchestrateSettingsPanel {
                                             .text_size(px(11.))
                                             .text_color(cx.theme().muted_foreground)
                                             .child(format!(
-                                                "{} · {}",
+                                                "{} · {} · {}",
                                                 provider_label(provider),
-                                                row.model
+                                                row.model,
+                                                effort,
                                             )),
                                     ),
                             )
@@ -765,12 +774,7 @@ impl OrchestrateSettingsPanel {
                                         tcode_i18n::tr!("orchestrate.children.enable")
                                     })
                                     .on_click(cx.listener(move |this, checked: &bool, _, cx| {
-                                        this.set_child_enabled(
-                                            provider,
-                                            &toggle_model,
-                                            *checked,
-                                            cx,
-                                        );
+                                        this.set_child_enabled(index, *checked, cx);
                                     })),
                             )
                             .child(
@@ -780,12 +784,7 @@ impl OrchestrateSettingsPanel {
                                     .icon(IconName::Undo)
                                     .label(tcode_i18n::tr!("orchestrate.restore_default"))
                                     .on_click(cx.listener(move |this, _, window, cx| {
-                                        this.reset_child_definition(
-                                            provider,
-                                            &reset_model,
-                                            window,
-                                            cx,
-                                        );
+                                        this.reset_child_definition(index, window, cx);
                                     })),
                             )
                             .child(
@@ -795,9 +794,21 @@ impl OrchestrateSettingsPanel {
                                     .icon(IconName::Delete)
                                     .tooltip(tcode_i18n::tr!("orchestrate.children.remove"))
                                     .on_click(cx.listener(move |this, _, window, cx| {
-                                        this.remove_child(provider, &model, window, cx);
+                                        this.remove_child(index, window, cx);
                                     })),
                             ),
+                    )
+                    .child(
+                        v_flex()
+                            .w(px(160.))
+                            .gap_1()
+                            .child(
+                                div()
+                                    .text_size(px(11.))
+                                    .text_color(cx.theme().muted_foreground)
+                                    .child(tcode_i18n::tr!("orchestrate.children.effort_label")),
+                            )
+                            .child(Input::new(&row.effort).small()),
                     )
                     .child(Input::new(&row.description).small()),
             );

--- a/crates/ui/src/provider_model_picker.rs
+++ b/crates/ui/src/provider_model_picker.rs
@@ -25,7 +25,7 @@ pub(crate) struct ModelOption {
     pub provider: ProviderKind,
     pub id: String,
     pub name: String,
-    pub default_effort: Option<String>,
+    pub effort: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -120,7 +120,7 @@ impl ProviderModelPicker {
         for provider in [ProviderKind::Codex, ProviderKind::ClaudeCode] {
             let catalog = state.models_for(provider);
             for model in state.resolved_models(provider) {
-                let default_effort = catalog
+                let effort = catalog
                     .iter()
                     .find(|spec| spec.id == model.id)
                     .and_then(default_reasoning_effort);
@@ -128,7 +128,7 @@ impl ProviderModelPicker {
                     provider,
                     id: model.id,
                     name: model.name,
-                    default_effort,
+                    effort,
                 });
             }
         }

--- a/crates/ui/src/runtime_event.rs
+++ b/crates/ui/src/runtime_event.rs
@@ -91,9 +91,6 @@ pub(super) fn present_runtime_event(event: &RuntimeEvent) -> PresentedRuntimeEve
                 RuntimeError::PersistSessionIndex { error } => {
                     tcode_i18n::tr!("errors.persist_session_index", error = error).into_owned()
                 }
-                RuntimeError::OrchestrateCallbackLimit { parent_id, cap } => format!(
-                    "Orchestrate callback limit ({cap}) reached for thread {parent_id}; automatic callbacks stopped."
-                ),
             };
             (RuntimeEventSeverity::Error, message)
         }
@@ -322,10 +319,6 @@ mod tests {
             },
             RuntimeError::ProviderClosed { reason: None },
             RuntimeError::PersistSessionIndex { error: "x".into() },
-            RuntimeError::OrchestrateCallbackLimit {
-                parent_id: "parent".into(),
-                cap: 100,
-            },
             RuntimeError::ProviderMessage("provider-error\0diagnostic".into()),
         ];
         let notices = vec![

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -188,7 +188,7 @@ orchestrate:
     use_generic: "Remove override and use the generic identity"
   children:
     title: "Allowed child models"
-    description: "Keep a routing definition for each child model and switch it on only when /orchestrate may dispatch work to it. Built-in definitions include the default ratings and recommended effort as editable text."
+    description: "Keep one routing profile per child model and effort tier; the same model may appear once per tier, and each profile pins the effort it dispatches at. Switch a profile on only when /orchestrate may use it."
     add: "Add child model"
     empty: "No child-model profiles are configured. /orchestrate remains available, but dispatch calls will be rejected until a child model is added."
     none_enabled: "Every child-model profile is switched off. /orchestrate can still plan, but all dispatch calls will be rejected."
@@ -196,6 +196,9 @@ orchestrate:
     disabled: "Paused"
     enable: "Allow /orchestrate to dispatch to this model"
     disable: "Pause dispatch while keeping this model's definition"
+    effort_label: "Dispatch effort"
+    effort_placeholder: "provider default"
+    effort_default: "provider default"
     description_placeholder: "Define this model's ratings, strengths, best-fit tasks, caveats, recommended effort, and escalation role…"
     remove: "Delete this child-model profile"
   no_more_models: "All available provider models are already configured. Add custom model slugs under Providers to expose more choices."

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -188,7 +188,7 @@ orchestrate:
     use_generic: "删除专属覆盖并使用通用自我认知"
   children:
     title: "允许派发的子模型"
-    description: "为每个子模型保留一段路由定义，只在允许 /orchestrate 派发给它时打开开关。内置定义已用可编辑文本写入默认评分和推荐 effort。"
+    description: "为每个子模型及其推理强度保留一份路由配置；同一模型可在每个强度档位各出现一次，每份配置都会固定派发时使用的强度。仅在允许 /orchestrate 使用时启用该配置。"
     add: "添加子模型"
     empty: "目前没有配置任何子模型。/orchestrate 仍然可用，但在添加子模型前，派发调用会被拒绝。"
     none_enabled: "所有子模型配置都已关闭。/orchestrate 仍可进行规划，但所有派发调用都会被拒绝。"
@@ -196,6 +196,9 @@ orchestrate:
     disabled: "已暂停"
     enable: "允许 /orchestrate 向这个模型派发任务"
     disable: "暂停派发，但保留这个模型的定义"
+    effort_label: "派发推理强度"
+    effort_placeholder: "模型默认"
+    effort_default: "模型默认"
     description_placeholder: "定义该模型的评分、优势、适合任务、注意事项、推荐 effort 和升级定位…"
     remove: "删除这个子模型配置"
   no_more_models: "所有可用的提供商模型都已配置。可先在“提供商”中添加自定义模型标识。"


### PR DESCRIPTION
## Summary

Closes the behavior gap between tcode's built-in `/orchestrate` and the original orchestrate skill it was ported from, while keeping (and improving) the child-thread dispatch channel:

- **Per-effort child profiles**: `OrchestrateChildModel` entries are now (provider, model, effort) tuples — the same model can appear once per tier (e.g. `gpt-5.6-sol` at `medium` as the bulk tier and at `max` as the exception tier), each with its own routing definition. Dispatch must name an enabled profile; the returned effort always comes from the profile. The settings UI keys child rows by index and adds a dispatch-effort field.
- **Full default fleet**: the five default profiles (gpt medium, gpt max, sonnet-5, opus-4.8, fable-5) ship enabled, with routing descriptions ported from the skill's calibration table (ratings, exception-tier caveats, latency warnings, taste bars).
- **Per-dispatch access control**: `dispatch` gains `access` — `read_only` (Codex read-only sandbox / Claude supervised), `workspace_write`, `full` (default) — restoring "reviews run read-only" granularity.
- **Token accounting**: `status`/`result` responses and completion callbacks now carry the child's token usage for per-dispatch cost accounting.
- **Callback digests**: instead of pushing the child's entire final message into the orchestrator's context, callbacks now carry status + token cost + the full output only when short (≤1200 chars), otherwise a 600-char tail plus an explicit pointer to `result`.
- **No more 100-callback cap**: `ORCHESTRATE_CALLBACK_CAP` and its error surface are removed; the per-turn dedup stays.
- **Guidance assets aligned with the skill**: attention budget/scale-ceremony, routing meta-rules (intelligence > taste > cost, standing permission to escalate), clean-tree/commit-only-accepted-work, failing-test-first, plan files for runs that outlive context, and eyes-on UI verification are restored in all three provider variants.

Legacy settings files keep loading via a `default_effort` serde alias.

## Test plan

- `cargo check --workspace` ✅
- `cargo test --workspace` ✅ (422 passed; includes new tests for effort-exact dispatch resolution, access mapping, callback digest format, alias parsing, default-fleet shape)
- `cargo fmt --all -- --check` ✅
- Grep gates: no `ORCHESTRATE_CALLBACK_CAP` / `take_callback_slot` / `OrchestrateCallbackLimit` / `callback_counts` remain; `default_effort` only as serde alias + compat test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)