### PR TITLE
Show per-turn net diffs in the changed-files card and diff panel

### DIFF
--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -8,6 +8,35 @@
 
 use std::collections::HashSet;
 
+use agent::FileChange;
+
+/// Collapse per-edit file changes into one approximate change per path.
+///
+/// This is the non-git fallback used by turn summaries. Concatenating the
+/// fragments makes line statistics additive; it is deliberately only an
+/// approximation because overlapping edits require checkpoint trees to obtain
+/// the real net diff.
+pub fn merge_file_changes_by_path<'a>(
+    changes: impl IntoIterator<Item = &'a FileChange>,
+) -> Vec<FileChange> {
+    let mut merged: Vec<FileChange> = Vec::new();
+    for change in changes {
+        if let Some(existing) = merged.iter_mut().find(|item| item.path == change.path) {
+            existing.kind = change.kind;
+            if let Some(fragment) = &change.diff {
+                let diff = existing.diff.get_or_insert_with(String::new);
+                if !diff.is_empty() && !diff.ends_with('\n') {
+                    diff.push('\n');
+                }
+                diff.push_str(fragment);
+            }
+        } else {
+            merged.push(change.clone());
+        }
+    }
+    merged
+}
+
 // ---------------------------------------------------------------------------
 // Status model
 // ---------------------------------------------------------------------------
