### PR TITLE
ci: build macOS releases on macos-26 runners, realign traffic-light insets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
           - name: macOS arm64
-            os: macos-14
+            os: macos-26
           - name: Linux x64
             os: ubuntu-24.04
           - name: Windows x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,12 @@ jobs:
       matrix:
         include:
           - label: macOS arm64
-            os: macos-14
+            os: macos-26
             target: aarch64-apple-darwin
             platform: macos
             arch: arm64
           - label: macOS x64
-            os: macos-14
+            os: macos-26
             target: x86_64-apple-darwin
             platform: macos
             arch: x64

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -421,7 +421,7 @@ fn main() {
                 titlebar: Some(TitlebarOptions {
                     title: None,
                     appears_transparent: cfg!(target_os = "macos"),
-                    traffic_light_position: Some(point(px(12.), px(18.))),
+                    traffic_light_position: Some(point(px(12.), px(19.))),
                 }),
                 // macOS vibrancy: blur whatever is behind the window; theme
                 // background colors carry alpha so the material shows through.

--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -2382,7 +2382,7 @@ impl ChatView {
             .flex_shrink_0()
             .h(px(52.))
             .px_4()
-            .when(collapsed, |this| this.pl(px(36.)))
+            .when(collapsed, |this| this.pl(px(40.)))
             .gap_2()
             .items_center();
 

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -31,9 +31,9 @@ use crate::settings::{LANGUAGE_ENGLISH, LANGUAGE_SIMPLIFIED_CHINESE, Settings, T
 use crate::time::now_secs;
 use crate::window_drag_area;
 
-/// Left inset so branding clears the native macOS traffic lights.
+/// Left inset so branding clears the native macOS 26 traffic lights near x=72.
 #[cfg(target_os = "macos")]
-const TRAFFIC_LIGHT_INSET: f32 = 74.;
+const TRAFFIC_LIGHT_INSET: f32 = 80.;
 #[cfg(not(target_os = "macos"))]
 const TRAFFIC_LIGHT_INSET: f32 = 8.;
 

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -25,9 +25,9 @@ use crate::time::now_secs;
 use crate::window_drag_area;
 
 /// Left padding on the sidebar's top row so branding clears the native macOS
-/// traffic lights (positioned at ~(9, 9)); a small inset elsewhere.
+/// traffic lights (ending near x=72 on macOS 26); a small inset elsewhere.
 #[cfg(target_os = "macos")]
-const TRAFFIC_LIGHT_INSET: f32 = 74.;
+const TRAFFIC_LIGHT_INSET: f32 = 80.;
 #[cfg(not(target_os = "macos"))]
 const TRAFFIC_LIGHT_INSET: f32 = 8.;
 


### PR DESCRIPTION
## Problem

Release builds installed on macOS 26 show the legacy small traffic-light window buttons instead of the new larger ones.

Root cause: macOS 26 renders the new (Liquid Glass) traffic lights only for apps whose Mach-O `LC_BUILD_VERSION` records the **macOS 26 SDK**. The release workflow built on `macos-14` runners, which ship at most Xcode 16 (macOS 15 SDK), so released binaries record `sdk 15.x` and AppKit renders them in compatibility mode with the old small buttons. Verified locally: the same source built with Xcode 26.5 records `sdk 26.5` and gets the new buttons.

## Changes

**CI (`release.yml`, `ci.yml`)** — macOS jobs move from `macos-14` to `macos-26`:
- `macos-26` is GA since 2026-02-26 and ships Xcode 26, so release binaries link the macOS 26 SDK and get the new chrome automatically.
- The x64 build keeps cross-compiling from the arm64 runner (`--target x86_64-apple-darwin`), same as before; the Xcode 26 SDK still supports x86_64.
- Also moves off an image that is deprecated as of 2026-07-06 and retires 2026-11-02 (brownouts start October).

**UI insets** — measured the new traffic-light geometry on macOS 26.5 (14pt buttons, 60pt-wide group ending at x=72pt with the existing placement) and adjusted the four constants tuned for the old 12pt buttons:
- `crates/app/src/main.rs`: `traffic_light_position` y 18 → 19, so the 14pt buttons sit exactly centered in the 52px top strip.
- `crates/ui/src/sidebar.rs` / `settings_page.rs`: `TRAFFIC_LIGHT_INSET` 74 → 80, keeping ~8pt clearance for the branding next to the wider group.
- `crates/ui/src/chat.rs`: collapsed-sidebar header inset 36 → 40 for the same reason.
- Non-macOS inset values unchanged.

## Verification

- `cargo build --release --locked` (LTO thin + strip, same as CI): `otool -l` shows `LC_BUILD_VERSION sdk 26.5`.
- Dry-ran the `release.yml` macOS packaging steps locally (Info.plist lint, `ditto` zip, `hdiutil` DMG) — all pass.
- Visual check with before/after screenshots of the expanded sidebar, collapsed sidebar, and settings page: branding/title clear the new light group by ~8pt and the group is vertically centered in the top strip.
- `cargo fmt --all --check` and `cargo check` pass.

## Notes

- `macos-latest` intentionally not used: the label only finished migrating to macOS 26 around 2026-07-15 and will drift again; pinning `macos-26` keeps the linked SDK deterministic.
- On pre-26 macOS the 1pt position nudge and 6pt wider inset are visually harmless (slightly more breathing room next to the old smaller buttons).

Co-Authored-By: kimi