### PR TITLE
Route preview MCP calls to their owning conversation

### DIFF
--- a/crates/preview-mcp/src/lib.rs
+++ b/crates/preview-mcp/src/lib.rs
@@ -16,6 +16,7 @@
 //!
 //! [Model Context Protocol]: https://modelcontextprotocol.io
 
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 pub mod js;
@@ -61,6 +62,7 @@ pub enum PreviewReply {
 /// `Err` = human-readable failure (surfaced to the agent as a tool error).
 #[derive(Debug)]
 pub struct BrokerRequest {
+    pub session_id: String,
     pub op: PreviewOp,
     pub reply: async_channel::Sender<Result<PreviewReply, String>>,
 }
@@ -76,10 +78,14 @@ pub struct Broker {
 
 impl Broker {
     /// Send `op` to the UI and await its reply (or a timeout / disconnect error).
-    pub async fn invoke(&self, op: PreviewOp) -> Result<PreviewReply, String> {
+    pub async fn invoke(&self, session_id: &str, op: PreviewOp) -> Result<PreviewReply, String> {
         let (tx, rx) = async_channel::bounded(1);
         self.requests
-            .send(BrokerRequest { op, reply: tx })
+            .send(BrokerRequest {
+                session_id: session_id.to_string(),
+                op,
+                reply: tx,
+            })
             .await
             .map_err(|_| "preview UI is not available".to_string())?;
         match tokio::time::timeout(self.timeout, rx.recv()).await {
@@ -90,13 +96,51 @@ impl Broker {
     }
 }
 
-/// A running preview MCP server: the URL + bearer token to register with agents,
-/// and the receiver the UI pumps to service automation requests.
+#[derive(Clone)]
+pub struct TokenRegistry {
+    inner: Arc<RwLock<tools::Services>>,
+    broker: Broker,
+}
+
+impl TokenRegistry {
+    /// Mint a distinct bearer token whose tool calls are permanently scoped to
+    /// `session_id`.
+    pub fn register(&self, session_id: &str) -> String {
+        let token = format!(
+            "{}{}",
+            uuid::Uuid::new_v4().simple(),
+            uuid::Uuid::new_v4().simple()
+        );
+        let entry = tools::service(self.broker.clone(), session_id.to_string());
+        self.inner.write().unwrap().insert(token.clone(), entry);
+        token
+    }
+
+    pub fn revoke(&self, token: &str) {
+        self.inner.write().unwrap().remove(token);
+    }
+
+    #[cfg(test)]
+    async fn invoke_registered(&self, token: &str, op: PreviewOp) -> Result<PreviewReply, String> {
+        let session_id = self
+            .inner
+            .read()
+            .unwrap()
+            .get(token)
+            .map(|entry| entry.session_id.clone())
+            .ok_or_else(|| "unauthorized".to_string())?;
+        self.broker.invoke(&session_id, op).await
+    }
+}
+
+/// A running preview MCP server: the URL + per-session bearer-token issuer to
+/// register with agents, and the receiver the UI pumps to service automation
+/// requests.
 pub struct PreviewMcpServer {
     /// Streamable-HTTP endpoint, e.g. `http://127.0.0.1:53211/mcp`.
     pub url: String,
-    /// Bearer token every request must present.
-    pub bearer_token: String,
+    /// Per-session bearer-token registry.
+    pub tokens: TokenRegistry,
     /// Automation requests to resolve against the live WebView. The UI consumes
     /// this (single consumer); dropping it makes [`Broker::invoke`] fail fast.
     pub requests: async_channel::Receiver<BrokerRequest>,
@@ -104,24 +148,22 @@ pub struct PreviewMcpServer {
 
 /// Bind a random loopback port and start the streamable-HTTP MCP server on a
 /// dedicated tokio runtime thread. Returns immediately with the bound URL and
-/// token; the server keeps running for the process lifetime.
+/// token issuer; the server keeps running for the process lifetime.
 pub fn start() -> std::io::Result<PreviewMcpServer> {
     // Bind synchronously so the caller learns the port before we return.
     let listener = std::net::TcpListener::bind(("127.0.0.1", 0))?;
     let port = listener.local_addr()?.port();
     let url = format!("http://127.0.0.1:{port}/mcp");
-    let bearer_token = format!(
-        "{}{}",
-        uuid::Uuid::new_v4().simple(),
-        uuid::Uuid::new_v4().simple()
-    );
-
     let (req_tx, req_rx) = async_channel::unbounded::<BrokerRequest>();
     let broker = Broker {
         requests: req_tx,
         timeout: Duration::from_secs(30),
     };
-    let token = bearer_token.clone();
+    let services = Arc::new(RwLock::new(tools::Services::new()));
+    let tokens = TokenRegistry {
+        inner: services.clone(),
+        broker,
+    };
 
     std::thread::Builder::new()
         .name("preview-mcp".into())
@@ -137,7 +179,7 @@ pub fn start() -> std::io::Result<PreviewMcpServer> {
                 }
             };
             rt.block_on(async move {
-                if let Err(err) = tools::serve(listener, broker, token).await {
+                if let Err(err) = tools::serve(listener, services).await {
                     log::error!("preview-mcp: server exited with error: {err}");
                 }
             });
@@ -146,7 +188,67 @@ pub fn start() -> std::io::Result<PreviewMcpServer> {
     log::info!("preview-mcp: serving at {url}");
     Ok(PreviewMcpServer {
         url,
-        bearer_token,
+        tokens,
         requests: req_rx,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry() -> (TokenRegistry, async_channel::Receiver<BrokerRequest>) {
+        let (requests, receiver) = async_channel::unbounded();
+        let broker = Broker {
+            requests,
+            timeout: Duration::from_secs(2),
+        };
+        let registry = TokenRegistry {
+            inner: Arc::new(RwLock::new(tools::Services::new())),
+            broker,
+        };
+        (registry, receiver)
+    }
+
+    #[tokio::test]
+    async fn registered_tokens_route_calls_to_their_owning_sessions() {
+        let (registry, requests) = registry();
+        let token_a = registry.register("session-a");
+        let token_b = registry.register("session-b");
+        let resolver = tokio::spawn(async move {
+            for expected in ["session-a", "session-b"] {
+                let request = requests.recv().await.unwrap();
+                assert_eq!(request.session_id, expected);
+                assert_eq!(request.op, PreviewOp::Status);
+                request
+                    .reply
+                    .send(Ok(PreviewReply::Json(serde_json::json!({ "ok": true }))))
+                    .await
+                    .unwrap();
+            }
+        });
+
+        registry
+            .invoke_registered(&token_a, PreviewOp::Status)
+            .await
+            .unwrap();
+        registry
+            .invoke_registered(&token_b, PreviewOp::Status)
+            .await
+            .unwrap();
+        resolver.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn revoked_token_can_no_longer_invoke_tools() {
+        let (registry, _requests) = registry();
+        let token = registry.register("session-a");
+        registry.revoke(&token);
+
+        let error = registry
+            .invoke_registered(&token, PreviewOp::Status)
+            .await
+            .unwrap_err();
+        assert_eq!(error, "unauthorized");
+    }
 }

--- a/crates/preview-mcp/src/tools.rs
+++ b/crates/preview-mcp/src/tools.rs
@@ -2,7 +2,8 @@
 //! with bearer-token auth. Each tool turns its arguments into a [`PreviewOp`],
 //! runs it through the [`Broker`], and maps the reply into an MCP result.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 use axum::Router;
 use axum::extract::State;
@@ -63,14 +64,16 @@ pub struct TypeParams {
 #[derive(Clone)]
 pub struct PreviewTools {
     broker: Broker,
+    session_id: String,
     tool_router: ToolRouter<Self>,
 }
 
 #[tool_router]
 impl PreviewTools {
-    pub fn new(broker: Broker) -> Self {
+    pub fn new(broker: Broker, session_id: String) -> Self {
         Self {
             broker,
+            session_id,
             tool_router: Self::tool_router(),
         }
     }
@@ -158,7 +161,7 @@ impl PreviewTools {
     /// Route one op through the broker and map its reply into a tool result.
     async fn run(&self, op: PreviewOp) -> CallToolResult {
         log::info!("preview-mcp: tool invoked: {op:?}");
-        match self.broker.invoke(op).await {
+        match self.broker.invoke(&self.session_id, op).await {
             Ok(PreviewReply::Json(value)) => {
                 let text =
                     serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
@@ -188,30 +191,42 @@ impl ServerHandler for PreviewTools {
     }
 }
 
-/// Shared axum state: the MCP service plus the expected bearer token.
-#[derive(Clone)]
-struct HttpState {
-    service: StreamableHttpService<PreviewTools>,
-    token: Arc<String>,
+pub type Service = StreamableHttpService<PreviewTools>;
+
+pub struct ServiceEntry {
+    pub session_id: String,
+    service: Service,
 }
 
-/// Serve the streamable-HTTP MCP endpoint at `/mcp` on `listener`, rejecting any
-/// request whose `Authorization` header isn't `Bearer <token>`.
-pub async fn serve(
-    listener: std::net::TcpListener,
-    broker: Broker,
-    token: String,
-) -> std::io::Result<()> {
+pub type Services = HashMap<String, ServiceEntry>;
+
+pub fn service(broker: Broker, session_id: String) -> ServiceEntry {
+    let service_session_id = session_id.clone();
     let service = StreamableHttpService::new(
-        move || Ok(PreviewTools::new(broker.clone())),
+        move || {
+            Ok(PreviewTools::new(
+                broker.clone(),
+                service_session_id.clone(),
+            ))
+        },
         Arc::new(LocalSessionManager::default()),
         StreamableHttpServerConfig::default(),
     );
-    let state = HttpState {
+    ServiceEntry {
+        session_id,
         service,
-        token: Arc::new(token),
-    };
-    let app = Router::new().route("/mcp", any(handle)).with_state(state);
+    }
+}
+
+/// Serve the streamable-HTTP MCP endpoint at `/mcp` on `listener`, resolving
+/// each bearer token to its per-session service.
+pub async fn serve(
+    listener: std::net::TcpListener,
+    services: Arc<RwLock<Services>>,
+) -> std::io::Result<()> {
+    let app = Router::new()
+        .route("/mcp", any(handle))
+        .with_state(services);
 
     listener.set_nonblocking(true)?;
     let listener = tokio::net::TcpListener::from_std(listener)?;
@@ -219,44 +234,35 @@ pub async fn serve(
 }
 
 /// Bearer-gate every request, then hand it to the rmcp streamable-HTTP service.
-async fn handle(State(state): State<HttpState>, req: axum::extract::Request) -> Response {
-    if !authorized(&req, &state.token) {
-        return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
-    }
-    let response = state.service.handle(req).await;
-    let (parts, body) = response.into_parts();
-    Response::from_parts(parts, axum::body::Body::new(body))
-}
-
-/// Constant-ish bearer check: `Authorization: Bearer <token>`.
-fn authorized<B>(req: &axum::http::Request<B>, token: &str) -> bool {
-    req.headers()
+async fn handle(
+    State(services): State<Arc<RwLock<Services>>>,
+    req: axum::extract::Request,
+) -> Response {
+    let token = req
+        .headers()
         .get(AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.strip_prefix("Bearer "))
-        .map(|presented| presented == token)
-        .unwrap_or(false)
+        .and_then(|value| value.strip_prefix("Bearer "));
+    let service = token.and_then(|token| {
+        services.read().unwrap().get(token).map(|entry| {
+            log::debug!(
+                "preview-mcp: authorized request for session {}",
+                entry.session_id
+            );
+            entry.service.clone()
+        })
+    });
+    let Some(service) = service else {
+        return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+    };
+    let response = service.handle(req).await;
+    let (parts, body) = response.into_parts();
+    Response::from_parts(parts, axum::body::Body::new(body))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn bearer_auth_accepts_matching_and_rejects_others() {
-        let build = |header: Option<&str>| {
-            let mut req = axum::http::Request::builder().uri("/mcp");
-            if let Some(h) = header {
-                req = req.header(AUTHORIZATION, h);
-            }
-            req.body(()).unwrap()
-        };
-        let token = "sekret";
-        assert!(authorized(&build(Some("Bearer sekret")), token));
-        assert!(!authorized(&build(Some("Bearer nope")), token));
-        assert!(!authorized(&build(Some("sekret")), token));
-        assert!(!authorized(&build(None), token));
-    }
 
     #[tokio::test]
     async fn broker_roundtrip_with_fake_resolver() {
@@ -268,6 +274,7 @@ mod tests {
         };
         let resolver = tokio::spawn(async move {
             while let Ok(request) = rx.recv().await {
+                assert_eq!(request.session_id, "session-a");
                 let reply = match &request.op {
                     PreviewOp::Status => {
                         PreviewReply::Json(serde_json::json!({ "url": "https://x/" }))
@@ -282,7 +289,7 @@ mod tests {
             }
         });
 
-        let tools = PreviewTools::new(broker);
+        let tools = PreviewTools::new(broker, "session-a".into());
         let status = tools.run(PreviewOp::Status).await;
         assert_eq!(status.is_error, Some(false));
         let shot = tools.run(PreviewOp::Screenshot).await;
@@ -299,7 +306,7 @@ mod tests {
             requests: tx,
             timeout: std::time::Duration::from_millis(200),
         };
-        let tools = PreviewTools::new(broker);
+        let tools = PreviewTools::new(broker, "session-a".into());
         let result = tools.run(PreviewOp::Status).await;
         assert_eq!(result.is_error, Some(true));
     }
@@ -311,7 +318,7 @@ mod tests {
             requests: tx,
             timeout: std::time::Duration::from_secs(1),
         };
-        let tools = PreviewTools::new(broker);
+        let tools = PreviewTools::new(broker, "session-a".into());
         let names: Vec<String> = tools
             .tool_router
             .list_all()

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -157,6 +157,15 @@ impl RightPanelState {
         active.diff_selected_turn = self.selected_turn;
         active.right_tab = self.tab;
     }
+
+    fn open_preview(&mut self) -> bool {
+        if self.open && self.tab == RightTab::Preview {
+            return false;
+        }
+        self.open = true;
+        self.tab = RightTab::Preview;
+        true
+    }
 }
 
 /// UI resources that belong to a conversation but outlive the currently
@@ -665,9 +674,10 @@ pub struct AppState {
     pub acp_registry_error: Option<String>,
     /// Registry ids currently downloading (their marketplace row shows a spinner).
     pub acp_installing: std::collections::HashSet<String>,
-    /// Preview MCP server registration, injected into every session so the agent
-    /// can drive the embedded browser. `None` if the server failed to start.
-    pub mcp_registration: Option<agent::McpRegistration>,
+    /// App-wide preview endpoint and its per-session bearer-token issuer.
+    preview_url: Option<String>,
+    preview_tokens: Option<preview_mcp::TokenRegistry>,
+    preview_registrations: HashMap<String, agent::McpRegistration>,
     /// Automation-request receiver from the preview MCP server. `AppShell` takes
     /// this once to pump requests into the live `PreviewPanel` WebView.
     pub preview_requests: Option<async_channel::Receiver<preview_mcp::BrokerRequest>>,
@@ -780,7 +790,9 @@ impl AppState {
             acp_registry_loading: false,
             acp_registry_error: None,
             acp_installing: std::collections::HashSet::new(),
-            mcp_registration: None,
+            preview_url: None,
+            preview_tokens: None,
+            preview_registrations: HashMap::new(),
             preview_requests: None,
             orchestrate_url: None,
             orchestrate_tokens: None,
@@ -822,14 +834,11 @@ impl AppState {
         self.pending_preview_url.take()
     }
 
-    /// Attach the running preview MCP server: its registration (injected into
-    /// every spawned session) and the request receiver (taken by `AppShell`).
+    /// Attach the running preview MCP server: its per-session token issuer and
+    /// the request receiver (taken by `AppShell`).
     pub fn attach_preview_mcp(&mut self, server: preview_mcp::PreviewMcpServer) {
-        self.mcp_registration = Some(agent::McpRegistration {
-            name: agent::McpRegistration::SERVER_NAME_PREVIEW.into(),
-            url: server.url,
-            bearer_token: server.bearer_token,
-        });
+        self.preview_url = Some(server.url);
+        self.preview_tokens = Some(server.tokens);
         self.preview_requests = Some(server.requests);
     }
 
@@ -950,6 +959,21 @@ impl AppState {
             bearer_token: token,
         };
         self.orchestrate_registrations
+            .insert(meta.id.clone(), registration.clone());
+        Some(registration)
+    }
+
+    fn preview_registration_for(&mut self, meta: &SessionMeta) -> Option<agent::McpRegistration> {
+        if let Some(registration) = self.preview_registrations.get(&meta.id) {
+            return Some(registration.clone());
+        }
+        let token = self.preview_tokens.as_ref()?.register(&meta.id);
+        let registration = agent::McpRegistration {
+            name: agent::McpRegistration::SERVER_NAME_PREVIEW.into(),
+            url: self.preview_url.clone()?,
+            bearer_token: token,
+        };
+        self.preview_registrations
             .insert(meta.id.clone(), registration.clone());
         Some(registration)
     }
@@ -4581,11 +4605,41 @@ impl AppState {
     /// Open the right panel on the Preview tab (used when the agent drives the
     /// preview so the webview surfaces without a manual toggle).
     pub fn open_preview_panel(&mut self, cx: &mut Context<Self>) {
-        if let Some(active) = self.active.as_mut()
-            && !(active.diff_open && active.right_tab == RightTab::Preview)
-        {
-            active.diff_open = true;
-            active.right_tab = RightTab::Preview;
+        if let Some(active) = self.active.as_mut() {
+            let mut panel = RightPanelState::capture(active);
+            if panel.open_preview() {
+                panel.restore_into(active);
+                cx.notify();
+            }
+        }
+    }
+
+    /// Open Preview in the owning conversation's right-panel state without
+    /// changing which conversation the user is viewing.
+    pub fn open_preview_panel_for(&mut self, session_id: &str, cx: &mut Context<Self>) {
+        if self.active_session_id() == Some(session_id) {
+            self.open_preview_panel(cx);
+            return;
+        }
+
+        let mut changed = false;
+        let destination = ConversationDestination::Thread(session_id.to_string());
+        let mut parked_ui = None;
+        if let Some(background) = self.background.get_mut(session_id) {
+            let mut panel = RightPanelState::capture(background);
+            changed |= panel.open_preview();
+            panel.restore_into(background);
+            if !self.conversation_ui.contains_key(&destination) {
+                parked_ui = Some(ConversationUiState::take_from(background));
+            }
+        }
+        if let Some(ui) = parked_ui {
+            self.conversation_ui.insert(destination.clone(), ui);
+        }
+        if let Some(ui) = self.conversation_ui.get_mut(&destination) {
+            changed |= ui.right_panel.open_preview();
+        }
+        if changed {
             cx.notify();
         }
     }
@@ -4782,7 +4836,7 @@ impl AppState {
         let meta = active.meta.clone();
         let settings = self.settings.clone();
         let launch_env = self.session_launch_env(&meta);
-        let mcp_registration = self.mcp_registration.clone();
+        let preview_registration = self.preview_registration_for(&meta);
         let orchestrate_registration = self.orchestrate_registration_for(&meta);
         let session_id = meta.id.clone();
         if let Some(cursor) = &meta.resume_cursor {
@@ -4800,7 +4854,7 @@ impl AppState {
                 &meta,
                 &settings,
                 launch_env,
-                mcp_registration,
+                preview_registration,
                 orchestrate_registration,
             );
             let result = start_session(meta.provider, opts).await;
@@ -5354,9 +5408,19 @@ impl AppState {
             .collect();
         for child_id in child_ids {
             self.drop_background(&child_id);
+            self.revoke_preview_registration(&child_id);
         }
+        self.revoke_preview_registration(parent_id);
         if let Some(registration) = self.orchestrate_registrations.remove(parent_id)
             && let Some(tokens) = &self.orchestrate_tokens
+        {
+            tokens.revoke(&registration.bearer_token);
+        }
+    }
+
+    fn revoke_preview_registration(&mut self, session_id: &str) {
+        if let Some(registration) = self.preview_registrations.remove(session_id)
+            && let Some(tokens) = &self.preview_tokens
         {
             tokens.revoke(&registration.bearer_token);
         }
@@ -6372,6 +6436,45 @@ mod tests {
             assert!(second.diff_open);
             assert_eq!(second.right_tab, RightTab::Plan);
             assert_eq!(second.terminal_workspace.height, 402.);
+        });
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[gpui::test]
+    fn preview_open_for_background_thread_does_not_switch_the_active_thread(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let root = std::env::temp_dir().join(format!(
+            "tcode-background-preview-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let store = SessionStore::open_at(root.clone()).unwrap();
+        let first = SessionMeta::new(ProviderKind::Codex, PathBuf::from("/tmp/a"), None);
+        let second = SessionMeta::new(ProviderKind::Codex, PathBuf::from("/tmp/b"), None);
+        store.upsert_meta(&first).unwrap();
+        store.upsert_meta(&second).unwrap();
+        let first_id = first.id.clone();
+        let second_id = second.id.clone();
+        let state = cx.new(|_| AppState::new(store));
+
+        state.update(cx, |state, cx| {
+            state.select_session(&first_id, cx);
+            let first = state.active.as_mut().unwrap();
+            first.turn_in_flight = true;
+            first.runtime = Runtime::Starting { generation: 1 };
+            state.select_session(&second_id, cx);
+            assert!(state.background.contains_key(&first_id));
+            state.open_preview_panel_for(&first_id, cx);
+
+            assert_eq!(state.active_session_id(), Some(second_id.as_str()));
+            assert!(!state.preview_panel_showing());
+            let background = state.background.get(&first_id).unwrap();
+            assert!(background.diff_open);
+            assert_eq!(background.right_tab, RightTab::Preview);
+
+            state.select_session(&first_id, cx);
+            assert!(state.preview_panel_showing());
         });
 
         let _ = std::fs::remove_dir_all(root);

--- a/crates/ui/src/preview_panel.rs
+++ b/crates/ui/src/preview_panel.rs
@@ -46,6 +46,21 @@ fn visible_preview_key(
         .flatten()
 }
 
+/// Resolve an MCP request's physical session id to the stable WebView key.
+/// Only the active surface can be an unsent project draft; every background
+/// request therefore keys directly by its stored session id.
+fn preview_key_for_session(
+    requested_session_id: &str,
+    active_session_id: Option<&str>,
+    active_key: Option<&str>,
+) -> String {
+    if active_session_id == Some(requested_session_id) {
+        active_key.unwrap_or(requested_session_id).to_string()
+    } else {
+        requested_session_id.to_string()
+    }
+}
+
 /// The reply channel a broker request is answered on.
 type ReplyTx = async_channel::Sender<Result<PreviewReply, String>>;
 
@@ -75,7 +90,9 @@ mod native {
     use preview_mcp::{PreviewOp, PreviewReply, js, ports};
     use raw_window_handle::HasWindowHandle as _;
 
-    use super::{ReplyTx, normalize_url, unavailable_message, visible_preview_key};
+    use super::{
+        ReplyTx, normalize_url, preview_key_for_session, unavailable_message, visible_preview_key,
+    };
     use tcode_runtime::app::AppState;
 
     pub struct PreviewPanel {
@@ -182,6 +199,20 @@ mod native {
             current.map(|(_, key)| key)
         }
 
+        fn routed_key(&mut self, session_id: &str, cx: &Context<Self>) -> String {
+            let active_key = self.active_key(cx);
+            let active_session_id = self
+                .app_state
+                .read(cx)
+                .active_session_id()
+                .map(str::to_string);
+            preview_key_for_session(
+                session_id,
+                active_session_id.as_deref(),
+                active_key.as_deref(),
+            )
+        }
+
         /// Hide native children that no longer belong to the visible Preview
         /// panel. This deliberately never shows a child: an opening transition
         /// may still have stale bounds until `render` mounts its GPUI owner.
@@ -270,21 +301,18 @@ mod native {
             Some(webview)
         }
 
-        /// Navigate the active session's WebView to `url`, remembering it.
-        fn navigate(&mut self, url: &str, window: &mut Window, cx: &mut Context<Self>) {
-            let Some(session_id) = self.active_key(cx) else {
-                return;
-            };
+        /// Navigate one conversation's WebView to `url`, remembering it.
+        fn navigate(&mut self, key: &str, url: &str, window: &mut Window, cx: &mut Context<Self>) {
             let url = normalize_url(url);
-            let Some(webview) = self.ensure_webview(&session_id, window, cx) else {
+            let Some(webview) = self.ensure_webview(key, window, cx) else {
                 cx.notify();
                 return;
             };
             webview.update(cx, |view, _| view.load_url(&url));
             // A navigation flushes lb-wry's pending-scripts buffer, so subsequent
             // evaluate callbacks will fire.
-            self.warm.insert(session_id.clone());
-            self.urls.insert(session_id, url);
+            self.warm.insert(key.to_string());
+            self.urls.insert(key.to_string(), url);
             self.sync_visibility(cx);
             cx.notify();
         }
@@ -298,8 +326,10 @@ mod native {
         ) {
             if let InputEvent::PressEnter { .. } = event {
                 let url = input.read(cx).value().trim().to_string();
-                if !url.is_empty() {
-                    self.navigate(&url, window, cx);
+                if !url.is_empty()
+                    && let Some(key) = self.active_key(cx)
+                {
+                    self.navigate(&key, &url, window, cx);
                 }
             }
         }
@@ -357,25 +387,24 @@ mod native {
         /// value-returning ops.
         pub fn handle_op(
             &mut self,
+            session_id: String,
             op: PreviewOp,
             reply: ReplyTx,
             window: &mut Window,
             cx: &mut Context<Self>,
         ) {
-            let Some(session_id) = self.active_key(cx) else {
-                let _ = reply.try_send(Err("no active session to preview".into()));
-                return;
-            };
+            let key = self.routed_key(&session_id, cx);
             log::info!("preview: handling op {op:?} for session {session_id}");
 
             match op {
                 PreviewOp::Open { url } => {
-                    self.app_state
-                        .update(cx, |state, cx| state.open_preview_panel(cx));
+                    self.app_state.update(cx, |state, cx| {
+                        state.open_preview_panel_for(&session_id, cx)
+                    });
                     if let Some(url) = url.as_deref() {
-                        self.navigate(url, window, cx);
+                        self.navigate(&key, url, window, cx);
                     } else {
-                        self.ensure_webview(&session_id, window, cx);
+                        self.ensure_webview(&key, window, cx);
                         self.sync_visibility(cx);
                     }
                     if let Some(err) = &self.webview_error {
@@ -384,42 +413,39 @@ mod native {
                     }
                     let payload = serde_json::json!({
                         "ok": true,
-                        "url": self.urls.get(&session_id),
+                        "url": self.urls.get(&key),
                         "note": "call preview_status for live page state once loaded",
                     });
                     let _ = reply.try_send(Ok(PreviewReply::Json(payload)));
                 }
                 PreviewOp::Navigate { url } => {
-                    self.app_state
-                        .update(cx, |state, cx| state.open_preview_panel(cx));
-                    self.navigate(&url, window, cx);
+                    self.app_state.update(cx, |state, cx| {
+                        state.open_preview_panel_for(&session_id, cx)
+                    });
+                    self.navigate(&key, &url, window, cx);
                     if let Some(err) = &self.webview_error {
                         let _ = reply.try_send(Err(unavailable_message(err)));
                         return;
                     }
                     let payload = serde_json::json!({
                         "ok": true,
-                        "url": self.urls.get(&session_id),
+                        "url": self.urls.get(&key),
                         "note": "page is loading; call preview_status for live state",
                     });
                     let _ = reply.try_send(Ok(PreviewReply::Json(payload)));
                 }
-                PreviewOp::Status => self.eval_json(&session_id, js::STATUS, reply, window, cx),
-                PreviewOp::Snapshot => self.eval_json(&session_id, js::SNAPSHOT, reply, window, cx),
+                PreviewOp::Status => self.eval_json(&key, js::STATUS, reply, window, cx),
+                PreviewOp::Snapshot => self.eval_json(&key, js::SNAPSHOT, reply, window, cx),
                 PreviewOp::Evaluate { js: expr } => {
-                    self.eval_json(&session_id, &js::evaluate(&expr), reply, window, cx)
+                    self.eval_json(&key, &js::evaluate(&expr), reply, window, cx)
                 }
                 PreviewOp::Click { selector } => {
-                    self.eval_json(&session_id, &js::click(&selector), reply, window, cx)
+                    self.eval_json(&key, &js::click(&selector), reply, window, cx)
                 }
-                PreviewOp::Type { selector, text } => self.eval_json(
-                    &session_id,
-                    &js::type_text(&selector, &text),
-                    reply,
-                    window,
-                    cx,
-                ),
-                PreviewOp::Screenshot => self.screenshot(&session_id, reply, window, cx),
+                PreviewOp::Type { selector, text } => {
+                    self.eval_json(&key, &js::type_text(&selector, &text), reply, window, cx)
+                }
+                PreviewOp::Screenshot => self.screenshot(&session_id, &key, reply, window, cx),
             }
         }
 
@@ -491,6 +517,7 @@ mod native {
         fn screenshot(
             &mut self,
             session_id: &str,
+            key: &str,
             reply: ReplyTx,
             window: &mut Window,
             cx: &mut Context<Self>,
@@ -498,7 +525,30 @@ mod native {
             use base64::Engine as _;
             use gpui::px;
 
-            let Some(view) = self.webviews.get(session_id) else {
+            let visible = {
+                let state = self.app_state.read(cx);
+                if state.active_session_id() != Some(session_id) {
+                    let _ = reply.try_send(Err(
+                        "preview is not visible; the user is viewing another conversation".into(),
+                    ));
+                    return;
+                }
+                visible_preview_key(
+                    Some(key),
+                    state.route,
+                    state.palette_open,
+                    state.preview_panel_showing(),
+                ) == Some(key)
+            };
+            if !visible {
+                let _ = reply.try_send(Err(
+                    "preview is not visible; open the Preview panel before taking a screenshot"
+                        .into(),
+                ));
+                return;
+            }
+
+            let Some(view) = self.webviews.get(key) else {
                 let _ = reply.try_send(Err("preview browser is not open".into()));
                 return;
             };
@@ -530,6 +580,7 @@ mod native {
         fn screenshot(
             &mut self,
             _session_id: &str,
+            _key: &str,
             reply: ReplyTx,
             _window: &mut Window,
             _cx: &mut Context<Self>,
@@ -548,7 +599,7 @@ mod native {
                     .app_state
                     .update(cx, |state, _| state.take_pending_preview_url())
             {
-                self.navigate(&url, window, cx);
+                self.navigate(active.as_deref().unwrap(), &url, window, cx);
             }
 
             // Mirror the active session's URL into the address bar when it changes.
@@ -682,7 +733,9 @@ mod native {
                         .label(format!(":{port}"))
                         .on_click(cx.listener(move |this, _, window, cx| {
                             let url = ports::url_for_port(port);
-                            this.navigate(&url, window, cx);
+                            if let Some(key) = this.active_key(cx) {
+                                this.navigate(&key, &url, window, cx);
+                            }
                         })),
                 );
             }
@@ -718,12 +771,15 @@ mod placeholder {
         /// `Err` into a normal MCP tool error.
         pub fn handle_op(
             &mut self,
+            session_id: String,
             op: PreviewOp,
             reply: ReplyTx,
             _window: &mut Window,
             _cx: &mut Context<Self>,
         ) {
-            log::info!("preview: rejecting op {op:?} (unsupported on Linux)");
+            log::info!(
+                "preview: rejecting op {op:?} for session {session_id} (unsupported on Linux)"
+            );
             let _ = reply.try_send(Err(
                 tcode_i18n::tr!("preview.unsupported_linux").into_owned()
             ));
@@ -791,6 +847,34 @@ fn normalize_url(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn routed_session_uses_active_draft_key_only_for_the_active_surface() {
+        assert_eq!(
+            preview_key_for_session(
+                "physical-draft",
+                Some("physical-draft"),
+                Some("draft:project-a")
+            ),
+            "draft:project-a"
+        );
+        assert_eq!(
+            preview_key_for_session(
+                "stored-background",
+                Some("physical-draft"),
+                Some("draft:project-a")
+            ),
+            "stored-background"
+        );
+        assert_eq!(
+            preview_key_for_session(
+                "stored-active",
+                Some("stored-active"),
+                Some("stored-active")
+            ),
+            "stored-active"
+        );
+    }
 
     #[test]
     fn normalize_url_adds_a_scheme_to_bare_hosts() {

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -142,10 +142,14 @@ impl AppShell {
             let preview = preview.clone();
             cx.spawn_in(window, async move |_, cx| {
                 while let Ok(request) = requests.recv().await {
-                    let preview_mcp::BrokerRequest { op, reply } = request;
+                    let preview_mcp::BrokerRequest {
+                        session_id,
+                        op,
+                        reply,
+                    } = request;
                     if preview
                         .update_in(cx, |panel, window, cx| {
-                            panel.handle_op(op, reply, window, cx)
+                            panel.handle_op(session_id, op, reply, window, cx)
                         })
                         .is_err()
                     {


### PR DESCRIPTION
## Summary
Fixes the bug where conversation A's preview tool call (e.g. `preview_open`) opened and bound the WebView to whichever conversation the user was currently viewing (C) instead of A.

- **preview-mcp**: replace the single app-wide bearer token with a `TokenRegistry` that mints a distinct token per session (same pattern as orchestrate-mcp); every `BrokerRequest` now carries the owning `session_id`; revoked tokens fail with `unauthorized`.
- **runtime**: per-session preview registrations minted on provider start and revoked together with orchestrate registrations; new `open_preview_panel_for(session_id)` opens the Preview tab in the owning conversation's right-panel state (background/parked included) without switching the user's active view.
- **ui**: `PreviewPanel::handle_op` routes by the request's session id (draft-key migration preserved for the active surface); WebViews for background conversations stay hidden; screenshots of a non-visible preview return a clear tool error instead of capturing unrelated pixels (macOS capture uses on-screen bounds, so real pixels are impossible while hidden).

## Verification
- `cargo build` — zero warnings; `cargo test --workspace` — all green; `cargo fmt --check` — clean (rebased on main, retested).
- New tests: two tokens route to their respective sessions; revoked token fails; draft vs background key resolution; opening Preview for a parked background session leaves the active thread untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)