### PR TITLE
Make read_only dispatch actually read-only-friendly, surface blocked approvals

### DIFF
--- a/crates/agent/examples/read_only_probe.rs
+++ b/crates/agent/examples/read_only_probe.rs
@@ -1,0 +1,235 @@
+//! Live probe for dispatch-only `ApprovalMode::ReadOnly`.
+//!
+//! ```text
+//! cargo run -p agent --example read_only_probe -- codex
+//! cargo run -p agent --example read_only_probe -- claude
+//! ```
+
+use std::time::Duration;
+
+use agent::{
+    AgentEvent, ApprovalMode, InteractionMode, ItemContent, ProviderKind, SessionCommand,
+    SessionOptions, start_session,
+};
+
+const EVENT_TIMEOUT: Duration = Duration::from_secs(180);
+
+fn main() {
+    env_logger::init();
+    let provider = match std::env::args().nth(1).as_deref() {
+        Some("codex") => ProviderKind::Codex,
+        Some("claude") => ProviderKind::ClaudeCode,
+        other => {
+            eprintln!("usage: read_only_probe <codex|claude> (got {other:?})");
+            std::process::exit(2);
+        }
+    };
+
+    let exit = smol::block_on(run(provider));
+    std::process::exit(exit);
+}
+
+async fn run(provider: ProviderKind) -> i32 {
+    let cwd = std::env::temp_dir().join(format!(
+        "tcode-read-only-probe-{}-{}",
+        provider_name(provider),
+        std::process::id()
+    ));
+    if let Err(err) = std::fs::create_dir_all(&cwd) {
+        eprintln!("probe: could not create {}: {err}", cwd.display());
+        return 1;
+    }
+    let marker = cwd.join("must-not-exist.txt");
+    let readable = cwd.join("read-me.txt");
+    let _ = std::fs::remove_file(&marker);
+    if let Err(err) = std::fs::write(&readable, "READ_ONLY_PROBE_OK\nsecond line\n") {
+        eprintln!("probe: could not create {}: {err}", readable.display());
+        let _ = std::fs::remove_dir_all(&cwd);
+        return 1;
+    }
+
+    let opts = SessionOptions {
+        cwd: cwd.clone(),
+        model: None,
+        resume: None,
+        binary_path: None,
+        approval_mode: ApprovalMode::ReadOnly,
+        option_selections: Vec::new(),
+        interaction_mode: InteractionMode::Build,
+        mcp_server: None,
+        orchestrate_server: None,
+        launch_env: Default::default(),
+        extra_args: Vec::new(),
+        acp: None,
+    };
+    let handle = match start_session(provider, opts).await {
+        Ok(handle) => handle,
+        Err(err) => {
+            eprintln!("probe: failed to start {provider:?}: {err}");
+            let _ = std::fs::remove_dir_all(&cwd);
+            return 1;
+        }
+    };
+
+    eprintln!("probe: READ turn -> read {}", readable.display());
+    handle
+        .commands
+        .send(SessionCommand::SendTurn {
+            text: format!(
+                "Read the file `{}` using a native file-read tool if one is available, then report its first line. Do not use a shell command and do not modify anything.",
+                readable.display()
+            ),
+            options: None,
+            attachments: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let read = observe_turn(&handle.events, "READ").await;
+
+    eprintln!("probe: WRITE turn -> create {}", marker.display());
+    handle
+        .commands
+        .send(SessionCommand::SendTurn {
+            text: format!(
+                "Create the file `{}` containing exactly `blocked`. Use a shell command or file-writing tool now; do not merely describe how.",
+                marker.display()
+            ),
+            options: None,
+            attachments: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let write = observe_turn_until_approval_or_completion(&handle.events, "WRITE").await;
+
+    if write.approvals > 0 {
+        eprintln!("probe: mutation approval surfaced; cancelling without approval");
+        let _ = handle.commands.send(SessionCommand::Interrupt).await;
+    }
+    let _ = handle.commands.send(SessionCommand::Shutdown).await;
+
+    let exists = marker.exists();
+    eprintln!(
+        "probe: SUMMARY provider={} read_completed={} read_approvals={} write_completed={} write_approvals={} file_exists={exists}",
+        provider_name(provider),
+        read.completed,
+        read.approvals,
+        write.completed,
+        write.approvals,
+    );
+    let ok = read.completed
+        && read.approvals == 0
+        && match provider {
+            ProviderKind::Codex | ProviderKind::ClaudeCode => write.approvals > 0 && !exists,
+            ProviderKind::Acp => unreachable!(),
+        };
+    let _ = std::fs::remove_dir_all(&cwd);
+    i32::from(!ok)
+}
+
+#[derive(Default)]
+struct Observation {
+    completed: bool,
+    approvals: usize,
+}
+
+async fn observe_turn(events: &async_channel::Receiver<AgentEvent>, label: &str) -> Observation {
+    let mut observation = Observation::default();
+    loop {
+        let Some(event) = recv_timeout(events).await else {
+            eprintln!("probe: {label} TIMEOUT");
+            break;
+        };
+        print_event(label, &event);
+        match event {
+            AgentEvent::ApprovalRequested(_) => observation.approvals += 1,
+            AgentEvent::TurnCompleted { .. } => {
+                observation.completed = true;
+                break;
+            }
+            AgentEvent::Error { fatal: true, .. } | AgentEvent::SessionClosed { .. } => break,
+            _ => {}
+        }
+    }
+    observation
+}
+
+async fn observe_turn_until_approval_or_completion(
+    events: &async_channel::Receiver<AgentEvent>,
+    label: &str,
+) -> Observation {
+    let mut observation = Observation::default();
+    loop {
+        let Some(event) = recv_timeout(events).await else {
+            eprintln!("probe: {label} TIMEOUT");
+            break;
+        };
+        print_event(label, &event);
+        match event {
+            AgentEvent::ApprovalRequested(_) => {
+                observation.approvals += 1;
+                break;
+            }
+            AgentEvent::TurnCompleted { .. } => {
+                observation.completed = true;
+                break;
+            }
+            AgentEvent::Error { fatal: true, .. } | AgentEvent::SessionClosed { .. } => break,
+            _ => {}
+        }
+    }
+    observation
+}
+
+async fn recv_timeout(events: &async_channel::Receiver<AgentEvent>) -> Option<AgentEvent> {
+    smol::future::or(async { events.recv().await.ok() }, async {
+        smol::Timer::after(EVENT_TIMEOUT).await;
+        None
+    })
+    .await
+}
+
+fn print_event(label: &str, event: &AgentEvent) {
+    match event {
+        AgentEvent::TurnStarted { turn_id } => {
+            eprintln!("probe: {label} TurnStarted id={turn_id}")
+        }
+        AgentEvent::ItemCompleted(item) => match &item.content {
+            ItemContent::CommandExecution {
+                command,
+                output,
+                exit_code,
+                ..
+            } => eprintln!(
+                "probe: {label} CommandCompleted command={command:?} exit={exit_code:?} output={:?}",
+                output.trim()
+            ),
+            ItemContent::AssistantMessage { text } => {
+                eprintln!("probe: {label} Assistant {:?}", text.trim())
+            }
+            _ => {}
+        },
+        AgentEvent::ApprovalRequested(request) => eprintln!(
+            "probe: {label} ApprovalRequested id={} kind={:?}",
+            request.id, request.kind
+        ),
+        AgentEvent::TurnCompleted { status, .. } => {
+            eprintln!("probe: {label} TurnCompleted status={status:?}")
+        }
+        AgentEvent::Warning(message) => eprintln!("probe: {label} Warning {message:?}"),
+        AgentEvent::Error { fatal, message } => {
+            eprintln!("probe: {label} Error fatal={fatal} {message:?}")
+        }
+        AgentEvent::SessionClosed { reason } => {
+            eprintln!("probe: {label} SessionClosed {reason:?}")
+        }
+        _ => {}
+    }
+}
+
+fn provider_name(provider: ProviderKind) -> &'static str {
+    match provider {
+        ProviderKind::Codex => "codex",
+        ProviderKind::ClaudeCode => "claude",
+        ProviderKind::Acp => "acp",
+    }
+}

--- a/crates/agent/src/acp.rs
+++ b/crates/agent/src/acp.rs
@@ -24,11 +24,12 @@ use futures_lite::{AsyncBufReadExt as _, AsyncReadExt as _, StreamExt as _, futu
 use serde_json::{Value, json};
 
 use crate::{
-    AcpAgent, AcpLaunch, AgentError, AgentEvent, ApprovalDecision, ApprovalKind, ApprovalOption,
-    ApprovalOptionKind, ApprovalRequest, Attachment, DeltaKind, FileChange, FileChangeKind,
-    ItemContent, ItemStatus, McpRegistration, OptionDescriptor, OptionSelection, PlanStep,
-    PlanStepStatus, ProviderCommand, ProviderCommandKind, ProviderKind, ResumeCursor, SelectOption,
-    SessionCommand, SessionHandle, SessionOptions, ThreadItem, TokenUsage, TurnStatus,
+    AcpAgent, AcpLaunch, AgentError, AgentEvent, ApprovalDecision, ApprovalKind, ApprovalMode,
+    ApprovalOption, ApprovalOptionKind, ApprovalRequest, Attachment, DeltaKind, FileChange,
+    FileChangeKind, ItemContent, ItemStatus, McpRegistration, OptionDescriptor, OptionSelection,
+    PlanStep, PlanStepStatus, ProviderCommand, ProviderCommandKind, ProviderKind, ResumeCursor,
+    SelectOption, SessionCommand, SessionHandle, SessionOptions, ThreadItem, TokenUsage,
+    TurnStatus,
 };
 
 /// Option-descriptor ids. The composer renders an ACP agent's own
@@ -435,7 +436,7 @@ async fn handshake(
         .map(str::to_string)
         .filter(|_| caps.load_session);
 
-    let (session_id, modes, models, config_options) = match resumed {
+    let (session_id, mut modes, models, config_options) = match resumed {
         Some(session_id) => {
             // `session/load` replays the whole conversation as `session/update`
             // notifications. Our JSONL log is the authoritative history and the
@@ -480,6 +481,36 @@ async fn handshake(
         }
     };
 
+    if opts.approval_mode == ApprovalMode::ReadOnly
+        && let Some(plan_mode) = modes.as_ref().and_then(acp_plan_mode)
+        && modes
+            .as_ref()
+            .is_some_and(|modes| modes.current_mode_id != plan_mode)
+    {
+        match connection
+            .set_session_mode(acp::SetSessionModeRequest::new(
+                session_id.clone(),
+                plan_mode.clone(),
+            ))
+            .await
+        {
+            Ok(_) => modes.as_mut().unwrap().current_mode_id = plan_mode,
+            Err(err) => {
+                // ACP has no provider-independent permission policy. If an
+                // advertised plan mode cannot be selected, retain the agent's
+                // current mode, which is the same least-privilege fallback used
+                // for Supervised sessions.
+                let _ = events
+                    .send(AgentEvent::Warning(format!(
+                        "{} could not enter its read-only plan mode: {}",
+                        agent.name,
+                        describe(&err)
+                    )))
+                    .await;
+            }
+        }
+    }
+
     let model = models
         .as_ref()
         .map(|models| models.current_model_id.0.to_string());
@@ -496,6 +527,14 @@ async fn handshake(
         model,
         can_close: caps.session_capabilities.close.is_some(),
     })
+}
+
+fn acp_plan_mode(modes: &acp::SessionModeState) -> Option<acp::SessionModeId> {
+    modes
+        .available_modes
+        .iter()
+        .find(|mode| mode.id.0.eq_ignore_ascii_case("plan"))
+        .map(|mode| mode.id.clone())
 }
 
 async fn new_session(

--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -49,10 +49,11 @@ const EXIT_PLAN_DENY_MESSAGE: &str = "The client captured your proposed plan. St
 /// Verified against `@anthropic-ai/claude-agent-sdk` v0.3.170
 /// `SDKControlSetPermissionModeRequest` (`sdk.d.ts`): `'default'` prompts for
 /// dangerous operations, `'acceptEdits'` auto-accepts file edits, and
-/// `'bypassPermissions'` skips all permission checks.
+/// `'bypassPermissions'` skips all permission checks. ReadOnly also launches in
+/// default mode; tcode enforces its narrower policy in [`Mapper`].
 pub(crate) fn permission_mode_flag(mode: ApprovalMode) -> &'static str {
     match mode {
-        ApprovalMode::Supervised => "default",
+        ApprovalMode::Supervised | ApprovalMode::ReadOnly => "default",
         ApprovalMode::AutoAcceptEdits => "acceptEdits",
         ApprovalMode::FullAccess => "bypassPermissions",
     }
@@ -671,7 +672,7 @@ async fn handle_command(
             // only a stdin write failure warrants a Warning.
             let flag = permission_mode_flag(mode);
             mapper.base_permission_mode = flag;
-            mapper.full_access = mode == ApprovalMode::FullAccess;
+            mapper.approval_mode = mode;
             let msg = mapper.set_permission_mode_request(mode);
             if write_line(stdin, &msg).await.is_err() {
                 let _ = event_tx
@@ -861,10 +862,10 @@ pub(crate) struct Mapper {
     /// Pending `AskUserQuestion` prompts: control request_id → the original
     /// `questions` array, echoed back verbatim in the allow response.
     pending_user_input: HashMap<String, Value>,
-    /// Whether the session runs in full-access (bypassPermissions) mode, in
-    /// which normal tools that reach `can_use_tool` are auto-allowed with no
-    /// approval event (AskUserQuestion / ExitPlanMode are still handled first).
-    full_access: bool,
+    /// Canonical session access policy. FullAccess auto-allows every ordinary
+    /// tool; ReadOnly auto-allows only classified file reads. Special tools are
+    /// handled before either policy.
+    approval_mode: ApprovalMode,
     /// Set when we send an `interrupt` control_request; the next non-success
     /// `result` is then attributed to the interrupt rather than a failure
     /// (the CLI's result carries no reliable interrupt marker).
@@ -906,7 +907,7 @@ impl Mapper {
             tail_requests: Vec::new(),
             pending_approvals: HashMap::new(),
             pending_user_input: HashMap::new(),
-            full_access: false,
+            approval_mode: ApprovalMode::Supervised,
             interrupt_pending: false,
             ultrathink: false,
             interaction_mode: InteractionMode::Build,
@@ -925,7 +926,7 @@ impl Mapper {
         self.interaction_mode = config.interaction_mode;
         self.base_permission_mode = config.base_permission_mode;
         self.applied_permission_mode = config.base_permission_mode.to_string();
-        self.full_access = config.approval_mode == ApprovalMode::FullAccess;
+        self.approval_mode = config.approval_mode;
     }
 
     /// Drain queued control-response writes for the actor to send.
@@ -1686,7 +1687,7 @@ impl Mapper {
         // (c) Full-access: ordinary SDK permission checks are bypassed, but the
         // callback stays installed. Any non-special tool that reaches it is
         // auto-allowed with no approval event (S2 §1.1/§1.2 "full-access allow").
-        if self.full_access {
+        if self.approval_mode == ApprovalMode::FullAccess {
             self.outgoing.push(json!({
                 "type": "control_response",
                 "response": {
@@ -1702,8 +1703,30 @@ impl Mapper {
         }
 
         // (d) Classify per the T3 substring matrix (S2 §1.3).
+        let request_type = classify_claude_tool(&tool_name);
+
+        // (e) Read-only: native read tools proceed without prompting. Commands
+        // and every other tool still fall through to the ordinary approval flow.
+        let read_only_allow = self.approval_mode == ApprovalMode::ReadOnly
+            && request_type == ClaudeRequestType::FileRead;
+        if read_only_allow {
+            self.outgoing.push(json!({
+                "type": "control_response",
+                "response": {
+                    "subtype": "success",
+                    "request_id": request_id,
+                    "response": {
+                        "behavior": "allow",
+                        "updatedInput": input,
+                    }
+                }
+            }));
+            return Vec::new();
+        }
+
+        // (f) Everything else becomes a user-visible approval request.
         let detail = approval_detail(&tool_name, &input);
-        let kind = match classify_claude_tool(&tool_name) {
+        let kind = match request_type {
             ClaudeRequestType::FileRead => ApprovalKind::FileRead { detail },
             ClaudeRequestType::ExecCommand => ApprovalKind::ExecCommand {
                 command: input
@@ -3258,7 +3281,7 @@ mod tests {
     #[test]
     fn full_access_auto_allows_without_event() {
         let mut m = Mapper::new();
-        m.full_access = true;
+        m.approval_mode = ApprovalMode::FullAccess;
         let evs = feed(
             &mut m,
             r#"{"type":"control_request","request_id":"req-fa","request":{"subtype":"can_use_tool","tool_name":"Bash","input":{"command":"ls"}}}"#,
@@ -3296,6 +3319,45 @@ mod tests {
             },
             other => panic!("expected ApprovalRequested, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn read_only_auto_allows_file_reads_without_approval() {
+        let mut m = Mapper::new();
+        m.approval_mode = ApprovalMode::ReadOnly;
+        let evs = feed(
+            &mut m,
+            r#"{"type":"control_request","request_id":"req-ro-read","request":{"subtype":"can_use_tool","tool_name":"Read","input":{"file_path":"/tmp/a.txt"}}}"#,
+        );
+        assert!(evs.is_empty(), "read-only file read emitted an approval");
+        assert!(m.pending_approvals.is_empty());
+        let outgoing = m.take_outgoing();
+        assert_eq!(outgoing.len(), 1);
+        assert_eq!(outgoing[0]["response"]["request_id"], "req-ro-read");
+        assert_eq!(outgoing[0]["response"]["response"]["behavior"], "allow");
+        assert_eq!(
+            outgoing[0]["response"]["response"]["updatedInput"]["file_path"],
+            "/tmp/a.txt"
+        );
+    }
+
+    #[test]
+    fn read_only_file_write_still_requests_approval() {
+        let mut m = Mapper::new();
+        m.approval_mode = ApprovalMode::ReadOnly;
+        let evs = feed(
+            &mut m,
+            r#"{"type":"control_request","request_id":"req-ro-write","request":{"subtype":"can_use_tool","tool_name":"Write","input":{"file_path":"/tmp/a.txt","content":"changed"}}}"#,
+        );
+        assert!(matches!(
+            evs.as_slice(),
+            [AgentEvent::ApprovalRequested(ApprovalRequest {
+                id,
+                kind: ApprovalKind::FileChange { .. },
+                ..
+            })] if id == "req-ro-write"
+        ));
+        assert!(m.take_outgoing().is_empty());
     }
 
     #[test]
@@ -3396,6 +3458,7 @@ mod tests {
     #[test]
     fn permission_mode_flag_maps_all_modes() {
         assert_eq!(permission_mode_flag(ApprovalMode::Supervised), "default");
+        assert_eq!(permission_mode_flag(ApprovalMode::ReadOnly), "default");
         assert_eq!(
             permission_mode_flag(ApprovalMode::AutoAcceptEdits),
             "acceptEdits"

--- a/crates/agent/src/codex.rs
+++ b/crates/agent/src/codex.rs
@@ -36,12 +36,15 @@ const DEFAULT_MODEL: &str = "gpt-5-codex";
 /// T3's `CodexSessionRuntime.runtimeModeToThreadConfig`:
 /// - Supervised (approval-required): everything outside a read-only sandbox is
 ///   confirmed → asks before commands and file changes.
+/// - ReadOnly: reads proceed inside the read-only sandbox; an attempted
+///   escalation to mutate requests approval.
 /// - AutoAcceptEdits: edits inside the workspace-write sandbox proceed;
 ///   escalations (e.g. commands needing more access) still request approval.
 /// - FullAccess: no prompts, unsandboxed.
 fn approval_knobs(mode: ApprovalMode) -> (&'static str, &'static str) {
     match mode {
         ApprovalMode::Supervised => ("untrusted", "read-only"),
+        ApprovalMode::ReadOnly => ("on-request", "read-only"),
         ApprovalMode::AutoAcceptEdits => ("on-request", "workspace-write"),
         ApprovalMode::FullAccess => ("never", "danger-full-access"),
     }
@@ -2547,6 +2550,10 @@ mod tests {
         assert_eq!(
             approval_knobs(ApprovalMode::Supervised),
             ("untrusted", "read-only")
+        );
+        assert_eq!(
+            approval_knobs(ApprovalMode::ReadOnly),
+            ("on-request", "read-only")
         );
         assert_eq!(
             approval_knobs(ApprovalMode::AutoAcceptEdits),

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -478,8 +478,8 @@ pub async fn list_models(
 /// The user-facing permission model, provider-agnostic.
 ///
 /// Providers map this onto their native controls:
-/// - Claude Code: `--permission-mode` default / acceptEdits / bypassPermissions
-///   (switchable mid-session via the control protocol).
+/// - Claude Code: `--permission-mode` default / acceptEdits / bypassPermissions,
+///   plus tcode-side ReadOnly filtering (switchable mid-session).
 /// - Codex: approval-policy × sandbox-mode combinations on thread start
 ///   (mid-session switch may require a resume-restart).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -487,6 +487,8 @@ pub async fn list_models(
 pub enum ApprovalMode {
     /// Ask before commands and file changes.
     Supervised,
+    /// Read-only actions run without prompts; anything that mutates pauses for approval.
+    ReadOnly,
     /// Auto-approve edits, ask before other actions.
     AutoAcceptEdits,
     /// Allow commands and edits without prompts.

--- a/crates/orchestrate-mcp/src/tools.rs
+++ b/crates/orchestrate-mcp/src/tools.rs
@@ -65,7 +65,7 @@ impl OrchestrateTools {
     }
 
     #[tool(
-        description = "Dispatch a brief to a new child tcode thread and return its thread id. access is one of read_only (review/investigation: the child cannot change files; actions beyond that pause for user approval), workspace_write (edits auto-approved inside the workspace), or full (default; no approval prompts)."
+        description = "Dispatch a brief to a new child tcode thread and return its thread id. access is one of read_only (review/investigation: read-only actions run without prompts; anything that mutates pauses for user approval), workspace_write (edits auto-approved inside the workspace), or full (default; no approval prompts)."
     )]
     async fn dispatch(
         &self,

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -703,6 +703,11 @@ pub struct AppState {
     /// Requests from the orchestrate MCP runtime, pumped on the gpui thread.
     pub orchestrate_requests: Option<async_channel::Receiver<orchestrate_mcp::BrokerRequest>>,
     callback_last_turn: HashMap<String, usize>,
+    callback_approval_requests: HashSet<(String, String)>,
+    /// Live provider approvals for sessions without an authoritative active
+    /// timeline. Maintained incrementally from `on_event`; never replayed from
+    /// disk, because a persisted approval cannot survive its provider process.
+    sessions_awaiting_approval: HashMap<String, Vec<agent::ApprovalRequest>>,
     /// A URL the preview panel should navigate to on its next render (set by the
     /// `--open-preview <url>` dev flag for headless screenshots). Consumed once.
     pub pending_preview_url: Option<String>,
@@ -818,6 +823,8 @@ impl AppState {
             orchestrate_registrations: HashMap::new(),
             orchestrate_requests: None,
             callback_last_turn: HashMap::new(),
+            callback_approval_requests: HashSet::new(),
+            sessions_awaiting_approval: HashMap::new(),
             pending_preview_url: None,
             git_status: None,
             git_busy: false,
@@ -1219,9 +1226,11 @@ impl AppState {
                 thread_id,
             } => {
                 self.require_child(&parent_id, &thread_id)?;
+                self.sessions_awaiting_approval.remove(&thread_id);
                 if self.active_session_id() == Some(&thread_id) {
                     if let Some(child) = self.active.as_mut() {
                         child.queue.clear();
+                        child.timeline.mark_idle();
                         child.shutdown_to_idle();
                     }
                 } else {
@@ -1305,11 +1314,16 @@ impl AppState {
 
     fn child_status_json(&self, meta: &SessionMeta) -> serde_json::Value {
         let (state, final_message, usage) = self.child_result(meta);
+        let waiting_approval = self
+            .pending_approval_for(&meta.id)
+            .as_ref()
+            .map(approval_request_summary);
         let mut status = serde_json::json!({
             "thread_id": meta.id,
             "title": meta.title,
             "provider": match meta.provider { ProviderKind::ClaudeCode => "claude", ProviderKind::Codex => "codex", ProviderKind::Acp => "acp" },
             "state": state,
+            "waiting_approval": waiting_approval,
             "last_output_tail": tail_chars(&final_message, 600),
             "updated_at": meta.updated_at,
         });
@@ -3084,6 +3098,7 @@ impl AppState {
         remove_worktree: bool,
         cx: &mut Context<Self>,
     ) {
+        self.sessions_awaiting_approval.remove(session_id);
         let meta = self.sessions.iter().find(|m| m.id == session_id).cloned();
         if self.active_session_id() == Some(session_id) {
             // shutdown_active drops the ActiveSession (and its terminal PTY).
@@ -3190,6 +3205,18 @@ impl AppState {
         self.background
             .get(session_id)
             .is_some_and(|s| s.turn_in_flight || !s.queue.is_empty())
+    }
+
+    /// The first approval currently blocking a session, including parked and
+    /// reopened sessions whose in-memory timeline may be stale.
+    pub fn pending_approval_for(&self, session_id: &str) -> Option<agent::ApprovalRequest> {
+        if let Some(active) = self.active.as_ref().filter(|a| a.meta.id == session_id) {
+            return active.timeline.pending_approvals.first().cloned();
+        }
+        self.sessions_awaiting_approval
+            .get(session_id)
+            .and_then(|requests| requests.first())
+            .cloned()
     }
 
     /// Number of active or parked sessions with a provider turn in flight.
@@ -4135,6 +4162,35 @@ impl AppState {
             timeline.usage.as_ref(),
         );
         self.deliver_orchestrate_callback_to_parent(&parent_id, text, cx);
+    }
+
+    fn deliver_child_approval_callback(
+        &mut self,
+        child_id: &str,
+        request: &agent::ApprovalRequest,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(child) = self
+            .sessions
+            .iter()
+            .find(|meta| meta.id == child_id && meta.parent_session_id.is_some())
+            .cloned()
+        else {
+            return;
+        };
+        if !self
+            .callback_approval_requests
+            .insert((child_id.to_string(), request.id.clone()))
+        {
+            return;
+        }
+        let parent_id = child.parent_session_id.as_deref().unwrap();
+        let text = format!(
+            "[orchestrate] thread {child_id} (\"{}\") is waiting for approval: {}.",
+            child.title,
+            approval_request_summary(request)
+        );
+        self.deliver_orchestrate_callback_to_parent(parent_id, text, cx);
     }
 
     /// Deliver a child result into the orchestrator's current reasoning turn.
@@ -5154,6 +5210,7 @@ impl AppState {
         }
 
         if let AgentEvent::SessionClosed { reason } = &event {
+            self.sessions_awaiting_approval.remove(session_id);
             self.close_orchestrator_children(session_id);
             let is_active = self.active_session_id() == Some(session_id);
             if !is_active {
@@ -5313,10 +5370,17 @@ impl AppState {
             _ => {}
         }
 
+        self.track_pending_approval_event(session_id, &event);
         self.record_event(session_id, &event, cx);
 
-        if let AgentEvent::TurnCompleted { status, .. } = &event {
-            self.deliver_child_callback(session_id, *status, cx);
+        match &event {
+            AgentEvent::TurnCompleted { status, .. } => {
+                self.deliver_child_callback(session_id, *status, cx);
+            }
+            AgentEvent::ApprovalRequested(request) => {
+                self.deliver_child_approval_callback(session_id, request, cx);
+            }
+            _ => {}
         }
 
         // Plan surfaces: a fresh proposed plan re-arms the composer's plan-ready
@@ -5412,6 +5476,32 @@ impl AppState {
         }
 
         cx.notify();
+    }
+
+    fn track_pending_approval_event(&mut self, session_id: &str, event: &AgentEvent) {
+        match event {
+            AgentEvent::ApprovalRequested(request) => {
+                let requests = self
+                    .sessions_awaiting_approval
+                    .entry(session_id.to_string())
+                    .or_default();
+                if !requests.iter().any(|pending| pending.id == request.id) {
+                    requests.push(request.clone());
+                }
+            }
+            AgentEvent::ApprovalResolved { request_id, .. } => {
+                if let Some(requests) = self.sessions_awaiting_approval.get_mut(session_id) {
+                    requests.retain(|request| request.id != *request_id);
+                    if requests.is_empty() {
+                        self.sessions_awaiting_approval.remove(session_id);
+                    }
+                }
+            }
+            AgentEvent::TurnCompleted { .. } => {
+                self.sessions_awaiting_approval.remove(session_id);
+            }
+            _ => {}
+        }
     }
 
     /// Append to JSONL + fold into the active timeline (if it's this session).
@@ -5543,6 +5633,9 @@ impl AppState {
 
     pub fn shutdown_active(&mut self) {
         self.persist_terminal_preferences();
+        if let Some(session_id) = self.active_session_id().map(str::to_string) {
+            self.sessions_awaiting_approval.remove(&session_id);
+        }
         if let Some(active) = self.active.take()
             && let Runtime::Live(commands) = active.runtime
         {
@@ -5594,6 +5687,7 @@ impl AppState {
 
     /// Shut down and forget a parked session (archive/delete paths).
     fn drop_background(&mut self, session_id: &str) {
+        self.sessions_awaiting_approval.remove(session_id);
         if let Some(parked) = self.background.remove(session_id)
             && let Runtime::Live(commands) = parked.runtime
         {
@@ -5770,7 +5864,7 @@ fn resolve_dispatch_access(access: Option<&str>) -> Result<ApprovalMode, String>
     };
     match access.to_ascii_lowercase().as_str() {
         "full" => Ok(ApprovalMode::FullAccess),
-        "read_only" => Ok(ApprovalMode::Supervised),
+        "read_only" => Ok(ApprovalMode::ReadOnly),
         "workspace_write" => Ok(ApprovalMode::AutoAcceptEdits),
         _ => Err(format!(
             "unknown access: {access}; expected read_only, workspace_write, or full"
@@ -5841,6 +5935,25 @@ fn final_assistant_message(timeline: &Timeline) -> String {
 fn tail_chars(text: &str, max: usize) -> String {
     let count = text.chars().count();
     text.chars().skip(count.saturating_sub(max)).collect()
+}
+
+fn approval_request_summary(request: &agent::ApprovalRequest) -> String {
+    let detail = match &request.kind {
+        agent::ApprovalKind::ExecCommand { command, .. } => format!("command `{command}`"),
+        agent::ApprovalKind::FileRead { detail } => format!("file read `{detail}`"),
+        agent::ApprovalKind::FileChange { changes, .. } => match changes.as_slice() {
+            [change] => format!("file change `{}`", change.path),
+            changes => format!("{} file changes", changes.len()),
+        },
+        agent::ApprovalKind::ToolUse { name, .. } => format!("tool `{name}`"),
+    };
+    let one_line = detail.split_whitespace().collect::<Vec<_>>().join(" ");
+    let truncated: String = one_line.chars().take(180).collect();
+    if one_line.chars().count() > 180 {
+        format!("{truncated}…")
+    } else {
+        truncated
+    }
 }
 
 fn token_usage_json(usage: &agent::TokenUsage) -> serde_json::Value {
@@ -6634,7 +6747,7 @@ mod tests {
         );
         assert_eq!(
             resolve_dispatch_access(Some("read_only")),
-            Ok(ApprovalMode::Supervised)
+            Ok(ApprovalMode::ReadOnly)
         );
         assert_eq!(
             resolve_dispatch_access(Some("WORKSPACE_WRITE")),
@@ -7430,6 +7543,59 @@ mod tests {
         assert!(failed.starts_with("[orchestrate] thread child (\"Title\") failed. tokens:"));
         assert!(failed.ends_with("\ndone"));
         assert!(failed.contains("tokens: input 100 (+25 cached), output 40, total 165."));
+    }
+
+    #[gpui::test]
+    fn child_approval_request_sends_exactly_one_parent_callback(cx: &mut gpui::TestAppContext) {
+        let root = std::env::temp_dir().join(format!(
+            "tcode-orchestrate-approval-callback-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let store = SessionStore::open_at(root.clone()).unwrap();
+        let state = cx.new(|_| AppState::new(store));
+        let (commands, receiver) = async_channel::unbounded();
+
+        state.update(cx, |state, cx| {
+            let mut parent = live_session(ProviderKind::Codex, commands);
+            parent.meta.id = "parent".into();
+            parent.turn_in_flight = true;
+            state.background.insert(parent.meta.id.clone(), parent);
+
+            let mut child =
+                SessionMeta::new(ProviderKind::Codex, PathBuf::from("/tmp/project"), None);
+            child.id = "child".into();
+            child.title = "Read-only review".into();
+            child.parent_session_id = Some("parent".into());
+            state.sessions.push(child.clone());
+
+            let request = agent::ApprovalRequest {
+                id: "approval-1".into(),
+                turn_id: Some("turn-1".into()),
+                kind: agent::ApprovalKind::ExecCommand {
+                    command: "touch blocked".into(),
+                    cwd: Some("/tmp/project".into()),
+                    reason: None,
+                },
+                options: Vec::new(),
+            };
+            state.on_event("child", AgentEvent::ApprovalRequested(request.clone()), cx);
+            state.on_event("child", AgentEvent::ApprovalRequested(request), cx);
+
+            let SessionCommand::Steer { text, .. } = receiver.try_recv().unwrap() else {
+                panic!("approval callback did not steer the parent")
+            };
+            assert!(text.starts_with("[orchestrate] thread child"));
+            assert!(text.contains("waiting for approval: command `touch blocked`"));
+            assert!(receiver.try_recv().is_err(), "callback was delivered twice");
+
+            let status = state.child_status_json(&child);
+            assert_eq!(
+                status["waiting_approval"],
+                serde_json::json!("command `touch blocked`")
+            );
+        });
+
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -180,6 +180,12 @@ const APPROVAL_MODES: [(ApprovalMode, &str, &str, &str); 3] = [
 ];
 
 fn approval_mode_meta(mode: ApprovalMode) -> (String, String, &'static str) {
+    // ReadOnly is dispatch-only for now. A selected child still needs a stable
+    // chip, but it must not add a fourth choice to the user-facing picker.
+    let mode = match mode {
+        ApprovalMode::ReadOnly => ApprovalMode::Supervised,
+        mode => mode,
+    };
     let (_, label_key, description_key, icon) = APPROVAL_MODES
         .iter()
         .find(|(m, ..)| *m == mode)

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -13,6 +13,7 @@ use gpui_component::{
     input::{Input, InputEvent, InputState},
     menu::ContextMenuExt as _,
     scroll::ScrollableElement as _,
+    tooltip::Tooltip,
     v_flex,
 };
 use serde::Deserialize;
@@ -812,6 +813,11 @@ impl SessionsSidebar {
         let row_key = format!("thread-{session_id}");
         let ago = humanize_ago(now_secs().saturating_sub(meta.updated_at));
         let unread = self.app_state.read(cx).session_unread(&session_id);
+        let waiting_for_approval = self
+            .app_state
+            .read(cx)
+            .pending_approval_for(&session_id)
+            .is_some();
         let is_worktree = meta.worktree.is_some();
         let render_state = {
             let state = self.app_state.read(cx);
@@ -868,7 +874,29 @@ impl SessionsSidebar {
                     cx.notify();
                 }
             }))
-            .when(working, |row| {
+            .when(waiting_for_approval, |row| {
+                row.tooltip(|window, cx| {
+                    Tooltip::new(tcode_i18n::tr!("sidebar.waiting_approval_tooltip").into_owned())
+                        .build(window, cx)
+                })
+            })
+            .when(waiting_for_approval, |row| {
+                row.child(
+                    h_flex()
+                        .flex_none()
+                        .items_center()
+                        .gap_1()
+                        .child(div().size(px(6.)).rounded_full().bg(cx.theme().warning))
+                        .child(
+                            div()
+                                .whitespace_nowrap()
+                                .text_size(px(11.))
+                                .text_color(cx.theme().warning)
+                                .child(tcode_i18n::tr!("sidebar.waiting_approval")),
+                        ),
+                )
+            })
+            .when(working && !waiting_for_approval, |row| {
                 row.child(
                     h_flex()
                         .flex_none()

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -83,6 +83,8 @@ sidebar:
   show_more: "Show more"
   show_less: "Show less"
   working: "Working"
+  waiting_approval: "Approval"
+  waiting_approval_tooltip: "Waiting for approval"
   archive: "Archive thread"
   archive_title: "Archive thread?"
   archive_description: 'Archive "%{title}" and its saved conversation? This cannot be undone.'

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -83,6 +83,8 @@ sidebar:
   show_more: "显示更多"
   show_less: "收起"
   working: "工作中"
+  waiting_approval: "待审批"
+  waiting_approval_tooltip: "正在等待审批"
   archive: "归档对话"
   archive_title: "归档对话？"
   archive_description: "要归档“%{title}”及其已保存的对话吗？此操作无法撤销。"


### PR DESCRIPTION
## Problem

Orchestrate children dispatched with `access: read_only` mapped to `ApprovalMode::Supervised`, whose provider knobs ask for everything — codex's `("untrusted", "read-only")` prompts even for read-only commands — so children hung waiting for approval from their very first action, with zero indication in the sidebar or to the parent orchestrator. Blocked children looked identical to running ones.

## Changes

**New `ApprovalMode::ReadOnly`** — read-only actions run without prompts; anything that mutates pauses for approval. `Supervised` is untouched (it remains the interactive ask-me mode), and the composer picker does not grow a fourth option.

- **codex**: `("on-request", "read-only")` — commands run freely inside the read-only sandbox; escalations prompt (consistent with `workspace_write`'s existing `on-request` policy).
- **claude**: launches in `default` permission mode — the CLI natively auto-approves its read tools, and no plan-mode behavior skew is introduced. The mapper additionally auto-allows `can_use_tool` requests the CLI classifies as file reads; everything else (all bash, edits, other tools) surfaces the normal approval.
- **acp**: selects the agent's advertised plan mode when available; warns and stays least-privilege otherwise.

**Blocked children are now visible**:
- Sidebar rows show a localized waiting-approval badge (en + zh-CN), backed by an incrementally maintained in-memory map — no store reads on the render path.
- The orchestrate `status` tool reports a `waiting_approval` summary of the blocked action.
- The parent thread receives exactly one `[orchestrate]` callback per approval request id, so orchestrators no longer mistake a blocked child for a running one.

## Verification

- Live probe (new `crates/agent/examples/read_only_probe.rs`), run against BOTH installed CLIs: a ReadOnly session completes a read prompt with zero `ApprovalRequested` events, and a write attempt surfaces exactly one approval (not approved; session shut down).
- Unit tests: knob/flag mappings for ReadOnly, mapper allow/deny under ReadOnly, `resolve_dispatch_access`, and a gpui test asserting one-parent-callback-per-approval-id plus the `waiting_approval` status field.
- `cargo test --workspace` green; `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)