### PR TITLE
Steer orchestrate send into a child's live turn

### DIFF
--- a/assets/orchestrate/codex.md
+++ b/assets/orchestrate/codex.md
@@ -20,7 +20,7 @@ The fleet table below is the authoritative allow list — user-configured profil
 
 - `dispatch {provider, model?, effort?, access?, title, brief, cwd?}` → new child thread, `brief` is its first message, returns `thread_id`. Visible in the user's sidebar. `model` + `effort` must name an enabled profile from the fleet table exactly (omit both → the provider's first enabled profile). `access`: `read_only` for reviews/investigation (no file changes; anything beyond pauses for user approval), `workspace_write` for implementation with auto-approved workspace edits, `full` (default).
 - `status {thread_id?}` → running/completed/failed + output tail + token usage. No `thread_id` = all children.
-- `send {thread_id, message}` → follow-up to a child that still has useful context (fix instructions, one focused retry).
+- `send {thread_id, message}` → follow-up to a child that still has useful context (fix instructions, mid-course corrections, one focused retry). Injected into the child's live turn when one is running, otherwise sent as its next turn — the response says which.
 - `result {thread_id}` → full final message of a completed child, with token usage.
 - `cancel {thread_id}` → stop a child.
 

--- a/assets/orchestrate/fable.md
+++ b/assets/orchestrate/fable.md
@@ -20,7 +20,7 @@ The fleet table below is the authoritative allow list — user-configured profil
 
 - `dispatch {provider, model?, effort?, access?, title, brief, cwd?}` → creates a child thread, sends `brief` as its first message, returns `thread_id`. The child appears in the user's sidebar; they can watch it live. `model` + `effort` must name an enabled profile exactly as listed in the fleet table (omit both to get the provider's first enabled profile). `access` gates what the child may do: `read_only` for reviews and investigation (the child cannot change files; anything beyond that pauses for user approval), `workspace_write` for implementation with edits auto-approved inside the workspace, `full` (default) for no prompts.
 - `status {thread_id?}` → running/completed/failed, an output tail, and token usage. Omit `thread_id` for all your children.
-- `send {thread_id, message}` → follow-up message to a child (feedback, one focused retry). Prefer this over dispatching a fresh child when the child's context is useful.
+- `send {thread_id, message}` → follow-up message to a child (feedback, a mid-course correction, one focused retry). Steered into the child's live turn immediately when one is running, otherwise sent as its next turn — the response says which. Prefer this over dispatching a fresh child when the child's context is useful.
 - `result {thread_id}` → the completed child's full final message plus token usage.
 - `cancel {thread_id}` → stop a child.
 

--- a/assets/orchestrate/generic.md
+++ b/assets/orchestrate/generic.md
@@ -20,7 +20,7 @@ The fleet table below is the authoritative allow list — user-configured profil
 
 - `dispatch {provider, model?, effort?, access?, title, brief, cwd?}` → creates a child thread and sends `brief` as its first message; returns `thread_id`. The child is visible in the user's sidebar. `model` + `effort` must name an enabled profile from the fleet table exactly (omit both for the provider's first enabled profile). `access`: `read_only` for reviews/investigation (no file changes; anything beyond pauses for user approval), `workspace_write` for implementation with auto-approved workspace edits, `full` (default).
 - `status {thread_id?}` → running/completed/failed plus the latest output tail and token usage. Omit `thread_id` for all children.
-- `send {thread_id, message}` → follow-up to a child with useful context (feedback, one focused retry).
+- `send {thread_id, message}` → follow-up to a child with useful context (feedback, mid-course corrections, one focused retry). Delivered into the child's live turn when one is running, otherwise sent as its next turn — the response says which.
 - `result {thread_id}` → completed child's full final message, with token usage.
 - `cancel {thread_id}` → stop a child.
 

--- a/crates/orchestrate-mcp/src/tools.rs
+++ b/crates/orchestrate-mcp/src/tools.rs
@@ -98,7 +98,9 @@ impl OrchestrateTools {
             .await)
     }
 
-    #[tool(description = "Send a follow-up message to one of this session's child threads.")]
+    #[tool(
+        description = "Send a follow-up message to one of this session's child threads. If the child has a turn in flight the message is steered into it immediately; otherwise it is queued and sent as the child's next turn. The response reports which (delivery: steered | queued)."
+    )]
     async fn send(
         &self,
         Parameters(p): Parameters<SendParams>,

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -1084,6 +1084,35 @@ impl AppState {
                 message,
             } => {
                 self.require_child(&parent_id, &thread_id)?;
+                // A live turn accepts the message right away — same routing as
+                // parent callbacks. Queueing a mid-turn correction until the
+                // turn ends would deliver it after the work it was meant to
+                // redirect (and never, if the turn hangs).
+                let can_steer = self
+                    .active
+                    .as_ref()
+                    .filter(|child| child.meta.id == thread_id)
+                    .or_else(|| self.background.get(&thread_id))
+                    .is_some_and(|child| child.turn_in_flight && child.supports_steering());
+                if can_steer {
+                    let request_id = self.record_steer_request(&thread_id, &message, cx);
+                    let sent = self
+                        .active
+                        .as_mut()
+                        .filter(|child| child.meta.id == thread_id)
+                        .or_else(|| self.background.get_mut(&thread_id))
+                        .is_some_and(|child| {
+                            child
+                                .steer_now(request_id, message.clone(), Vec::new())
+                                .is_ok()
+                        });
+                    if sent {
+                        cx.notify();
+                        return Ok(serde_json::json!({ "ok": true, "delivery": "steered" }));
+                    }
+                    // Provider channel gone: fall through so the text survives
+                    // in the queue for the wake-up path.
+                }
                 if self.active_session_id() == Some(&thread_id) {
                     let child = self.active.as_mut().unwrap();
                     child.push_queued(message, Vec::new());
@@ -1094,7 +1123,7 @@ impl AppState {
                     if idle {
                         self.ensure_started(cx);
                     }
-                    return Ok(serde_json::json!({ "ok": true }));
+                    return Ok(serde_json::json!({ "ok": true, "delivery": "queued" }));
                 }
                 self.ensure_child_loaded(&thread_id)?;
                 let child = self.background.get_mut(&thread_id).unwrap();
@@ -1106,7 +1135,7 @@ impl AppState {
                 if idle {
                     self.ensure_session_started(&thread_id, cx);
                 }
-                Ok(serde_json::json!({ "ok": true }))
+                Ok(serde_json::json!({ "ok": true, "delivery": "queued" }))
             }
             OrchestrateOp::Result {
                 parent_id,


### PR DESCRIPTION
## Summary

`send` used to `push_queued` unconditionally. With a turn in flight, the follow-up sat in the child's queue until the turn completed — a mid-course correction arrived after the work it was meant to redirect (and never, if the turn hung with no `TurnCompleted`). Parent-bound callbacks already steer into an in-flight turn; this gives `send` the same routing:

- Child turn in flight + provider supports steering → `record_steer_request` + `steer_now` (message lands in the running turn immediately, recorded in the JSONL like a user steer).
- Otherwise → existing queue + wake paths, unchanged.
- Tool response now reports `delivery: steered | queued`, and the `send` tool description plus all three guidance assets document the semantics.

## Test plan

- `cargo check --workspace` ✅
- `cargo test -p tcode-runtime -p orchestrate-mcp` ✅
- `cargo fmt --all -- --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)