### PR TITLE
Tie steer acceptance to model consumption, float pending steers

### DIFF
--- a/crates/agent/examples/steer_probe.rs
+++ b/crates/agent/examples/steer_probe.rs
@@ -15,8 +15,10 @@
 //!      `TurnCompleted` are observed. A steered message must NOT manufacture a
 //!      phantom turn. After the first `TurnCompleted` we keep draining for a
 //!      few seconds specifically to catch a late second one.
+//!   3. ACCEPTANCE IS CONSUMPTION-TIED — `SteerAccepted` for the request arrives
+//!      after the steering write and before the turn completes.
 //!
-//! Exits 0 only when both hold; 1 otherwise.
+//! Exits 0 only when all three hold; 1 otherwise.
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -113,6 +115,7 @@ fn main() {
         let mut turns_started = 0usize;
         let mut turns_completed = 0usize;
         let mut first_status = None;
+        let mut steer_accepted_before_completion = false;
 
         loop {
             // After the first completion, only wait out the grace window: any
@@ -147,6 +150,18 @@ fn main() {
                 AgentEvent::Error { message, .. } => {
                     eprintln!("steer_probe: provider error: {message}");
                 }
+                AgentEvent::SteerAccepted { request_id } if request_id == "steer-probe-1" => {
+                    if turns_completed == 0 {
+                        steer_accepted_before_completion = true;
+                        eprintln!(
+                            "steer_probe: SteerAccepted {request_id} (after write, before first TurnCompleted)"
+                        );
+                    } else {
+                        eprintln!(
+                            "steer_probe: SteerAccepted {request_id} (after TurnCompleted #{turns_completed})"
+                        );
+                    }
+                }
                 AgentEvent::TurnCompleted {
                     status, turn_id, ..
                 } => {
@@ -165,18 +180,27 @@ fn main() {
         println!("--- transcript ---\n{}", assistant.trim());
         println!("--- steering marker {MARKER} present: {steered} ---");
         println!(
+            "--- steer acceptance before completion observed: \
+             {steer_accepted_before_completion} ---"
+        );
+        println!(
             "--- turn accounting: TurnStarted={turns_started} TurnCompleted={turns_completed} \
              (both must be 1; a steer must not create a phantom turn) ---"
         );
 
         let _ = handle.commands.send(SessionCommand::Shutdown).await;
 
-        match (first_status, steered, clean_accounting) {
-            (Some(TurnStatus::Completed), true, true) => 0,
-            (status, steered, clean) => {
+        match (
+            first_status,
+            steered,
+            clean_accounting,
+            steer_accepted_before_completion,
+        ) {
+            (Some(TurnStatus::Completed), true, true, true) => 0,
+            (status, steered, clean, accepted) => {
                 eprintln!(
                     "steer_probe: FAILED (status={status:?}, steered={steered}, \
-                     clean_accounting={clean})"
+                     clean_accounting={clean}, steer_accepted_before_completion={accepted})"
                 );
                 1
             }

--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -22,7 +22,7 @@
 //! task owns the child: it reads stdout lines, receives [`SessionCommand`]s, and
 //! writes stream-json lines to stdin. Multiple turns run over one process.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 
 use futures_lite::io::AsyncWrite;
@@ -696,10 +696,13 @@ async fn handle_command(
             // Steering writes the *same* stream-json user-message line as
             // `SendTurn`, but deliberately skips the turn bookkeeping: no
             // `start_turn()`, no `TurnStarted`. The CLI folds the message into
-            // the turn that is already running (it is picked up at the next
-            // input checkpoint — in practice the next tool call) and still
-            // emits exactly one `result` for that turn, so allocating a turn id
-            // here would leave a phantom turn that never completes.
+            // the turn that is already running at its next input checkpoint.
+            // A successful write only queues the request id; acceptance is
+            // emitted when stdout next reports `status: requesting`, the best
+            // available signal that the CLI consumed it. There is a small
+            // residual race: a steer written microseconds before that status
+            // may actually miss the request, but the CLI protocol exposes no
+            // stronger acknowledgement, so we accept it at that checkpoint.
             //
             // Verified live (examples/steer_probe.rs): 1 `TurnStarted`,
             // 1 `TurnCompleted` across a steered turn.
@@ -709,7 +712,7 @@ async fn handle_command(
                 text
             };
             let msg = user_message(&text, &attachments);
-            write_steering_message(stdin, &msg, request_id, event_tx).await;
+            write_steering_message(stdin, &msg, request_id, mapper, event_tx).await;
             Flow::Continue
         }
         SessionCommand::Shutdown => {
@@ -735,6 +738,7 @@ async fn write_steering_message<W: AsyncWrite + Unpin>(
     stdin: &mut W,
     message: &Value,
     request_id: String,
+    mapper: &mut Mapper,
     event_tx: &async_channel::Sender<AgentEvent>,
 ) {
     if write_line(stdin, message).await.is_err() {
@@ -745,9 +749,7 @@ async fn write_steering_message<W: AsyncWrite + Unpin>(
             })
             .await;
     } else {
-        let _ = event_tx
-            .send(AgentEvent::SteerAccepted { request_id })
-            .await;
+        mapper.pending_steers.push_back(request_id);
     }
 }
 
@@ -883,6 +885,10 @@ pub(crate) struct Mapper {
     /// (Claude reports only per-turn usage, so we accumulate it ourselves for
     /// the "Total processed" display).
     cumulative_processed: u64,
+    /// Successfully written steers awaiting the CLI's next input checkpoint.
+    pending_steers: VecDeque<String>,
+    /// Once the CLI exposes request checkpoints, never use the legacy fallback.
+    saw_requesting: bool,
 }
 
 impl Mapper {
@@ -909,6 +915,8 @@ impl Mapper {
             exit_plan_captures: HashSet::new(),
             outgoing: Vec::new(),
             cumulative_processed: 0,
+            pending_steers: VecDeque::new(),
+            saw_requesting: false,
         }
     }
 
@@ -1116,7 +1124,15 @@ impl Mapper {
         match msg.get("type").and_then(Value::as_str) {
             Some("system") => self.on_system(&msg),
             Some("stream_event") => self.on_stream_event(&msg),
-            Some("assistant") => self.on_assistant(&msg),
+            Some("assistant") => {
+                let mut events = if self.saw_requesting {
+                    Vec::new()
+                } else {
+                    self.accept_pending_steers()
+                };
+                events.extend(self.on_assistant(&msg));
+                events
+            }
             Some("user") => self.on_user(&msg),
             Some("control_request") => self.on_control_request(&msg),
             Some("result") => self.on_result(&msg),
@@ -1128,6 +1144,12 @@ impl Mapper {
     }
 
     fn on_system(&mut self, msg: &Value) -> Vec<AgentEvent> {
+        if msg.get("subtype").and_then(Value::as_str) == Some("status")
+            && msg.get("status").and_then(Value::as_str) == Some("requesting")
+        {
+            self.saw_requesting = true;
+            return self.accept_pending_steers();
+        }
         match msg.get("subtype").and_then(Value::as_str) {
             Some("init") => {}
             // Claude compacted its context window (verified shape:
@@ -1162,6 +1184,13 @@ impl Mapper {
             events.push(AgentEvent::ProviderCommands { commands });
         }
         events
+    }
+
+    fn accept_pending_steers(&mut self) -> Vec<AgentEvent> {
+        self.pending_steers
+            .drain(..)
+            .map(|request_id| AgentEvent::SteerAccepted { request_id })
+            .collect()
     }
 
     fn on_task_started(&mut self, msg: &Value) -> Vec<AgentEvent> {
@@ -3511,7 +3540,7 @@ mod tests {
     }
 
     #[test]
-    fn steer_acceptance_requires_successful_write_and_flush() {
+    fn steer_write_success_queues_acceptance_and_failures_remain_fatal() {
         smol::block_on(async {
             use std::io;
             use std::pin::Pin;
@@ -3558,15 +3587,22 @@ mod tests {
 
             let (event_tx, event_rx) = async_channel::unbounded();
             let mut writer = DeterministicWriter::default();
+            let mut mapper = Mapper::new();
             let message = user_message("redirect", &[]);
-            write_steering_message(&mut writer, &message, "steer-ok".into(), &event_tx).await;
-            assert!(matches!(
-                event_rx.recv().await.unwrap(),
-                AgentEvent::SteerAccepted { ref request_id } if request_id == "steer-ok"
-            ));
+            write_steering_message(
+                &mut writer,
+                &message,
+                "steer-ok".into(),
+                &mut mapper,
+                &event_tx,
+            )
+            .await;
+            assert!(event_rx.try_recv().is_err());
+            assert_eq!(mapper.pending_steers, VecDeque::from(["steer-ok".into()]));
             assert_eq!(writer.bytes.last(), Some(&b'\n'));
 
             let (event_tx, event_rx) = async_channel::unbounded();
+            let mut mapper = Mapper::new();
             let mut writer = DeterministicWriter {
                 failure: Some(FailurePoint::Write),
                 ..Default::default()
@@ -3575,6 +3611,7 @@ mod tests {
                 &mut writer,
                 &message,
                 "steer-write-failed".into(),
+                &mut mapper,
                 &event_tx,
             )
             .await;
@@ -3589,6 +3626,7 @@ mod tests {
             );
 
             let (event_tx, event_rx) = async_channel::unbounded();
+            let mut mapper = Mapper::new();
             let mut writer = DeterministicWriter {
                 failure: Some(FailurePoint::Flush),
                 ..Default::default()
@@ -3597,6 +3635,7 @@ mod tests {
                 &mut writer,
                 &message,
                 "steer-flush-failed".into(),
+                &mut mapper,
                 &event_tx,
             )
             .await;
@@ -3610,5 +3649,98 @@ mod tests {
                 "stdin flush failures must not accept a steer"
             );
         });
+    }
+
+    fn accepted_request_ids(events: &[AgentEvent]) -> Vec<&str> {
+        events
+            .iter()
+            .filter_map(|event| match event {
+                AgentEvent::SteerAccepted { request_id } => Some(request_id.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn pending_steer_waits_for_requesting_checkpoint() {
+        let mut mapper = Mapper::new();
+        mapper.pending_steers.push_back("steer-1".into());
+
+        assert_eq!(mapper.pending_steers.len(), 1);
+        let events = feed(
+            &mut mapper,
+            r#"{"type":"system","subtype":"status","status":"requesting","uuid":"checkpoint-1","session_id":"session-1"}"#,
+        );
+        assert_eq!(accepted_request_ids(&events), ["steer-1"]);
+        assert!(mapper.pending_steers.is_empty());
+    }
+
+    #[test]
+    fn requesting_accepts_multiple_pending_steers_in_fifo_order() {
+        let mut mapper = Mapper::new();
+        mapper.pending_steers.push_back("steer-first".into());
+        mapper.pending_steers.push_back("steer-second".into());
+
+        let events = feed(
+            &mut mapper,
+            r#"{"type":"system","subtype":"status","status":"requesting","uuid":"checkpoint-2","session_id":"session-1"}"#,
+        );
+        assert_eq!(
+            accepted_request_ids(&events),
+            ["steer-first", "steer-second"]
+        );
+    }
+
+    #[test]
+    fn result_keeps_pending_steer_for_follow_up_requesting() {
+        let mut mapper = Mapper::new();
+        mapper.pending_steers.push_back("steer-late".into());
+
+        let result_events = feed(
+            &mut mapper,
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"first response","session_id":"session-1","usage":{"input_tokens":2,"output_tokens":3}}"#,
+        );
+        assert!(accepted_request_ids(&result_events).is_empty());
+        assert_eq!(mapper.pending_steers.len(), 1);
+
+        let requesting_events = feed(
+            &mut mapper,
+            r#"{"type":"system","subtype":"status","status":"requesting","uuid":"follow-up-checkpoint","session_id":"session-1"}"#,
+        );
+        assert_eq!(accepted_request_ids(&requesting_events), ["steer-late"]);
+    }
+
+    #[test]
+    fn assistant_accepts_pending_steer_for_legacy_cli_fallback() {
+        let mut mapper = Mapper::new();
+        mapper.pending_steers.push_back("steer-legacy".into());
+
+        let events = feed(
+            &mut mapper,
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-8","id":"msg_legacy","type":"message","role":"assistant","content":[{"type":"text","text":"consumed"}]},"session_id":"session-legacy","request_id":"req_legacy"}"#,
+        );
+        assert_eq!(accepted_request_ids(&events), ["steer-legacy"]);
+    }
+
+    #[test]
+    fn assistant_does_not_fallback_after_requesting_was_observed() {
+        let mut mapper = Mapper::new();
+        assert!(
+            feed(
+                &mut mapper,
+                r#"{"type":"system","subtype":"status","status":"requesting","uuid":"checkpoint-early","session_id":"session-1"}"#,
+            )
+            .is_empty()
+        );
+        mapper
+            .pending_steers
+            .push_back("steer-after-checkpoint".into());
+
+        let events = feed(
+            &mut mapper,
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-8","id":"msg_current","type":"message","role":"assistant","content":[{"type":"text","text":"current response"}]},"session_id":"session-1","request_id":"req_current"}"#,
+        );
+        assert!(accepted_request_ids(&events).is_empty());
+        assert_eq!(mapper.pending_steers.len(), 1);
     }
 }

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -624,7 +624,12 @@ pub enum AgentEvent {
         request_id: String,
         text: String,
     },
-    /// Emitted only after the provider has accepted the correlated steer.
+    /// Emitted only after the provider has consumed the correlated steer into
+    /// its model context (or provided the strongest available consumption
+    /// signal when its protocol has no explicit acknowledgement). Claude uses
+    /// its next `status: requesting` checkpoint; a steer written microseconds
+    /// before that status can still miss the request, but this is the best
+    /// available signal without CLI protocol support.
     SteerAccepted {
         request_id: String,
     },

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -612,16 +612,32 @@ impl Timeline {
     }
 
     fn accept_steer(&mut self, request_id: &str) {
-        let Some(entry) = self.entries.iter_mut().find(|entry| entry.id == request_id) else {
+        let Some(position) = self.entries.iter().position(|entry| entry.id == request_id) else {
             return;
         };
+        if !matches!(
+            self.entries[position].content,
+            EntryContent::User {
+                steering: Some(SteeringStatus::Pending),
+                ..
+            }
+        ) {
+            return;
+        }
+
+        let mut entry = self.entries.remove(position);
+        let current_turn = self.turns.iter().rposition(|turn| turn.running);
         if let EntryContent::User {
             steering: steering @ Some(SteeringStatus::Pending),
             ..
-        } = &mut Arc::make_mut(entry).content
+        } = &mut Arc::make_mut(&mut entry).content
         {
             *steering = Some(SteeringStatus::Accepted);
         }
+        if let Some(turn) = current_turn {
+            Arc::make_mut(&mut entry).turn = turn;
+        }
+        self.entries.push(entry);
     }
 
     fn content_from_item(content: &ItemContent) -> EntryContent {
@@ -1115,6 +1131,64 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn accepted_steer_moves_to_its_consumption_position_live_and_on_replay() {
+        let assistant_item = |id: &str| {
+            AgentEvent::ItemCompleted(ThreadItem {
+                id: id.into(),
+                parent_item_id: None,
+                content: ItemContent::AssistantMessage { text: id.into() },
+            })
+        };
+        let events = vec![
+            user_msg("user-a", "start"),
+            AgentEvent::TurnStarted {
+                turn_id: "turn-a".into(),
+            },
+            AgentEvent::SteerRequested {
+                request_id: "S".into(),
+                text: "change direction".into(),
+            },
+            assistant_item("A"),
+            assistant_item("B"),
+            AgentEvent::SteerAccepted {
+                request_id: "S".into(),
+            },
+            assistant_item("C"),
+            assistant_item("D"),
+        ];
+
+        let mut live = Timeline::default();
+        for event in &events {
+            live.apply_at(None, event);
+        }
+        let replayed = Timeline::fold_events(events);
+
+        let live_ids: Vec<&str> = live.entries.iter().map(|entry| entry.id.as_str()).collect();
+        let replayed_ids: Vec<&str> = replayed
+            .entries
+            .iter()
+            .map(|entry| entry.id.as_str())
+            .collect();
+        assert_eq!(live_ids, ["user-a", "A", "B", "S", "C", "D"]);
+        assert_eq!(replayed_ids, live_ids);
+        assert!(matches!(
+            live.entries[3].content,
+            EntryContent::User {
+                steering: Some(SteeringStatus::Accepted),
+                ..
+            }
+        ));
+        assert!(matches!(
+            replayed.entries[3].content,
+            EntryContent::User {
+                steering: Some(SteeringStatus::Accepted),
+                ..
+            }
+        ));
+        assert_eq!(replayed.entries[3].turn, live.entries[3].turn);
     }
 
     fn assistant_delta(id: &str, text: &str) -> AgentEvent {

--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -149,6 +149,12 @@ enum Segment<'a> {
     Error(&'a TimelineEntry),
 }
 
+#[derive(Debug)]
+struct SegmentedEntries<'a> {
+    flow: Vec<Segment<'a>>,
+    pending_steers: Vec<&'a TimelineEntry>,
+}
+
 fn displayed_error_text(content: &EntryContent) -> Cow<'_, str> {
     match content {
         EntryContent::Error { message } => Cow::Borrowed(message),
@@ -161,11 +167,25 @@ fn displayed_error_text(content: &EntryContent) -> Cow<'_, str> {
 
 /// Coalesce only adjacent activity entries, leaving messages and errors at
 /// their exact positions in the timeline.
-fn segment_entries<'a>(entries: &'a [Arc<TimelineEntry>], turn_running: bool) -> Vec<Segment<'a>> {
+fn segment_entries<'a>(
+    entries: &'a [Arc<TimelineEntry>],
+    turn_running: bool,
+) -> SegmentedEntries<'a> {
     let mut segments = Vec::new();
     let mut activities = Vec::new();
+    let mut pending_steers = Vec::new();
     let live_reasoning_index = turn_running
-        .then(|| entries.len().checked_sub(1))
+        .then(|| {
+            entries.iter().rposition(|entry| {
+                !matches!(
+                    entry.content,
+                    EntryContent::User {
+                        steering: Some(SteeringStatus::Pending),
+                        ..
+                    }
+                )
+            })
+        })
         .flatten()
         .filter(|index| matches!(entries[*index].content, EntryContent::Reasoning { .. }));
 
@@ -178,6 +198,18 @@ fn segment_entries<'a>(entries: &'a [Arc<TimelineEntry>], turn_running: bool) ->
 
     for (entry_index, entry) in entries.iter().enumerate() {
         let entry = entry.as_ref();
+        if turn_running
+            && matches!(
+                entry.content,
+                EntryContent::User {
+                    steering: Some(SteeringStatus::Pending),
+                    ..
+                }
+            )
+        {
+            pending_steers.push(entry);
+            continue;
+        }
         match &entry.content {
             EntryContent::Command { .. }
             | EntryContent::Tool { .. }
@@ -204,7 +236,10 @@ fn segment_entries<'a>(entries: &'a [Arc<TimelineEntry>], turn_running: bool) ->
         }
     }
     flush_activities(&mut segments, &mut activities);
-    segments
+    SegmentedEntries {
+        flow: segments,
+        pending_steers,
+    }
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -765,7 +800,8 @@ impl ChatView {
     ) -> AnyElement {
         let mut column = v_flex().w_full().gap_4();
 
-        let segments = segment_entries(entries, turn.running);
+        let segmented = segment_entries(entries, turn.running);
+        let segments = &segmented.flow;
         let turn_entries: Vec<&TimelineEntry> = entries.iter().map(AsRef::as_ref).collect();
         let turn_counts = work_log_counts(&turn_entries);
         let last_assistant_id = entries.iter().rev().find_map(|entry| {
@@ -911,6 +947,30 @@ impl ChatView {
             column = column.child(self.render_timestamp(ts, cx));
         }
 
+        // Pending steers float below every live transcript/work-log element.
+        // Keeping them separate from `segments` preserves FIFO order without
+        // making their request-time position look model-visible.
+        for entry in segmented.pending_steers {
+            let EntryContent::User {
+                text,
+                steering,
+                context_len,
+            } = &entry.content
+            else {
+                unreachable!();
+            };
+            column = column.child(self.render_user(
+                index,
+                &entry.id,
+                text,
+                *context_len,
+                *steering,
+                false,
+                pinned.0 == Some(entry.id.as_str()),
+                cx,
+            ));
+        }
+
         column.into_any_element()
     }
 
@@ -1049,17 +1109,24 @@ impl ChatView {
                         }),
                 )
             })
-            .child(
+            .child({
+                let pending = steering == Some(SteeringStatus::Pending);
                 div()
                     .max_w_3_4()
                     .px_4()
                     .py_3()
                     .rounded_xl()
-                    .bg(cx.theme().muted)
+                    .when(pending, |bubble| {
+                        bubble
+                            .border_1()
+                            .border_dashed()
+                            .border_color(cx.theme().border)
+                    })
+                    .when(!pending, |bubble| bubble.bg(cx.theme().muted))
                     .text_color(cx.theme().foreground)
                     .text_size(px(15.))
-                    .child(visible.to_string()),
-            )
+                    .child(visible.to_string())
+            })
             .child(self.reserve_action_row(actions, group_key, pinned));
 
         let Some(context) = context else {
@@ -3101,7 +3168,7 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::path::Path;
     use std::sync::Arc;
-    use tcode_core::session::{EntryContent, TimelineEntry, TurnMeta};
+    use tcode_core::session::{EntryContent, SteeringStatus, TimelineEntry, TurnMeta};
 
     fn entry(id: &str, content: EntryContent) -> Arc<TimelineEntry> {
         Arc::new(TimelineEntry {
@@ -3351,7 +3418,7 @@ mod tests {
                 },
             ),
         ];
-        let segments = segment_entries(&entries, false);
+        let segments = segment_entries(&entries, false).flow;
 
         assert_eq!(segments.len(), 6);
         assert!(matches!(segments[0], Segment::User(entry) if entry.id == "user"));
@@ -3374,7 +3441,7 @@ mod tests {
     #[test]
     fn segment_entries_coalesces_an_all_activity_turn() {
         let entries = [command("cmd-1"), command("cmd-2")];
-        let segments = segment_entries(&entries, false);
+        let segments = segment_entries(&entries, false).flow;
 
         assert!(matches!(
             segments.as_slice(),
@@ -3384,7 +3451,108 @@ mod tests {
 
     #[test]
     fn segment_entries_handles_an_empty_turn() {
-        assert!(segment_entries(&[], false).is_empty());
+        let segmented = segment_entries(&[], false);
+        assert!(segmented.flow.is_empty());
+        assert!(segmented.pending_steers.is_empty());
+    }
+
+    #[test]
+    fn pending_steers_float_after_live_flow_in_fifo_order_only_while_running() {
+        let pending = |id: &str| {
+            entry(
+                id,
+                EntryContent::User {
+                    text: id.into(),
+                    steering: Some(SteeringStatus::Pending),
+                    context_len: None,
+                },
+            )
+        };
+        let entries = [
+            entry("assistant-a", EntryContent::Assistant { text: "a".into() }),
+            pending("steer-a"),
+            command("command"),
+            pending("steer-b"),
+            entry("assistant-b", EntryContent::Assistant { text: "b".into() }),
+        ];
+
+        let live = segment_entries(&entries, true);
+        assert_eq!(live.flow.len(), 3);
+        assert!(matches!(live.flow[0], Segment::Assistant(entry) if entry.id == "assistant-a"));
+        assert!(matches!(
+            &live.flow[1],
+            Segment::ActivityRun(run) if run.len() == 1 && run[0].id == "command"
+        ));
+        assert!(matches!(live.flow[2], Segment::Assistant(entry) if entry.id == "assistant-b"));
+        assert_eq!(
+            live.pending_steers
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            ["steer-a", "steer-b"]
+        );
+
+        let idle = segment_entries(&entries, false);
+        assert!(idle.pending_steers.is_empty());
+        assert_eq!(idle.flow.len(), 5);
+        assert!(matches!(idle.flow[1], Segment::User(entry) if entry.id == "steer-a"));
+        assert!(matches!(idle.flow[3], Segment::User(entry) if entry.id == "steer-b"));
+    }
+
+    #[test]
+    fn steer_status_and_reordering_invalidate_the_virtualized_turn_row() {
+        let turns = vec![TurnMeta {
+            running: true,
+            ..Default::default()
+        }];
+        let children = HashMap::new();
+        let expanded = HashSet::new();
+        let pending = entry(
+            "steer",
+            EntryContent::User {
+                text: "redirect".into(),
+                steering: Some(SteeringStatus::Pending),
+                context_len: None,
+            },
+        );
+        let assistant = entry(
+            "assistant",
+            EntryContent::Assistant {
+                text: "working".into(),
+            },
+        );
+        let before = index_turns(
+            &turns,
+            &[pending.clone(), assistant.clone()],
+            None,
+            &children,
+            &expanded,
+        );
+
+        let mut accepted = pending;
+        if let EntryContent::User { steering, .. } = &mut Arc::make_mut(&mut accepted).content {
+            *steering = Some(SteeringStatus::Accepted);
+        }
+        let status_changed = index_turns(
+            &turns,
+            &[accepted.clone(), assistant.clone()],
+            None,
+            &children,
+            &expanded,
+        );
+        assert_eq!(
+            list_sync(&before, &status_changed, false),
+            ListSync::Incremental {
+                append: None,
+                remeasure: vec![0],
+            }
+        );
+
+        let reordered = index_turns(&turns, &[assistant, accepted], None, &children, &expanded);
+        assert_eq!(
+            list_sync(&status_changed, &reordered, false),
+            ListSync::Reset { count: 1 }
+        );
     }
 
     /// A file edit between two commands is one continuous work log. FileChange
@@ -3396,7 +3564,7 @@ mod tests {
             entry("edit", EntryContent::FileChange { changes: vec![] }),
             command("cmd-2"),
         ];
-        let segments = segment_entries(&entries, false);
+        let segments = segment_entries(&entries, false).flow;
 
         assert!(matches!(
             segments.as_slice(),
@@ -3423,7 +3591,7 @@ mod tests {
             ),
         ];
 
-        let segments = segment_entries(&entries, true);
+        let segments = segment_entries(&entries, true).flow;
         assert!(matches!(
             segments.as_slice(),
             [Segment::ActivityRun(run)] if run.len() == 1 && run[0].id == "reason-2"
@@ -3442,7 +3610,7 @@ mod tests {
             command("later-command"),
         ];
 
-        let segments = segment_entries(&entries, true);
+        let segments = segment_entries(&entries, true).flow;
         assert!(matches!(
             segments.as_slice(),
             [Segment::ActivityRun(run)] if run.len() == 1 && run[0].id == "later-command"
@@ -3462,7 +3630,7 @@ mod tests {
                 },
             ),
         ];
-        let segments = segment_entries(&entries, true);
+        let segments = segment_entries(&entries, true).flow;
         assert!(matches!(
             segments.as_slice(),
             [Segment::Assistant(entry)] if entry.id == "assistant"
@@ -3478,7 +3646,7 @@ mod tests {
             },
         )];
 
-        assert!(segment_entries(&entries, false).is_empty());
+        assert!(segment_entries(&entries, false).flow.is_empty());
     }
 
     fn file_change(id: &str, paths: &[&str]) -> Arc<TimelineEntry> {
@@ -3607,7 +3775,7 @@ mod tests {
             command("command-2"),
             file_change("files-2", &["src/shared.rs"]),
         ];
-        let segments = segment_entries(&entries, false);
+        let segments = segment_entries(&entries, false).flow;
         let activity_indexes: Vec<usize> = segments
             .iter()
             .enumerate()


### PR DESCRIPTION
## Problem

`SteerAccepted` ("已引导") fired the instant the steering line was written to the claude CLI's stdin, long before the model actually saw the message. The steered bubble also stayed frozen at its send position, so the model's eventual response to it appeared far below, detached from the bubble.

## Investigation (live-probed against claude CLI 2.1.208)

- The CLI never echoes a consumed steer back on stdout — echo detection is impossible.
- The CLI emits `{"type":"system","subtype":"status","status":"requesting"}` before each API request; a steer written before that line is included in that request.
- A steer that misses the last checkpoint of a turn is not dropped: the CLI runs a follow-up cycle (second `result` on the same turn) that consumes it.
- Multiple steers are consumed together at the next checkpoint, FIFO.

## Changes

- **claude provider**: steer writes only queue the request id; `SteerAccepted` is emitted at the CLI's next `status: requesting` checkpoint (FIFO). Fallback for CLIs that never emit status lines: accept at the next assistant message. Write/flush failures remain fatal errors.
- **timeline**: accepting a steer moves its entry to the end, so items that arrived while it was pending stay before it and the model's response to it renders immediately after.
- **chat**: pending steers render as dashed-border bubbles pinned below the streaming transcript while the turn runs; accepted steers rejoin the flow as normal bubbles. Virtualized-list invalidation covered (status flip → remeasure, reorder → reset).
- **steer_probe**: now additionally asserts `SteerAccepted` arrives mid-turn (after the write, before `TurnCompleted`).

## Verification

- `cargo test --workspace` green (core 70, ui 99, agent 104; pre-existing PTY flake in `term` under parallel load is unrelated).
- Live end-to-end: `cargo run -p agent --example steer_probe -- claude /tmp` exits 0 — marker delivered, acceptance observed mid-turn at the consumption checkpoint, clean turn accounting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)