### PR TITLE
fix(ui): keep disclosure card chrome fixed while its content scrolls

### DIFF
--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -23,7 +23,6 @@ use gpui_component::{
     input::{Input, InputEvent, InputState},
     notification::Notification,
     popover::Popover,
-    scroll::ScrollableElement as _,
     text::{TextView, TextViewState},
     tooltip::Tooltip,
     v_flex,
@@ -43,11 +42,13 @@ use crate::terminal_drawer::TerminalDrawer;
 use crate::time::now_millis;
 use crate::window_drag_area;
 
-/// Content-column max width (T3 centers the timeline at ~760px).
-const CONTENT_MAX_WIDTH: f32 = 768.;
+/// Content-column max width (T3 centers the timeline at ~760px). Shared with
+/// the composer, which mirrors this column so the input aligns with the
+/// messages above it.
+pub(crate) const CONTENT_MAX_WIDTH: f32 = 768.;
 /// Minimum horizontal padding around the content column so bubbles/cards never
 /// clip when the chat region is narrowed (e.g. the diff panel is open).
-const CONTENT_MIN_PADDING: f32 = 24.;
+pub(crate) const CONTENT_MIN_PADDING: f32 = 24.;
 /// How many activity rows to show before the "+N previous log entrys" expander.
 const WORKLOG_VISIBLE_ROWS: usize = 2;
 
@@ -65,11 +66,8 @@ fn previous_logs_toggle_label(hidden: usize, expanded: bool) -> Option<Cow<'stat
 /// Height reserved under every message for its (hover-revealed) action row, so
 /// revealing it never shifts the timeline.
 const ACTION_ROW_HEIGHT: f32 = 24.;
-/// Line height of the preformatted text inside an expanded disclosure card; also
-/// the per-line unit used to resolve the card's capped scroll viewport.
+/// Line height of the preformatted text inside an expanded disclosure card.
 const DISCLOSURE_LINE_HEIGHT: f32 = 20.;
-/// Vertical padding (top + bottom) added to a disclosure card's viewport estimate.
-const DISCLOSURE_CARD_PADDING: f32 = 24.;
 /// Cap on an expanded disclosure card's height; taller content scrolls within it.
 const DISCLOSURE_CARD_MAX_HEIGHT: f32 = 320.;
 /// Child-thread title budget in a callback disclosure row before it is ellipsized.
@@ -1262,7 +1260,7 @@ impl ChatView {
     /// The reusable disclosure element: a centered, collapsed-by-default row of
     /// 13px muted `label` + rotating chevron (hover shows an accent background);
     /// clicking toggles the per-entry expansion keyed by `key`. When open it
-    /// reveals `full_text` verbatim inside a bordered, height-capped scroll card.
+    /// reveals `full_text` verbatim inside a muted, height-capped scroll card.
     /// Shared by the orchestrate context split and child-thread callbacks so any
     /// future injected context can adopt the same affordance.
     fn render_disclosure(
@@ -1302,9 +1300,14 @@ impl ChatView {
 
     /// The expanded body of a disclosure: the injected text rendered verbatim
     /// (line by line, so newlines survive regardless of wrapping) as 13px muted
-    /// preformatted source inside a muted card. The guidance can be long,
-    /// so the card gets its own resolved-height, capped scroll viewport rather
-    /// than growing the turn without bound (DESIGN.md scrolling contract).
+    /// preformatted source inside a muted card. The guidance can be long, so the
+    /// card caps its height and the text scrolls INSIDE it — the card chrome
+    /// (fill, radius, padding) is a fixed shell that never moves (DESIGN.md
+    /// scrolling contract). Two nested divs are deliberate: gpui-component's
+    /// `overflow_y_scrollbar` wrapper strips the element's explicit height and
+    /// paints its background onto the scrolling content layer, which is what
+    /// made the whole rounded card slide and clip; `occlude` keeps wheel events
+    /// over the card from also reaching the timeline list behind it.
     fn render_disclosure_body(
         &self,
         key: &str,
@@ -1326,23 +1329,25 @@ impl ChatView {
                     .into_any_element()
             })
             .collect();
-        let line_count = lines.len() as f32;
-        let viewport = (line_count * DISCLOSURE_LINE_HEIGHT + DISCLOSURE_CARD_PADDING)
-            .min(DISCLOSURE_CARD_MAX_HEIGHT);
         div()
-            .id(SharedString::from(format!("disclosure-body-{key}")))
             .w_full()
-            .h(px(viewport))
-            .overflow_y_scrollbar()
-            .p_3()
             .rounded(crate::material::radius_card())
             .bg(cx.theme().muted)
+            .occlude()
+            .p_3()
             .child(
-                v_flex()
+                div()
+                    .id(SharedString::from(format!("disclosure-body-{key}")))
                     .w_full()
-                    .text_size(px(13.))
-                    .text_color(muted)
-                    .children(lines),
+                    .max_h(px(DISCLOSURE_CARD_MAX_HEIGHT))
+                    .overflow_y_scroll()
+                    .child(
+                        v_flex()
+                            .w_full()
+                            .text_size(px(13.))
+                            .text_color(muted)
+                            .children(lines),
+                    ),
             )
     }
 
@@ -4193,5 +4198,107 @@ mod tests {
         cx.update(|cx| md.sync("Stored reply. And more.".into(), false, cx));
         cx.run_until_parked();
         assert_eq!(rendered(&md.state, cx), "Stored reply. And more.\n");
+    }
+
+    /// The disclosure card's scroll contract: a fixed chrome shell (fill,
+    /// radius) whose height caps at the viewport, with the text scrolling
+    /// INSIDE it — and wheel events over the card never reach the timeline
+    /// list behind it (the "whole card gets clipped and scrolls with the chat"
+    /// regression). Mirrors `render_disclosure_body` nested in the virtualized
+    /// timeline `list`.
+    #[gpui::test]
+    fn disclosure_card_scrolls_internally_without_moving_the_list(cx: &mut TestAppContext) {
+        use gpui::{
+            Context, InteractiveElement as _, IntoElement, ListAlignment, ListState,
+            ParentElement as _, Render, ScrollDelta, ScrollHandle, ScrollWheelEvent,
+            StatefulInteractiveElement as _, Styled as _, Window, div, list, point, px, size,
+        };
+        use gpui_component::v_flex;
+
+        cx.update(gpui_component::init);
+        let cx = cx.add_empty_window();
+
+        let list_state = ListState::new(2, ListAlignment::Top, px(50.));
+        let card_scroll = ScrollHandle::new();
+
+        struct TestView {
+            list: ListState,
+            card: ScrollHandle,
+        }
+        impl Render for TestView {
+            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                let card = self.card.clone();
+                list(self.list.clone(), move |ix, _, _| {
+                    if ix == 0 {
+                        // Same shape as render_disclosure_body: an occluding
+                        // chrome shell around a capped native scroll viewport
+                        // holding 50 x 20px lines.
+                        div()
+                            .w_full()
+                            .debug_selector(|| "card-chrome".to_string())
+                            .occlude()
+                            .child(
+                                div()
+                                    .id("disclosure-body")
+                                    .w_full()
+                                    .max_h(px(100.))
+                                    .overflow_y_scroll()
+                                    .track_scroll(&card)
+                                    .debug_selector(|| "card-viewport".to_string())
+                                    .child(
+                                        v_flex().w_full().children(
+                                            (0..50).map(|i| {
+                                                div().h(px(20.)).child(format!("line {i}"))
+                                            }),
+                                        ),
+                                    ),
+                            )
+                            .into_any_element()
+                    } else {
+                        // Enough content below that the list itself can scroll.
+                        div().h(px(600.)).w_full().into_any_element()
+                    }
+                })
+                .w_full()
+                .h_full()
+            }
+        }
+
+        cx.draw(point(px(0.), px(0.)), size(px(400.), px(300.)), |_, cx| {
+            cx.new(|_| TestView {
+                list: list_state.clone(),
+                card: card_scroll.clone(),
+            })
+            .into_any_element()
+        });
+
+        // The viewport is capped even though its content is 1000px tall.
+        let viewport = cx
+            .debug_bounds("card-viewport")
+            .expect("card viewport should be painted");
+        assert_eq!(
+            viewport.size.height,
+            px(100.),
+            "the card must keep its fixed capped height"
+        );
+
+        // Wheel down over the card (which spans y 0..100 at the list top).
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(10.), px(50.)),
+            delta: ScrollDelta::Pixels(point(px(0.), px(-120.))),
+            ..Default::default()
+        });
+
+        assert!(
+            card_scroll.offset().y < px(0.),
+            "the card's content must scroll inside its fixed viewport, got {:?}",
+            card_scroll.offset()
+        );
+        let top = list_state.logical_scroll_top();
+        assert_eq!(
+            (top.item_ix, top.offset_in_item),
+            (0, px(0.)),
+            "the timeline list must not co-scroll under the card"
+        );
     }
 }

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -3233,25 +3233,23 @@ impl Render for Composer {
         );
 
         // The hero input surface (spec §5): 16px composer corners; resting =
