### PR TITLE
Keep Claude background terminal tasks in the active turn

### DIFF
--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -797,6 +797,7 @@ fn user_message(text: &str, attachments: &[Attachment]) -> Value {
 enum ToolItem {
     Command {
         command: String,
+        output: String,
     },
     File {
         changes: Vec<FileChange>,
@@ -890,6 +891,16 @@ pub(crate) struct Mapper {
     pending_steers: VecDeque<String>,
     /// Once the CLI exposes request checkpoints, never use the legacy fallback.
     saw_requesting: bool,
+    /// Claude may return the turn-level `result` while a Bash command continues
+    /// as a background task. Keep those task ids authoritative so the app does
+    /// not expose a new turn until the command really stops.
+    background_tasks: HashSet<String>,
+    /// Bash tasks which were observed in `background_tasks_changed`, retained
+    /// until their final notification so the command card can be completed.
+    background_task_history: HashSet<String>,
+    /// A successful turn result held while one or more background Bash tasks
+    /// still belong to that turn.
+    pending_turn_completion: Vec<AgentEvent>,
 }
 
 impl Mapper {
@@ -918,6 +929,9 @@ impl Mapper {
             cumulative_processed: 0,
             pending_steers: VecDeque::new(),
             saw_requesting: false,
+            background_tasks: HashSet::new(),
+            background_task_history: HashSet::new(),
+            pending_turn_completion: Vec::new(),
         }
     }
 
@@ -1159,6 +1173,7 @@ impl Mapper {
             Some("task_started") => return self.on_task_started(msg),
             Some("task_updated") => return self.on_task_updated(msg),
             Some("task_notification") => return self.on_task_notification(msg),
+            Some("background_tasks_changed") => return self.on_background_tasks_changed(msg),
             other => {
                 log::debug!("claude: ignoring system/{other:?}");
                 return Vec::new();
@@ -1201,17 +1216,34 @@ impl Mapper {
         if let Some(task_id) = msg.get("task_id").and_then(Value::as_str) {
             self.task_tools
                 .insert(task_id.to_owned(), tool_use_id.to_owned());
-            self.tail_requests.push(TailRequest::Start {
-                parent_id: tool_use_id.to_owned(),
-                task_id: task_id.to_owned(),
-                session_id: msg
-                    .get("session_id")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .to_owned(),
-            });
+            if msg.get("task_type").and_then(Value::as_str) != Some("local_bash") {
+                self.tail_requests.push(TailRequest::Start {
+                    parent_id: tool_use_id.to_owned(),
+                    task_id: task_id.to_owned(),
+                    session_id: msg
+                        .get("session_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_owned(),
+                });
+            }
         }
         self.update_subagent(tool_use_id, ItemStatus::InProgress, None, false)
+    }
+
+    fn on_background_tasks_changed(&mut self, msg: &Value) -> Vec<AgentEvent> {
+        let current: HashSet<String> = msg
+            .get("tasks")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter(|task| task.get("task_type").and_then(Value::as_str) == Some("local_bash"))
+            .filter_map(|task| task.get("task_id").and_then(Value::as_str))
+            .map(str::to_owned)
+            .collect();
+        self.background_task_history.extend(current.iter().cloned());
+        self.background_tasks = current;
+        self.finish_pending_turn_if_idle()
     }
 
     fn on_task_updated(&mut self, msg: &Value) -> Vec<AgentEvent> {
@@ -1234,6 +1266,10 @@ impl Mapper {
     }
 
     fn on_task_notification(&mut self, msg: &Value) -> Vec<AgentEvent> {
+        let task_id = msg
+            .get("task_id")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
         let tool_use_id = msg
             .get("tool_use_id")
             .and_then(Value::as_str)
@@ -1244,8 +1280,14 @@ impl Mapper {
                     .and_then(|task_id| self.task_tools.get(task_id).cloned())
             });
         let Some(tool_use_id) = tool_use_id else {
-            return Vec::new();
+            return self.finish_pending_turn_if_idle();
         };
+        let is_background_bash = task_id
+            .as_ref()
+            .is_some_and(|id| self.background_task_history.remove(id));
+        if let Some(task_id) = &task_id {
+            self.background_tasks.remove(task_id);
+        }
         if let Some(path) = msg.get("output_file").and_then(Value::as_str) {
             self.tail_requests.push(TailRequest::PreferPath {
                 parent_id: tool_use_id.clone(),
@@ -1264,7 +1306,51 @@ impl Mapper {
             .get("summary")
             .and_then(Value::as_str)
             .map(one_line_summary);
-        self.update_subagent(&tool_use_id, status, summary, false)
+        let mut events = if is_background_bash {
+            self.complete_background_command(&tool_use_id, status, summary)
+        } else {
+            self.update_subagent(&tool_use_id, status, summary, false)
+        };
+        events.extend(self.finish_pending_turn_if_idle());
+        events
+    }
+
+    fn complete_background_command(
+        &mut self,
+        tool_use_id: &str,
+        status: ItemStatus,
+        summary: Option<String>,
+    ) -> Vec<AgentEvent> {
+        let Some(ToolItem::Command {
+            command,
+            mut output,
+        }) = self.tool_items.remove(tool_use_id)
+        else {
+            return Vec::new();
+        };
+        if output.trim().is_empty()
+            && let Some(summary) = summary
+        {
+            output = summary;
+        }
+        vec![AgentEvent::ItemCompleted(ThreadItem {
+            id: tool_use_id.to_owned(),
+            parent_item_id: None,
+            content: ItemContent::CommandExecution {
+                command,
+                output,
+                exit_code: (status == ItemStatus::Completed).then_some(0),
+                status,
+            },
+        })]
+    }
+
+    fn finish_pending_turn_if_idle(&mut self) -> Vec<AgentEvent> {
+        if self.background_tasks.is_empty() {
+            std::mem::take(&mut self.pending_turn_completion)
+        } else {
+            Vec::new()
+        }
     }
 
     fn update_subagent(
@@ -1507,6 +1593,7 @@ impl Mapper {
             (
                 ToolItem::Command {
                     command: command.clone(),
+                    output: String::new(),
                 },
                 ItemContent::CommandExecution {
                     command,
@@ -1567,6 +1654,10 @@ impl Mapper {
                 Some(id) => id.to_string(),
                 None => continue,
             };
+            let background_task_id = msg
+                .pointer("/tool_use_result/backgroundTaskId")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
             let item = match self.tool_items.remove(&tool_use_id) {
                 Some(i) => i,
                 None => continue,
@@ -1582,7 +1673,26 @@ impl Mapper {
                 ItemStatus::Completed
             };
             let content = match item {
-                ToolItem::Command { command } => ItemContent::CommandExecution {
+                ToolItem::Command { command, .. } if background_task_id.is_some() => {
+                    self.tool_items.insert(
+                        tool_use_id.clone(),
+                        ToolItem::Command {
+                            command: command.clone(),
+                            output: output.clone(),
+                        },
+                    );
+                    if let Some(task_id) = background_task_id {
+                        self.background_tasks.insert(task_id.clone());
+                        self.background_task_history.insert(task_id);
+                    }
+                    ItemContent::CommandExecution {
+                        command,
+                        output,
+                        exit_code: None,
+                        status: ItemStatus::InProgress,
+                    }
+                }
+                ToolItem::Command { command, .. } => ItemContent::CommandExecution {
                     command,
                     output,
                     exit_code: if is_error { Some(1) } else { Some(0) },
@@ -1607,7 +1717,18 @@ impl Mapper {
                         .or_else(|| (!output.trim().is_empty()).then(|| one_line_summary(&output))),
                 },
             };
-            out.push(AgentEvent::ItemCompleted(ThreadItem {
+            let event = if matches!(
+                &content,
+                ItemContent::CommandExecution {
+                    status: ItemStatus::InProgress,
+                    ..
+                }
+            ) {
+                AgentEvent::ItemUpdated
+            } else {
+                AgentEvent::ItemCompleted
+            };
+            out.push(event(ThreadItem {
                 id: tool_use_id,
                 parent_item_id: None,
                 content,
@@ -1807,7 +1928,12 @@ impl Mapper {
             status,
             usage,
         });
-        events
+        if self.background_tasks.is_empty() || status != TurnStatus::Completed {
+            events
+        } else {
+            self.pending_turn_completion = events;
+            Vec::new()
+        }
     }
 }
 
@@ -1818,7 +1944,9 @@ fn is_file_tool(name: &str) -> bool {
 fn subagent_status(status: &str) -> ItemStatus {
     match status {
         "completed" | "done" | "succeeded" => ItemStatus::Completed,
-        "failed" | "error" | "cancelled" | "canceled" => ItemStatus::Failed,
+        "failed" | "error" | "cancelled" | "canceled" | "stopped" | "killed" | "interrupted" => {
+            ItemStatus::Failed
+        }
         _ => ItemStatus::InProgress,
     }
 }
@@ -3004,6 +3132,115 @@ mod tests {
             },
             other => panic!("expected ItemCompleted, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn background_bash_keeps_turn_running_until_task_stops() {
+        let mut m = Mapper::new();
+        let turn_id = m.start_turn();
+
+        let started = feed(
+            &mut m,
+            r#"{"type":"assistant","message":{"id":"msg-bg","content":[{"type":"tool_use","id":"toolu-bg","name":"Bash","input":{"command":"sleep 30","run_in_background":true}}]}}"#,
+        );
+        assert!(matches!(
+            &started[0],
+            AgentEvent::ItemStarted(ThreadItem {
+                content: ItemContent::CommandExecution {
+                    status: ItemStatus::InProgress,
+                    ..
+                },
+                ..
+            })
+        ));
+
+        assert!(
+            feed(
+                &mut m,
+                r#"{"type":"system","subtype":"background_tasks_changed","tasks":[{"task_id":"bg-1","task_type":"local_bash","description":"sleep"}]}"#,
+            )
+            .is_empty()
+        );
+        assert!(
+            feed(
+                &mut m,
+                r#"{"type":"system","subtype":"task_started","task_id":"bg-1","tool_use_id":"toolu-bg","task_type":"local_bash"}"#,
+            )
+            .is_empty()
+        );
+        let running = feed(
+            &mut m,
+            r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu-bg","content":"Command running in background with ID: bg-1"}]},"tool_use_result":{"backgroundTaskId":"bg-1"}}"#,
+        );
+        assert!(matches!(
+            &running[0],
+            AgentEvent::ItemUpdated(ThreadItem {
+                content: ItemContent::CommandExecution {
+                    status: ItemStatus::InProgress,
+                    exit_code: None,
+                    ..
+                },
+                ..
+            })
+        ));
+
+        // Claude ends its model turn as soon as it launches the process. The
+        // canonical turn must stay open while that process is still listed.
+        let result = feed(
+            &mut m,
+            r#"{"type":"result","subtype":"success","is_error":false}"#,
+        );
+        assert!(result.is_empty());
+
+        let finished = feed(
+            &mut m,
+            r#"{"type":"system","subtype":"background_tasks_changed","tasks":[]}"#,
+        );
+        assert!(matches!(
+            &finished[0],
+            AgentEvent::TurnCompleted {
+                turn_id: completed,
+                status: TurnStatus::Completed,
+                ..
+            } if completed == &turn_id
+        ));
+    }
+
+    #[test]
+    fn background_bash_notification_completes_command_card() {
+        let mut m = Mapper::new();
+        feed(
+            &mut m,
+            r#"{"type":"assistant","message":{"id":"msg-bg","content":[{"type":"tool_use","id":"toolu-bg","name":"Bash","input":{"command":"sleep 30","run_in_background":true}}]}}"#,
+        );
+        feed(
+            &mut m,
+            r#"{"type":"system","subtype":"background_tasks_changed","tasks":[{"task_id":"bg-1","task_type":"local_bash"}]}"#,
+        );
+        feed(
+            &mut m,
+            r#"{"type":"system","subtype":"task_started","task_id":"bg-1","tool_use_id":"toolu-bg","task_type":"local_bash"}"#,
+        );
+        feed(
+            &mut m,
+            r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu-bg","content":"Command running in background with ID: bg-1"}]},"tool_use_result":{"backgroundTaskId":"bg-1"}}"#,
+        );
+
+        let finished = feed(
+            &mut m,
+            r#"{"type":"system","subtype":"task_notification","task_id":"bg-1","tool_use_id":"toolu-bg","status":"completed","summary":"sleep finished"}"#,
+        );
+        assert!(matches!(
+            &finished[0],
+            AgentEvent::ItemCompleted(ThreadItem {
+                content: ItemContent::CommandExecution {
+                    status: ItemStatus::Completed,
+                    exit_code: Some(0),
+                    ..
+                },
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -434,6 +434,10 @@ fn mime_from_path(path: &std::path::Path) -> String {
 pub struct Composer {
     app_state: Entity<AppState>,
     input: Entity<InputState>,
+    /// Dedicated free-form answer field shown inside an agent question card.
+    /// Keeping it separate from the turn composer makes the pending question
+    /// and the destination of typed text unambiguous.
+    user_input_custom: Entity<InputState>,
     /// Unsent text is isolated by persisted thread or project New thread page.
     text_cache: ComposerTextCache,
     model_search: Entity<InputState>,
@@ -504,6 +508,11 @@ impl Composer {
         let model_search = cx.new(|cx| {
             InputState::new(window, cx).placeholder(tcode_i18n::tr!("composer.search_models"))
         });
+        let user_input_custom = cx.new(|cx| {
+            InputState::new(window, cx)
+                .submit_on_enter(true)
+                .placeholder(tcode_i18n::tr!("userinput.custom_placeholder"))
+        });
 
         let subscriptions = vec![
             // Re-render when app state changes (e.g. the provider's commands /
@@ -539,6 +548,17 @@ impl Composer {
                     _ => {}
                 }
             }),
+            cx.subscribe_in(
+                &user_input_custom,
+                window,
+                |this, input, event, window, cx| match event {
+                    InputEvent::PressEnter { shift: false, .. } => {
+                        this.submit_custom_user_input(input, window, cx);
+                    }
+                    InputEvent::Change => cx.notify(),
+                    _ => {}
+                },
+            ),
             // Live-filter the model picker as the user types in its search box.
             cx.subscribe(&model_search, |_, _, event, cx| {
                 if matches!(event, InputEvent::Change) {
@@ -550,6 +570,7 @@ impl Composer {
         Self {
             app_state,
             input,
+            user_input_custom,
             text_cache: ComposerTextCache::default(),
             model_search,
             picker_rail: None,
@@ -649,26 +670,8 @@ impl Composer {
         // While a user-input question is pending, normal send is suppressed
         // (S1 §7). Typed text becomes the current question's custom answer and
         // flows through the same advance-or-submit path as clicking an option.
-        if let Some((request_id, questions)) = self.pending_user_input(cx) {
-            let text = input.read(cx).value().trim().to_string();
-            if text.is_empty() {
-                return;
-            }
-            let index = self
-                .ui_question_index
-                .min(questions.len().saturating_sub(1));
-            if let Some(question) = questions.get(index) {
-                let entry = self.ui_selections.entry(question.id.clone()).or_default();
-                if question.multi_select {
-                    entry.push(text);
-                } else {
-                    *entry = vec![text];
-                }
-            }
-            self.input
-                .update(cx, |state, cx| state.set_value("", window, cx));
-            self.ui_advance_or_submit(&questions, request_id, window, cx);
-            cx.notify();
+        if self.pending_user_input(cx).is_some() {
+            self.submit_custom_user_input(input, window, cx);
             return;
         }
         let text = input.read(cx).value().trim().to_string();
@@ -2055,7 +2058,7 @@ impl Composer {
 
     /// Keep the per-request question state in sync: reset the index/selections
     /// when a new request arrives (or the pending one resolves).
-    fn sync_user_input_state(&mut self, cx: &mut Context<Self>) {
+    fn sync_user_input_state(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let current = self.app_state.read(cx).active.as_ref().and_then(|a| {
             a.timeline
                 .pending_user_input
@@ -2066,6 +2069,9 @@ impl Composer {
             self.ui_request_id = current;
             self.ui_question_index = 0;
             self.ui_selections.clear();
+            self.user_input_custom.update(cx, |state, cx| {
+                state.set_value("", window, cx);
+            });
         }
     }
 
@@ -2207,6 +2213,52 @@ impl Composer {
             .overflow_y_scroll()
             .child(options_content);
 
+        let custom_input = self.user_input_custom.clone();
+        let custom_has_text = !custom_input.read(cx).value().trim().is_empty();
+        let custom_answer =
+            h_flex()
+                .w_full()
+                .items_center()
+                .gap_2()
+                .px_2()
+                .py_1()
+                .rounded(px(8.))
+                .border_1()
+                .border_color(cx.theme().input)
+                .bg(cx.theme().popover)
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w_0()
+                        .child(Input::new(&self.user_input_custom).appearance(false)),
+                )
+                .child(
+                    div()
+                        .id("ui-custom-answer-submit")
+                        .size(px(28.))
+                        .rounded_full()
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .bg(if custom_has_text {
+                            cx.theme().primary
+                        } else {
+                            cx.theme().muted
+                        })
+                        .cursor_pointer()
+                        .when(custom_has_text, |this| this.hover(|this| this.opacity(0.9)))
+                        .child(Icon::new(IconName::ArrowUp).xsmall().text_color(
+                            if custom_has_text {
+                                cx.theme().primary_foreground
+                            } else {
+                                cx.theme().muted_foreground
+                            },
+                        ))
+                        .on_click(cx.listener(move |this, _, window, cx| {
+                            this.submit_custom_user_input(&custom_input, window, cx);
+                        })),
+                );
+
         // Actions row: navigation only. Answers submit themselves — a
         // single-select click that completes the set submits it, so the only
         // finishing affordance left is Done on a multi-select question (clicks
@@ -2283,6 +2335,7 @@ impl Composer {
             .child(header)
             .child(div().text_size(px(15.)).child(question.question.clone()))
             .child(options)
+            .child(custom_answer)
             .when(multi, |this| {
                 this.child(
                     div()
@@ -2313,6 +2366,35 @@ impl Composer {
         } else {
             *entry = vec![label];
         }
+        cx.notify();
+    }
+
+    fn submit_custom_user_input(
+        &mut self,
+        input: &Entity<InputState>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some((request_id, questions)) = self.pending_user_input(cx) else {
+            return;
+        };
+        let text = input.read(cx).value().trim().to_string();
+        if text.is_empty() {
+            return;
+        }
+        let index = self
+            .ui_question_index
+            .min(questions.len().saturating_sub(1));
+        if let Some(question) = questions.get(index) {
+            let entry = self.ui_selections.entry(question.id.clone()).or_default();
+            if question.multi_select {
+                entry.push(text);
+            } else {
+                *entry = vec![text];
+            }
+        }
+        input.update(cx, |state, cx| state.set_value("", window, cx));
+        self.ui_advance_or_submit(&questions, request_id, window, cx);
         cx.notify();
     }
 
@@ -2366,7 +2448,7 @@ impl Composer {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let custom = self.input.read(cx).value().trim().to_string();
+        let custom = self.user_input_custom.read(cx).value().trim().to_string();
         let custom = if custom.is_empty() {
             None
         } else {
@@ -2378,7 +2460,7 @@ impl Composer {
             self.ui_question_index,
             custom,
         );
-        self.input
+        self.user_input_custom
             .update(cx, |state, cx| state.set_value("", window, cx));
         self.ui_selections.clear();
         self.ui_question_index = 0;
@@ -2942,7 +3024,7 @@ impl Composer {
 
 impl Render for Composer {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        self.sync_user_input_state(cx);
+        self.sync_user_input_state(window, cx);
         self.sync_images_session(cx);
         self.sync_text_destination(window, cx);
         self.apply_debug_seed(window, cx);

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -465,6 +465,7 @@ plan:
   saved_workspace: "Saved %{file}"
 userinput:
   question_count: "%{index}/%{total}"
+  custom_placeholder: "Type your own answer…"
   multi_hint: "Select one or more options."
   previous: "Previous"
   next_question: "Next question"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -458,6 +458,7 @@ plan:
   saved_workspace: "已保存 %{file}"
 userinput:
   question_count: "%{index}/%{total}"
+  custom_placeholder: "输入自定义答案…"
   multi_hint: "选择一个或多个选项。"
   previous: "上一个"
   next_question: "下一个问题"


### PR DESCRIPTION
## Summary
- hold Claude turn completion while background Bash tasks are still running
- keep background command cards in progress until their final task notification
- restore a dedicated custom-answer input inside user-question cards

## Verification
- cargo test --workspace --all-targets (all code/UI suites passed; two parallel PTY tests hit macOS error -6)
- cargo test -p term --lib -- --test-threads=1
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- live Claude provider probe with a background Bash command