@@ -564,6 +593,48 @@ fn parse_porcelain_path(line: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agent::FileChangeKind;
+
+    #[test]
+    fn fallback_merge_collapses_fragments_and_keeps_summed_stats() {
+        let changes = [
+            FileChange {
+                path: "/repo/src/lib.rs".into(),
+                kind: FileChangeKind::Modify,
+                diff: Some("--- a/src/lib.rs\n+++ b/src/lib.rs\n-old\n+middle\n".into()),
+            },
+            FileChange {
+                path: "/repo/other.rs".into(),
+                kind: FileChangeKind::Modify,
+                diff: Some("-gone\n+new\n".into()),
+            },
+            FileChange {
+                path: "/repo/src/lib.rs".into(),
+                kind: FileChangeKind::Modify,
+                diff: Some("-middle\n-final\n+replacement\n".into()),
+            },
+        ];
+
+        let merged = merge_file_changes_by_path(&changes);
+        assert_eq!(merged.len(), 2);
+        let lib = merged
+            .iter()
+            .find(|change| change.path.ends_with("src/lib.rs"))
+            .unwrap();
+        let diff = lib.diff.as_deref().unwrap();
+        let stats = diff.lines().fold((0, 0), |(added, deleted), line| {
+            if line.starts_with("+++") || line.starts_with("---") {
+                (added, deleted)
+            } else if line.starts_with('+') {
+                (added + 1, deleted)
+            } else if line.starts_with('-') {
+                (added, deleted + 1)
+            } else {
+                (added, deleted)
+            }
+        });
+        assert_eq!(stats, (2, 3));
+    }
 
     fn dirty_upstream() -> GitStatus {
         GitStatus {

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -1,12 +1,12 @@
 //! Application state: session registry, active session runtime, event pump.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use agent::{
-    AgentEvent, ApprovalDecision, ApprovalMode, Attachment, InteractionMode, ItemContent,
-    LaunchEnv, ModelSpec, OptionDescriptor, OptionSelection, ProviderCommand, ProviderKind,
-    SessionCommand, SessionOptions, ThreadItem, TurnOptions, TurnStatus, list_models,
+    AgentEvent, ApprovalDecision, ApprovalMode, Attachment, FileChange, InteractionMode,
+    ItemContent, LaunchEnv, ModelSpec, OptionDescriptor, OptionSelection, ProviderCommand,
+    ProviderKind, SessionCommand, SessionOptions, ThreadItem, TurnOptions, TurnStatus, list_models,
     start_session,
 };
 #[cfg(test)]
@@ -37,7 +37,7 @@ use tcode_services::acp_registry::{
 use tcode_services::checkpoints::checkpoint_ref_exists;
 use tcode_services::checkpoints::{
     create_checkpoint, delete_all_checkpoint_refs, delete_checkpoint_refs_from, is_git_repo,
-    restore_checkpoint,
+    net_turn_file_changes, restore_checkpoint,
 };
 use tcode_services::git::{
     CheckoutError, checkout_if_clean, commit_diff_context, create_git_worktree, list_git_branches,
@@ -730,6 +730,10 @@ pub struct AppState {
     review_comment_drafts: HashMap<String, Vec<ReviewComment>>,
     /// Invalidates working-tree/branch previews on panel open and turn finish.
     pub diff_refresh_generation: u64,
+    /// Lazily computed checkpoint-tree diffs. `None` is a remembered failure
+    /// (missing ref, non-git/replayed cwd); absence means not requested yet.
+    turn_net_changes: HashMap<(String, usize), Option<Vec<FileChange>>>,
+    turn_net_changes_loading: HashSet<(String, usize)>,
     /// Per-provider version-check results (Group C). Populated on launch (when
     /// the toggle is on) and by Settings → "Check now".
     pub provider_versions: HashMap<ProviderKind, ProviderVersionStatus>,
@@ -823,6 +827,8 @@ impl AppState {
             debug_edit_open: false,
             review_comment_drafts: HashMap::new(),
             diff_refresh_generation: 0,
+            turn_net_changes: HashMap::new(),
+            turn_net_changes_loading: HashSet::new(),
             debug_palette: None,
             debug_settings_section: None,
             debug_acp_search: None,
@@ -2255,6 +2261,98 @@ impl AppState {
         }
     }
 
+    /// Return a completed net result for the active session/turn. `None` also
+    /// covers pending and unavailable results so callers can use their merged
+    /// per-edit fallback in either state.
+    pub fn turn_net_file_changes(&self, turn: usize) -> Option<Vec<FileChange>> {
+        let session_id = &self.active.as_ref()?.meta.id;
+        self.turn_net_changes
+            .get(&(session_id.clone(), turn))
+            .and_then(|result| result.clone())
+    }
+
+    /// Start the checkpoint diff for a finished turn once. The base is that
+    /// turn's checkpoint and the target is the next recorded checkpoint, or
+    /// the worktree if this is the latest checkpointed turn.
+    pub fn request_turn_net_file_changes(&mut self, turn: usize, cx: &mut Context<Self>) {
+        let Some(active) = self.active.as_ref() else {
+            return;
+        };
+        // A running turn is still producing edits; computing (and permanently
+        // caching) a worktree diff now would freeze a mid-turn snapshot.
+        // Callers keep their per-edit fallback until the turn finishes.
+        if active
+            .timeline
+            .turns
+            .get(turn)
+            .is_some_and(|meta| meta.running)
+        {
+            return;
+        }
+        let session_id = active.meta.id.clone();
+        let key = (session_id.clone(), turn);
+        if self.turn_net_changes.contains_key(&key) || self.turn_net_changes_loading.contains(&key)
+        {
+            return;
+        }
+
+        if !active
+            .meta
+            .checkpoints
+            .iter()
+            .any(|checkpoint| checkpoint.turn == turn)
+        {
+            self.turn_net_changes.insert(key, None);
+            return;
+        }
+        let target_turn = active
+            .meta
+            .checkpoints
+            .iter()
+            .filter(|checkpoint| checkpoint.turn > turn)
+            .map(|checkpoint| checkpoint.turn)
+            .min();
+        let mut paths = Vec::new();
+        for entry in &active.timeline.entries {
+            if entry.turn != turn {
+                continue;
+            }
+            if let EntryContent::FileChange { changes, .. } = &entry.content {
+                for change in changes {
+                    if !paths.contains(&change.path) {
+                        paths.push(change.path.clone());
+                    }
+                }
+            }
+        }
+        if paths.is_empty() {
+            self.turn_net_changes.insert(key, Some(Vec::new()));
+            return;
+        }
+
+        let cwd = active.meta.cwd.clone();
+        self.turn_net_changes_loading.insert(key.clone());
+        cx.spawn(async move |this, cx| {
+            let result = unblock(cx.background_executor(), move || {
+                net_turn_file_changes(&cwd, &session_id, turn, target_turn, &paths)
+            })
+            .await;
+            let _ = this.update(cx, |state, cx| {
+                // Rewind invalidation removes the loading marker. Do not let an
+                // already-running task repopulate an orphaned turn afterward.
+                if state.turn_net_changes_loading.remove(&key) {
+                    if let Err(err) = &result {
+                        log::debug!("turn net diff unavailable: {err}");
+                    }
+                    state.turn_net_changes.insert(key, result.ok());
+                    state.diff_refresh_generation = state.diff_refresh_generation.wrapping_add(1);
+                    cx.notify();
+                }
+            });
+        })
+        .detach();
+    }
+
     pub fn diff_panel_open(&self) -> bool {
         self.active.as_ref().is_some_and(|a| a.diff_open)
     }
@@ -3176,6 +3274,13 @@ impl AppState {
         let Some(turn) = active.timeline.entries.last().map(|e| e.turn) else {
             return;
         };
+        let previous_checkpoint_turn = active
+            .meta
+            .checkpoints
+            .iter()
+            .filter(|checkpoint| checkpoint.turn < turn)
+            .map(|checkpoint| checkpoint.turn)
+            .max();
         // A second queued send can land in the same open turn — checkpoint once.
         if active.meta.checkpoints.iter().any(|c| c.turn == turn) {
             return;
@@ -3185,6 +3290,13 @@ impl AppState {
         }
         match create_checkpoint(&cwd, session_id, turn) {
             Ok(commit) => {
+                // A previous last turn may have been computed against the
+                // worktree. It now has an immutable checkpoint target instead.
+                if let Some(previous_turn) = previous_checkpoint_turn {
+                    let key = (session_id.to_string(), previous_turn);
+                    self.turn_net_changes.remove(&key);
+                    self.turn_net_changes_loading.remove(&key);
+                }
                 if let Some(active) = self.active.as_mut().filter(|a| a.meta.id == session_id) {
                     active.meta.checkpoints.push(Checkpoint {
                         turn,
@@ -3252,6 +3364,10 @@ impl AppState {
             }
             delete_checkpoint_refs_from(&cwd, &session_id, turn);
         }
+        self.turn_net_changes
+            .retain(|(id, cached_turn), _| id != &session_id || *cached_turn < turn);
+        self.turn_net_changes_loading
+            .retain(|(id, cached_turn)| id != &session_id || *cached_turn < turn);
         if let Err(err) = self.store.truncate_events(&session_id, event_offset) {
             self.report_error(
                 RuntimeError::PersistEvent {

--- a/crates/services/src/checkpoints.rs
+++ b/crates/services/src/checkpoints.rs
@@ -19,6 +19,8 @@
 
 use std::path::Path;
 
+use agent::{FileChange, FileChangeKind};
+
 /// The ref name for one checkpoint (`refs/tcode/checkpoints/<session>/<turn>`).
 fn checkpoint_ref(session_id: &str, turn: usize) -> String {
     format!("refs/tcode/checkpoints/{session_id}/{turn}")
@@ -64,6 +66,152 @@ fn run_git(cwd: &Path, args: &[&str], index: Option<&Path>) -> Result<String, St
         ));
     }
     Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Compute the net changes made by one turn from its checkpoint tree to the
+/// next checkpoint tree, or to the current worktree when there is no later
+/// checkpoint. Only the supplied paths are included.
+pub fn net_turn_file_changes(
+    cwd: &Path,
+    session_id: &str,
+    base_turn: usize,
+    target_turn: Option<usize>,
+    paths: &[String],
+) -> Result<Vec<FileChange>, String> {
+    if paths.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let base = checkpoint_ref(session_id, base_turn);
+    if !checkpoint_ref_exists(cwd, session_id, base_turn) {
+        return Err(format!("checkpoint ref does not exist: {base}"));
+    }
+    let target = target_turn.map(|turn| checkpoint_ref(session_id, turn));
+    if let Some(turn) = target_turn
+        && !checkpoint_ref_exists(cwd, session_id, turn)
+    {
+        return Err(format!(
+            "checkpoint ref does not exist: {}",
+            checkpoint_ref(session_id, turn)
+        ));
+    }
+
+    let mut args = vec![
+        "diff".to_string(),
+        "--no-color".to_string(),
+        "--no-ext-diff".to_string(),
+        "--find-renames".to_string(),
+        base,
+    ];
+    if let Some(target) = target {
+        args.push(target);
+    }
+    args.push("--".to_string());
+    for path in paths {
+        let path = Path::new(path);
+        let relative = path.strip_prefix(cwd).unwrap_or(path);
+        args.push(relative.to_string_lossy().to_string());
+    }
+
+    let args_ref: Vec<&str> = args.iter().map(String::as_str).collect();
+    let raw = run_git(cwd, &args_ref, None)?;
+    let mut changes = split_git_patch(&raw, cwd);
+
+    // `git diff <tree>` intentionally ignores untracked worktree files. Agent
+    // creates are nevertheless named in `paths`, so add those explicitly when
+    // the target is the worktree and the base tree has no such path.
+    if target_turn.is_none() {
+        for path in paths {
+            let path = Path::new(path);
+            let relative = path.strip_prefix(cwd).unwrap_or(path);
+            let absolute = cwd.join(relative);
+            if changes
+                .iter()
+                .any(|change| Path::new(&change.path) == absolute)
+                || !absolute.is_file()
+            {
+                continue;
+            }
+            let tree_path = format!(
+                "{}:{}",
+                checkpoint_ref(session_id, base_turn),
+                relative.display()
+            );
+            if run_git(cwd, &["cat-file", "-e", &tree_path], None).is_ok() {
+                continue;
+            }
+            let output = crate::process::command("git")
+                .args(["diff", "--no-color", "--no-index", "--", "/dev/null"])
+                .arg(relative)
+                .current_dir(cwd)
+                .output()
+                .map_err(|err| format!("git diff --no-index: {err}"))?;
+            if !output.status.success() && output.status.code() != Some(1) {
+                return Err(format!(
+                    "git diff --no-index failed: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ));
+            }
+            changes.extend(split_git_patch(
+                &String::from_utf8_lossy(&output.stdout),
+                cwd,
+            ));
+        }
+    }
+    Ok(changes)
+}
+
+fn split_git_patch(raw: &str, cwd: &Path) -> Vec<FileChange> {
+    let mut sections = Vec::new();
+    let mut current = String::new();
+    for line in raw.lines() {
+        if line.starts_with("diff --git ") && !current.is_empty() {
+            sections.push(std::mem::take(&mut current));
+        }
+        if !current.is_empty() || line.starts_with("diff --git ") {
+            current.push_str(line);
+            current.push('\n');
+        }
+    }
+    if !current.is_empty() {
+        sections.push(current);
+    }
+
+    sections
+        .into_iter()
+        .filter_map(|patch| {
+            let old_null = patch.lines().any(|line| line == "--- /dev/null")
+                || patch.lines().any(|line| line.starts_with("new file mode "));
+            let new_null = patch.lines().any(|line| line == "+++ /dev/null")
+                || patch
+                    .lines()
+                    .any(|line| line.starts_with("deleted file mode "));
+            let path = patch
+                .lines()
+                .find_map(|line| line.strip_prefix("rename to "))
+                .or_else(|| patch.lines().find_map(|line| line.strip_prefix("+++ b/")))
+                .or_else(|| patch.lines().find_map(|line| line.strip_prefix("--- a/")))
+                .or_else(|| {
+                    patch
+                        .lines()
+                        .find_map(|line| line.strip_prefix("diff --git "))
+                        .and_then(|header| header.rsplit_once(" b/").map(|(_, path)| path))
+                })?;
+            Some(FileChange {
+                path: cwd.join(path).to_string_lossy().to_string(),
+                kind: if old_null {
+                    FileChangeKind::Create
+                } else if new_null {
+                    FileChangeKind::Delete
+                } else if patch.lines().any(|line| line.starts_with("rename to ")) {
+                    FileChangeKind::Rename
+                } else {
+                    FileChangeKind::Modify
+                },
+                diff: Some(patch),
+            })
+        })
+        .collect()
 }
 
 /// Snapshot `cwd`'s working tree into `refs/tcode/checkpoints/<session>/<turn>`
@@ -201,6 +349,116 @@ mod tests {
     fn commit_all(root: &Path, message: &str) {
         run_git(root, &["add", "-A"], None).unwrap();
         run_git(root, &["commit", "-q", "-m", message], None).unwrap();
+    }
+
+    fn diff_stats(diff: &str) -> (u32, u32) {
+        diff.lines().fold((0, 0), |(added, deleted), line| {
+            if line.starts_with("+++") || line.starts_with("---") {
+                (added, deleted)
+            } else if line.starts_with('+') {
+                (added + 1, deleted)
+            } else if line.starts_with('-') {
+                (added, deleted + 1)
+            } else {
+                (added, deleted)
+            }
+        })
+    }
+
+    #[test]
+    fn net_turn_diff_uses_checkpoint_trees_and_restricts_paths() {
+        let root = scratch_repo();
+        fs::write(root.join("tracked.txt"), "alpha\nbeta\ngamma\n").unwrap();
+        fs::write(root.join("outside.txt"), "outside base\n").unwrap();
+        commit_all(&root, "seed");
+        create_checkpoint(&root, "sess", 1).unwrap();
+
+        // Multiple overlapping rewrites of the same lines. The intermediate
+        // fragments would total 4 additions / 4 deletions, but only the final
+        // tree relative to checkpoint 1 is the turn's true result.
+        fs::write(root.join("tracked.txt"), "alpha\nintermediate\ngamma\n").unwrap();
+        fs::write(root.join("tracked.txt"), "alpha\nsecond pass\ngamma\n").unwrap();
+        fs::write(root.join("tracked.txt"), "alpha\nfinal\ngamma\n").unwrap();
+        fs::write(root.join("created.txt"), "created in turn\n").unwrap();
+        fs::write(root.join("outside.txt"), "outside changed\n").unwrap();
+        create_checkpoint(&root, "sess", 2).unwrap();
+
+        let paths = vec![
+            root.join("tracked.txt").to_string_lossy().to_string(),
+            root.join("created.txt").to_string_lossy().to_string(),
+        ];
+        let changes = net_turn_file_changes(&root, "sess", 1, Some(2), &paths).unwrap();
+        assert_eq!(changes.len(), 2);
+        assert!(
+            changes
+                .iter()
+                .all(|change| !change.path.ends_with("outside.txt"))
+        );
+        let tracked = changes
+            .iter()
+            .find(|change| change.path.ends_with("tracked.txt"))
+            .unwrap();
+        let expected = run_git(
+            &root,
+            &[
+                "diff",
+                "--no-color",
+                &checkpoint_ref("sess", 1),
+                &checkpoint_ref("sess", 2),
+                "--",
+                "tracked.txt",
+            ],
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            diff_stats(tracked.diff.as_deref().unwrap()),
+            diff_stats(&expected)
+        );
+        assert_ne!(diff_stats(tracked.diff.as_deref().unwrap()), (4, 4));
+        assert_eq!(
+            changes
+                .iter()
+                .find(|change| change.path.ends_with("created.txt"))
+                .unwrap()
+                .kind,
+            FileChangeKind::Create
+        );
+
+        // With no next checkpoint, compare the base tree to the worktree.
+        fs::write(root.join("tracked.txt"), "alpha\nworktree\ngamma\n").unwrap();
+        let worktree = net_turn_file_changes(
+            &root,
+            "sess",
+            2,
+            None,
+            &[root.join("tracked.txt").to_string_lossy().to_string()],
+        )
+        .unwrap();
+        assert_eq!(worktree.len(), 1);
+        assert_eq!(worktree[0].kind, FileChangeKind::Modify);
+        assert_eq!(diff_stats(worktree[0].diff.as_deref().unwrap()), (1, 1));
+
+        fs::write(root.join("worktree-created.txt"), "new after checkpoint\n").unwrap();
+        let worktree_create = net_turn_file_changes(
+            &root,
+            "sess",
+            2,
+            None,
+            &[root
+                .join("worktree-created.txt")
+                .to_string_lossy()
+                .to_string()],
+        )
+        .unwrap();
+        assert_eq!(worktree_create.len(), 1);
+        assert_eq!(worktree_create[0].kind, FileChangeKind::Create);
+        assert_eq!(
+            diff_stats(worktree_create[0].diff.as_deref().unwrap()),
+            (1, 0)
+        );
+
+        let _ = fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -29,7 +29,7 @@ use gpui_component::{
     v_flex,
 };
 
-use tcode_core::git::GitAction;
+use tcode_core::git::{GitAction, merge_file_changes_by_path};
 use tcode_core::session::{
     EntryContent, OrchestrateCallback, SteeringStatus, TimelineEntry, TurnMeta,
     parse_orchestrate_callback,
@@ -925,18 +925,26 @@ impl ChatView {
         // silently. Replay marks turns idle (mark_idle), so finished turns from
         // stored sessions still render the card.
         if !turn.running {
-            let mut changes: Vec<&FileChange> = Vec::new();
+            let mut fragments: Vec<&FileChange> = Vec::new();
             for entry in entries {
                 if let EntryContent::FileChange {
                     changes: file_changes,
                     ..
                 } = &entry.content
                 {
-                    changes.extend(file_changes.iter());
+                    fragments.extend(file_changes.iter());
                 }
             }
-            if !changes.is_empty() {
-                column = column.child(self.render_changed_files(index, cwd, &changes, cx));
+            if !fragments.is_empty() {
+                let fallback = merge_file_changes_by_path(fragments);
+                let changes = self.app_state.update(cx, |state, cx| {
+                    state.request_turn_net_file_changes(index, cx);
+                    state.turn_net_file_changes(index)
+                });
+                let changes = changes.unwrap_or(fallback);
+                if !changes.is_empty() {
+                    column = column.child(self.render_changed_files(index, cwd, &changes, cx));
+                }
             }
         }
 
@@ -1964,7 +1972,7 @@ impl ChatView {
         &self,
         index: usize,
         cwd: &Path,
-        changes: &[&FileChange],
+        changes: &[FileChange],
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let muted = cx.theme().muted_foreground;
@@ -3088,7 +3096,7 @@ struct FileRow {
 /// Group file changes by their parent directory (preserving first-seen order),
 /// so the CHANGED FILES card can render a folder → files tree. Paths are shown
 /// relative to the session `cwd` when they live under it.
-fn group_by_dir(changes: &[&FileChange], cwd: &Path) -> Vec<(String, Vec<FileRow>)> {
+fn group_by_dir(changes: &[FileChange], cwd: &Path) -> Vec<(String, Vec<FileRow>)> {
     let mut groups: Vec<(String, Vec<FileRow>)> = Vec::new();
     for change in changes {
         let display = tcode_runtime::ui_facade::relativize_to_workspace(&change.path, cwd);

--- a/crates/ui/src/diff_panel.rs
+++ b/crates/ui/src/diff_panel.rs
@@ -32,6 +32,7 @@ use gpui_component::{
 };
 
 use crate::plan_panel::PlanPanel;
+use tcode_core::git::merge_file_changes_by_path;
 use tcode_core::session::{EntryContent, ReviewComment, ReviewSide};
 use tcode_runtime::app::{AppState, RightTab};
 use tcode_runtime::ui_facade::{
@@ -742,6 +743,16 @@ impl DiffPanel {
                 active.meta.cwd.clone(),
             )
         };
+
+        if let DiffScope::Turn(turn) = scope {
+            changes = merge_file_changes_by_path(&changes);
+            if let Some(net_changes) = self.app_state.update(cx, |state, cx| {
+                state.request_turn_net_file_changes(turn, cx);
+                state.turn_net_file_changes(turn)
+            }) {
+                changes = net_changes;
+            }
+        }
 
         if matches!(scope, DiffScope::WorkingTree | DiffScope::Branch) {
             let base = (scope == DiffScope::Branch)


### PR DESCRIPTION
## Problem

The CHANGED FILES card and the diff panel's Turn scope render one row per individual edit — a file edited four times shows as `main.rs -5 +1`, `main.rs -10 +21`, `main.rs -40 +34`, `main.rs -65 +107` instead of one `main.rs -50 +76` row. Summing the fragments is not a correct net diff either, since overlapping edits rewrite the same lines.

## Approach

The per-turn git checkpoints already captured for the revert feature (`refs/tcode/checkpoints/<session>/<turn>`) are the source of truth: the net diff for turn T is `git diff` between checkpoint(T)'s tree and the next checkpoint's tree (or the worktree for the latest checkpointed turn), restricted to the paths the agent actually touched in that turn.

- `net_turn_file_changes` in the checkpoints service computes it (rename detection, untracked in-turn creates handled in the worktree case).
- The runtime caches results per (session, turn), computed lazily on a background task. Invalidation: rewind clears affected turns (in-flight tasks cannot repopulate), and creating the next checkpoint replaces the previous worktree-target result. The running turn is never computed or cached — a mid-turn snapshot would freeze; callers keep the fallback until the turn finishes.
- The card and panel consume the net changes when available; otherwise they fall back to per-edit fragments merged by path (approximate, but one row per file) — covers non-git cwds, deleted refs, and replayed sessions.

## Verification

- New test: overlapping rewrites of the same file across two checkpoints — asserts one `FileChange` whose stats equal `git diff ref1 ref2` and explicitly differ from the fragment sum; also covers in-turn creates, the worktree case, and path restriction.
- Fallback merge test: same-path fragments collapse into one row with additive stats.
- `cargo test --workspace` green; `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)