-        // hairline `input.border` + `shadow_md`; focused = ring-colored border +
-        // the blue `focus_glow`. Focus is read off the field's own handle.
+        // hairline `input.border` + `shadow_md`. Focus only deepens the border
+        // to a neutral tone — the redesign's blue ring + glow read as garish
+        // against the frosted canvas and were reverted.
         let composer_focused = self.input.read(cx).focus_handle(cx).is_focused(window);
         let card = v_flex()
             .w_full()
             .rounded(crate::material::radius_composer())
             .border_1()
             .border_color(if composer_focused {
-                cx.theme().ring
+                cx.theme().foreground.opacity(0.35)
             } else {
                 cx.theme().input
             })
             // White console on paper (T3-grade fill): the glass `background`
             // token would render as a murky translucent wash here.
             .bg(cx.theme().popover)
-            .when(composer_focused, |this| {
-                this.shadow(crate::material::focus_glow(cx))
-            })
-            .when(!composer_focused, |this| this.shadow_md())
+            .shadow_md()
             // ⌘V with image clipboard content, and arrow/Escape trigger-menu
             // navigation (fires after the input's own key actions).
             .capture_key_down(cx.listener(|this, ev: &gpui::KeyDownEvent, window, cx| {
@@ -3326,13 +3324,17 @@ impl Render for Composer {
             })
             .child(control_row);
 
+        // Mirror the chat timeline's centered content column (same page
+        // padding, same max width) so the composer lines up with the messages
+        // above it instead of stretching edge to edge on wide windows.
         v_flex()
             .relative()
             .flex_shrink_0()
-            .px_4()
+            .w_full()
+            .items_center()
+            .px(px(crate::chat::CONTENT_MIN_PADDING))
             .pt_2()
             .pb_3()
-            .gap_2()
             // Shift+Tab toggles Build ↔ Plan (S1 §4).
             .on_key_down(cx.listener(|this, ev: &gpui::KeyDownEvent, _, cx| {
                 if ev.keystroke.key == "tab" && ev.keystroke.modifiers.shift {
@@ -3341,16 +3343,22 @@ impl Render for Composer {
                     cx.notify();
                 }
             }))
-            .when_some(approval, |this, request| {
-                this.child(self.render_approval_panel(&request, approval_count, cx))
-            })
-            .when_some(user_input, |this, (request_id, questions)| {
-                this.child(self.render_user_input_panel(request_id, questions, cx))
-            })
-            .children(self.render_trigger_menu(cx))
-            .children(self.render_queue_strip(cx))
-            .child(card)
-            .children(self.render_checkout_row(cx))
+            .child(
+                v_flex()
+                    .w_full()
+                    .max_w(px(crate::chat::CONTENT_MAX_WIDTH))
+                    .gap_2()
+                    .when_some(approval, |this, request| {
+                        this.child(self.render_approval_panel(&request, approval_count, cx))
+                    })
+                    .when_some(user_input, |this, (request_id, questions)| {
+                        this.child(self.render_user_input_panel(request_id, questions, cx))
+                    })
+                    .children(self.render_trigger_menu(cx))
+                    .children(self.render_queue_strip(cx))
+                    .child(card)
+                    .children(self.render_checkout_row(cx)),
+            )
             .children(self.render_image_preview(cx))
     }
 }

--- a/crates/ui/src/material.rs
+++ b/crates/ui/src/material.rs
@@ -4,11 +4,12 @@
 //! tier; reading surfaces sit on top of it at near-full opacity so body text
 //! never lands on the raw blur. Semantic colors stay on `cx.theme()` — this
 //! module owns the material tiers, the role-based radius scale, and the few
-//! light effects (faded hairlines, focus glow) the spec defines.
+//! light effects (faded hairlines, the primary-button top light) the spec
+//! defines.
 
 use gpui::{
-    App, BoxShadow, Div, Hsla, IntoElement, ParentElement as _, Pixels, Rgba, Styled as _, div,
-    linear_color_stop, linear_gradient, point, px,
+    App, Div, Hsla, IntoElement, ParentElement as _, Pixels, Rgba, Styled as _, div,
+    linear_color_stop, linear_gradient, px,
 };
 use gpui_component::ActiveTheme as _;
 
@@ -74,17 +75,6 @@ pub fn faded_hairline(cx: &App) -> impl IntoElement {
             linear_color_stop(clear, 1.),
             linear_color_stop(color, 0.),
         )))
