### PR TITLE
Gate preview_key_for_session for non-Linux and test builds

### DIFF
--- a/crates/ui/src/preview_panel.rs
+++ b/crates/ui/src/preview_panel.rs
@@ -49,6 +49,7 @@ fn visible_preview_key(
 /// Resolve an MCP request's physical session id to the stable WebView key.
 /// Only the active surface can be an unsent project draft; every background
 /// request therefore keys directly by its stored session id.
+#[cfg(any(not(target_os = "linux"), test))]
 fn preview_key_for_session(
     requested_session_id: &str,
     active_session_id: Option<&str>,


### PR DESCRIPTION
The helper is only consumed by the macOS-gated native module and unit
tests, so plain Linux check builds flagged it as dead code under
-D warnings and broke CI.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