-}
-
-/// The focused composer's blue outer glow (paired with the theme `ring`).
-pub fn focus_glow(cx: &App) -> Vec<BoxShadow> {
-    vec![BoxShadow {
-        color: cx.theme().primary.opacity(0.25),
-        offset: point(px(0.), px(0.)),
-        blur_radius: px(10.),
-        spread_radius: px(2.),
-        inset: false,
-    }]
 }
 
 /// Primary buttons get a faint top light so they read as physical controls:

--- a/docs/visual-redesign.md
+++ b/docs/visual-redesign.md
@@ -152,7 +152,7 @@ material.rs 常量，禁止再写魔法数字：
 
 - hover：T2 叠色浮现；禁止 hover 改变布局尺寸。
 - 选中：主色着色（token 表）。
-- focus：仅键盘可聚焦元素 ring；composer 额外 focus_glow。
+- focus：仅键盘可聚焦元素 ring；composer 仅加深中性描边（蓝色 ring + glow 已回退，磨砂画布上太刺眼）。
 - disabled：50% opacity。
 
 ## 8. 排版


### PR DESCRIPTION
## Summary

Fixes two nested-scroll regressions in the `/orchestrate` disclosure cards, plus composer polish following the Frosted Instrument redesign.

### Disclosure card scroll (`chat.rs`)

**Root causes:**
- The expanded card used gpui-component's `overflow_y_scrollbar` wrapper, which strips the element's explicit height (`h_auto().min_h_full()`) and leaves the background, radius, and padding on the *scrolling content layer*. The whole rounded card slid and clipped, instead of a fixed-height card whose content scrolls inside it.
- gpui dispatches wheel events to every scrollable hitbox under the mouse without stopping propagation, so the timeline list co-scrolled behind the card.

**Fix:** restructure to a fixed chrome shell (fill, radius, padding, `.occlude()`) around a native `overflow_y_scroll` viewport capped at 320px — the same pattern as the commit dialog's file list. The line-count viewport math is gone; `max_h` handles short and tall content natively.

**Regression test:** `disclosure_card_scrolls_internally_without_moving_the_list` replicates the card inside a virtualized `list` and asserts the full contract — capped viewport height, content scrolls internally, and the timeline list never co-scrolls.

### Composer (`composer.rs`, `material.rs`)

- **Focus restyle:** removed the blue ring border + `focus_glow` shadow on focus; focus now only deepens the border to a neutral tone. The blue glow read as garish on the frosted canvas. `focus_glow` is removed from the material module and the redesign spec is updated.
- **Width alignment:** the composer now mirrors the chat content column (shared 768px max width / 24px page padding) instead of stretching edge to edge on wide windows. Trigger menu, queue strip, and approval panels align with the card.

## Verification

- `cargo check` / `cargo clippy --all-targets`: clean
- `cargo test -p tcode-ui`: 103 passed (including the new regression test)
- Manual: expand an `/orchestrate` disclosure — the rounded card stays fixed, only its text scrolls, and the chat list no longer co-scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)