### PR TITLE
feat: user provider profiles in settings model pickers

### DIFF
--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -211,6 +211,10 @@ pub struct OrchestratorIdentity {
 pub struct OrchestrateChildModel {
     pub provider: ProviderKind,
     pub model: String,
+    /// Which provider profile (endpoint config) the dispatch launches against;
+    /// `None` = the kind's built-in profile.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
     /// Disabled profiles retain all routing preferences but cannot receive a
     /// dispatch and are omitted from the lead model's available-fleet table.
     #[serde(default = "default_true")]
@@ -294,6 +298,7 @@ impl Default for OrchestrateSettings {
                 OrchestrateChildModel {
                     provider: ProviderKind::Codex,
                     model: "gpt-5.6-sol".into(),
+                    profile_id: None,
                     enabled: true,
                     effort: Some("medium".into()),
                     description: DEFAULT_GPT_MEDIUM_CHILD_DEFINITION.into(),
@@ -301,6 +306,7 @@ impl Default for OrchestrateSettings {
                 OrchestrateChildModel {
                     provider: ProviderKind::Codex,
                     model: "gpt-5.6-sol".into(),
+                    profile_id: None,
                     enabled: true,
                     effort: Some("max".into()),
                     description: DEFAULT_GPT_MAX_CHILD_DEFINITION.into(),
@@ -308,6 +314,7 @@ impl Default for OrchestrateSettings {
                 OrchestrateChildModel {
                     provider: ProviderKind::ClaudeCode,
                     model: "claude-sonnet-5".into(),
+                    profile_id: None,
                     enabled: true,
                     effort: Some("high".into()),
                     description: DEFAULT_SONNET_CHILD_DEFINITION.into(),
@@ -315,6 +322,7 @@ impl Default for OrchestrateSettings {
                 OrchestrateChildModel {
                     provider: ProviderKind::ClaudeCode,
                     model: "claude-opus-4-8".into(),
+                    profile_id: None,
                     enabled: true,
                     effort: Some("high".into()),
                     description: DEFAULT_OPUS_CHILD_DEFINITION.into(),
@@ -322,6 +330,7 @@ impl Default for OrchestrateSettings {
                 OrchestrateChildModel {
                     provider: ProviderKind::ClaudeCode,
                     model: "claude-fable-5".into(),
+                    profile_id: None,
                     enabled: true,
                     effort: Some("high".into()),
                     description: DEFAULT_FABLE_CHILD_DEFINITION.into(),
@@ -408,6 +417,21 @@ impl OrchestrateSettings {
                 && entry.matches_effort(effort)
         })
     }
+
+    pub fn enabled_child_profiles(
+        &self,
+        provider: ProviderKind,
+        model: Option<&str>,
+        effort: Option<&str>,
+    ) -> impl Iterator<Item = &OrchestrateChildModel> {
+        self.child_models.iter().filter(move |entry| {
+            entry.enabled
+                && entry.provider == provider
+                && model.is_none_or(|model| entry.model == model)
+                && !entry.model.trim().is_empty()
+                && entry.matches_effort(effort)
+        })
+    }
 }
 
 /// Provider and model used for the isolated, background request that names a
@@ -419,6 +443,10 @@ pub struct TitleGenerationSettings {
     pub provider: ProviderKind,
     #[serde(default = "default_title_model")]
     pub model: String,
+    /// Which provider profile (endpoint config) the dispatch launches against;
+    /// `None` = the kind's built-in profile.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
 }
 
 pub const DEFAULT_TITLE_MODEL: &str = "gpt-5.6-luna";
@@ -436,6 +464,7 @@ impl Default for TitleGenerationSettings {
         Self {
             provider: default_title_provider(),
             model: default_title_model(),
+            profile_id: None,
         }
     }
 }
@@ -830,6 +859,7 @@ mod tests {
         let profile = OrchestrateChildModel {
             provider: ProviderKind::Codex,
             model: "m".into(),
+            profile_id: None,
             enabled: true,
             effort: Some("High".into()),
             description: String::new(),
@@ -853,6 +883,7 @@ mod tests {
             TitleGenerationSettings {
                 provider: ProviderKind::Codex,
                 model: "gpt-5.6-luna".into(),
+                profile_id: None,
             }
         );
         let partial: TitleGenerationSettings = serde_json::from_str("{}").unwrap();
@@ -862,12 +893,40 @@ mod tests {
             title_generation: TitleGenerationSettings {
                 provider: ProviderKind::ClaudeCode,
                 model: "claude-haiku-4-5".into(),
+                profile_id: Some("work-claude".into()),
             },
             ..Default::default()
         };
         let json = serde_json::to_string(&settings).unwrap();
         let back: Settings = serde_json::from_str(&json).unwrap();
         assert_eq!(back.title_generation, settings.title_generation);
+    }
+
+    #[test]
+    fn provider_profile_fields_are_backward_compatible_and_round_trip() {
+        let child: OrchestrateChildModel =
+            serde_json::from_str(r#"{"provider":"codex","model":"m","enabled":true}"#).unwrap();
+        assert_eq!(child.profile_id, None);
+
+        let title: TitleGenerationSettings =
+            serde_json::from_str(r#"{"provider":"codex","model":"m"}"#).unwrap();
+        assert_eq!(title.profile_id, None);
+
+        let child = OrchestrateChildModel {
+            profile_id: Some("kimi".into()),
+            ..child
+        };
+        let child_back: OrchestrateChildModel =
+            serde_json::from_str(&serde_json::to_string(&child).unwrap()).unwrap();
+        assert_eq!(child_back, child);
+
+        let title = TitleGenerationSettings {
+            profile_id: Some("kimi".into()),
+            ..title
+        };
+        let title_back: TitleGenerationSettings =
+            serde_json::from_str(&serde_json::to_string(&title).unwrap()).unwrap();
+        assert_eq!(title_back, title);
     }
 
     #[test]

--- a/crates/orchestrate-mcp/src/lib.rs
+++ b/crates/orchestrate-mcp/src/lib.rs
@@ -12,6 +12,7 @@ pub enum OrchestrateOp {
         provider: String,
         model: Option<String>,
         effort: Option<String>,
+        profile: Option<String>,
         access: Option<String>,
         title: String,
         brief: String,

--- a/crates/orchestrate-mcp/src/tools.rs
+++ b/crates/orchestrate-mcp/src/tools.rs
@@ -26,6 +26,8 @@ struct DispatchParams {
     #[serde(default)]
     effort: Option<String>,
     #[serde(default)]
+    profile: Option<String>,
+    #[serde(default)]
     access: Option<String>,
     title: String,
     brief: String,
@@ -65,7 +67,7 @@ impl OrchestrateTools {
     }
 
     #[tool(
-        description = "Dispatch a brief to a new child tcode thread and return its thread id. access is one of read_only (review/investigation: read-only actions run without prompts; anything that mutates pauses for user approval), workspace_write (edits auto-approved inside the workspace), or full (default; no approval prompts)."
+        description = "Dispatch a brief to a new child tcode thread and return its thread id. profile is the provider-profile id from the fleet table, required when the entry names one. access is one of read_only (review/investigation: read-only actions run without prompts; anything that mutates pauses for user approval), workspace_write (edits auto-approved inside the workspace), or full (default; no approval prompts)."
     )]
     async fn dispatch(
         &self,
@@ -77,6 +79,7 @@ impl OrchestrateTools {
                 provider: p.provider,
                 model: p.model,
                 effort: p.effort,
+                profile: p.profile,
                 access: p.access,
                 title: p.title,
                 brief: p.brief,

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -1028,6 +1028,7 @@ impl AppState {
         provider: ProviderKind,
         model: Option<String>,
         effort: Option<String>,
+        profile_id: Option<String>,
         approval_mode: ApprovalMode,
         title: String,
         cwd: Option<PathBuf>,
@@ -1064,7 +1065,16 @@ impl AppState {
             }
             None => parent.cwd.clone(),
         };
-        let meta = build_child_meta(&parent, provider, model, effort, approval_mode, title, cwd);
+        let mut meta = build_child_meta(
+            &parent,
+            provider,
+            model,
+            effort,
+            profile_id,
+            approval_mode,
+            cwd,
+        );
+        meta.title = title;
         self.store
             .upsert_meta(&meta)
             .map_err(|err| format!("failed to persist child session: {err}"))?;
@@ -1102,23 +1112,31 @@ impl AppState {
                 provider,
                 model,
                 effort,
+                profile,
                 access,
                 title,
                 brief,
                 cwd,
             } => {
-                let (provider, model, effort) = resolve_orchestrate_dispatch(
+                let (provider, model, effort, profile_id) = resolve_orchestrate_dispatch(
                     &self.settings.orchestrate,
                     &provider,
                     model.as_deref(),
                     effort.as_deref(),
+                    profile.as_deref(),
                 )?;
+                if let Some(id) = profile_id.as_deref()
+                    && self.settings.resolved_profile(id).is_none()
+                {
+                    return Err(format!("unknown profile: {id}"));
+                }
                 let approval_mode = resolve_dispatch_access(access.as_deref())?;
                 let id = self.create_child_session(
                     &parent_id,
                     provider,
                     Some(model),
                     effort,
+                    profile_id,
                     approval_mode,
                     title,
                     cwd.map(PathBuf::from),
@@ -6038,7 +6056,7 @@ fn render_orchestrate_configuration(
         text.push_str(identity);
     }
     text.push_str(
-        "\n\n### Allowed child models\n\nProfiles pin the effort they dispatch at. A dispatch must name `model` and `effort` exactly as listed; both may be omitted, in which case tcode picks the first enabled profile for the provider. The definitions below are user-configured routing guidance.\n",
+        "\n\n### Allowed child models\n\nProfiles pin the effort they dispatch at. A dispatch must name `model` and `effort` exactly as listed; both may be omitted, in which case tcode picks the first enabled profile for the provider. When an entry names a `profile`, pass it exactly as listed. The definitions below are user-configured routing guidance.\n",
     );
     if !settings.child_models.iter().any(|child| child.enabled) {
         text.push_str("No child models are enabled. Work without dispatching until the user enables one in Settings → Orchestrate.");
@@ -6051,13 +6069,24 @@ fn render_orchestrate_configuration(
             ProviderKind::Acp => "acp",
         };
         let effort = child.effort.as_deref().unwrap_or("provider default");
-        text.push_str(&format!(
-            "\n#### `{}` / `{}` — effort `{}`\n\n{}\n",
-            escape_markdown_inline(provider),
-            escape_markdown_inline(&child.model),
-            escape_markdown_inline(effort),
-            child.description.trim(),
-        ));
+        if let Some(profile_id) = child.profile_id.as_deref() {
+            text.push_str(&format!(
+                "\n#### `{}` / `{}` — effort `{}` — profile `{}`\n\n{}\n",
+                escape_markdown_inline(provider),
+                escape_markdown_inline(&child.model),
+                escape_markdown_inline(effort),
+                escape_markdown_inline(profile_id),
+                child.description.trim(),
+            ));
+        } else {
+            text.push_str(&format!(
+                "\n#### `{}` / `{}` — effort `{}`\n\n{}\n",
+                escape_markdown_inline(provider),
+                escape_markdown_inline(&child.model),
+                escape_markdown_inline(effort),
+                child.description.trim(),
+            ));
+        }
     }
     text
 }
@@ -6074,7 +6103,8 @@ fn resolve_orchestrate_dispatch(
     provider: &str,
     model: Option<&str>,
     effort: Option<&str>,
-) -> Result<(ProviderKind, String, Option<String>), String> {
+    profile: Option<&str>,
+) -> Result<(ProviderKind, String, Option<String>, Option<String>), String> {
     let provider = match provider.trim().to_ascii_lowercase().as_str() {
         "claude" | "claude_code" | "claude-code" => ProviderKind::ClaudeCode,
         "codex" => ProviderKind::Codex,
@@ -6088,14 +6118,26 @@ fn resolve_orchestrate_dispatch(
     };
     let requested_model = model.map(str::trim).filter(|model| !model.is_empty());
     let requested_effort = effort.map(str::trim).filter(|effort| !effort.is_empty());
-    let profile = match requested_model {
-        Some(model) => settings.enabled_child_profile(provider, model, requested_effort),
-        None => settings.child_models.iter().find(|entry| {
-            entry.enabled
-                && entry.provider == provider
-                && !entry.model.trim().is_empty()
-                && entry.matches_effort(requested_effort)
-        }),
+    let requested_profile = profile.map(str::trim).filter(|profile| !profile.is_empty());
+    let candidates: Vec<_> = settings
+        .enabled_child_profiles(provider, requested_model, requested_effort)
+        .filter(|entry| {
+            requested_profile.is_none_or(|requested| {
+                entry
+                    .profile_id
+                    .as_deref()
+                    .is_some_and(|id| id.eq_ignore_ascii_case(requested))
+            })
+        })
+        .collect();
+    let child = if requested_profile.is_some() {
+        candidates.first().copied()
+    } else {
+        candidates
+            .iter()
+            .find(|entry| entry.profile_id.is_none())
+            .copied()
+            .or_else(|| candidates.first().copied())
     }
     .ok_or_else(|| {
         let enabled = settings
@@ -6103,11 +6145,15 @@ fn resolve_orchestrate_dispatch(
             .iter()
             .filter(|entry| entry.enabled && entry.provider == provider)
             .map(|entry| {
-                format!(
+                let mut option = format!(
                     "{} (effort {})",
                     entry.model,
                     entry.effort.as_deref().unwrap_or("provider default")
-                )
+                );
+                if let Some(profile_id) = entry.profile_id.as_deref() {
+                    option.push_str(&format!(", profile {profile_id}"));
+                }
+                option
             })
             .collect::<Vec<_>>()
             .join(", ");
@@ -6115,13 +6161,21 @@ fn resolve_orchestrate_dispatch(
         let effort = requested_effort
             .map(|effort| format!(" (effort {effort})"))
             .unwrap_or_default();
+        let profile = requested_profile
+            .map(|profile| format!(" under profile {profile}"))
+            .unwrap_or_default();
         format!(
-            "no enabled child profile matches {requested}{effort} under {}; enabled profiles: {}",
+            "no enabled child profile matches {requested}{effort}{profile} under {}; enabled profiles: {}",
             provider_name(provider),
             if enabled.is_empty() { "none" } else { &enabled }
         )
     })?;
-    Ok((provider, profile.model.clone(), profile.effort.clone()))
+    Ok((
+        provider,
+        child.model.clone(),
+        child.effort.clone(),
+        child.profile_id.clone(),
+    ))
 }
 
 fn resolve_dispatch_access(access: Option<&str>) -> Result<ApprovalMode, String> {
@@ -6151,14 +6205,14 @@ fn build_child_meta(
     provider: ProviderKind,
     model: Option<String>,
     effort: Option<String>,
+    profile_id: Option<String>,
     approval_mode: ApprovalMode,
-    title: String,
     cwd: PathBuf,
 ) -> SessionMeta {
     let mut meta = SessionMeta::new(provider, cwd, model);
-    meta.title = title;
     meta.project_id = parent.project_id.clone();
     meta.parent_session_id = Some(parent.id.clone());
+    meta.profile_id = profile_id;
     meta.approval_mode = approval_mode;
     if let Some(effort) = effort {
         meta.option_selections.push(OptionSelection {
@@ -6418,6 +6472,10 @@ fn title_session_meta(settings: &Settings, cwd: PathBuf) -> SessionMeta {
     let title = &settings.title_generation;
     let model = (!title.model.trim().is_empty()).then(|| title.model.trim().to_string());
     let mut meta = SessionMeta::new(title.provider, cwd, model);
+    meta.profile_id = title
+        .profile_id
+        .clone()
+        .filter(|id| settings.resolved_profile(id).is_some());
     meta.approval_mode = ApprovalMode::Supervised;
     meta.interaction_mode = InteractionMode::Build;
     meta.orchestrate_enabled = false;
@@ -6697,9 +6755,18 @@ mod tests {
         let mut settings = Settings::default();
         settings.title_generation.provider = ProviderKind::ClaudeCode;
         settings.title_generation.model = "claude-haiku-4-5".into();
+        settings.profiles.insert(
+            "work-claude".into(),
+            ProviderProfile {
+                kind: ProviderKind::ClaudeCode,
+                settings: ProviderSettings::default(),
+            },
+        );
+        settings.title_generation.profile_id = Some("work-claude".into());
         let custom = title_session_meta(&settings, PathBuf::from("/tmp/project"));
         assert_eq!(custom.provider, ProviderKind::ClaudeCode);
         assert_eq!(custom.model.as_deref(), Some("claude-haiku-4-5"));
+        assert_eq!(custom.profile_id.as_deref(), Some("work-claude"));
         assert_eq!(custom.approval_mode, ApprovalMode::Supervised);
         assert_eq!(custom.interaction_mode, InteractionMode::Build);
         assert!(!custom.orchestrate_enabled);
@@ -6707,6 +6774,10 @@ mod tests {
             title_turn_options().effort.as_deref(),
             Some(AI_TITLE_REASONING_EFFORT)
         );
+
+        settings.title_generation.profile_id = Some("deleted-profile".into());
+        let fallback = title_session_meta(&settings, PathBuf::from("/tmp/project"));
+        assert_eq!(fallback.profile_id, None);
     }
 
     #[gpui::test]
@@ -6965,32 +7036,69 @@ mod tests {
 
     #[test]
     fn orchestrate_dispatch_enforces_child_allow_list_and_defaults() {
-        let settings = OrchestrateSettings::default();
+        let mut settings = OrchestrateSettings::default();
+        let mut custom_profile = settings.child_models[0].clone();
+        custom_profile.profile_id = Some("kimi".into());
+        settings.child_models.push(custom_profile);
         assert_eq!(
-            resolve_orchestrate_dispatch(&settings, "codex", None, None).unwrap(),
+            resolve_orchestrate_dispatch(&settings, "codex", None, None, None).unwrap(),
             (
                 ProviderKind::Codex,
                 "gpt-5.6-sol".into(),
-                Some("medium".into())
+                Some("medium".into()),
+                None
             )
         );
         assert_eq!(
             resolve_orchestrate_dispatch(
                 &settings,
+                "codex",
+                Some("gpt-5.6-sol"),
+                Some("medium"),
+                Some("KIMI"),
+            )
+            .unwrap(),
+            (
+                ProviderKind::Codex,
+                "gpt-5.6-sol".into(),
+                Some("medium".into()),
+                Some("kimi".into()),
+            )
+        );
+        let unknown_profile = resolve_orchestrate_dispatch(
+            &settings,
+            "codex",
+            Some("gpt-5.6-sol"),
+            Some("medium"),
+            Some("missing"),
+        )
+        .unwrap_err();
+        assert!(unknown_profile.contains("profile missing"));
+        assert!(unknown_profile.contains("profile kimi"));
+        assert_eq!(
+            resolve_orchestrate_dispatch(
+                &settings,
                 "claude_code",
                 Some("claude-opus-4-8"),
-                Some(" HIGH ")
+                Some(" HIGH "),
+                None,
             )
             .unwrap(),
             (
                 ProviderKind::ClaudeCode,
                 "claude-opus-4-8".into(),
-                Some("high".into())
+                Some("high".into()),
+                None
             )
         );
-        let wrong_effort =
-            resolve_orchestrate_dispatch(&settings, "codex", Some("gpt-5.6-sol"), Some("xhigh"))
-                .unwrap_err();
+        let wrong_effort = resolve_orchestrate_dispatch(
+            &settings,
+            "codex",
+            Some("gpt-5.6-sol"),
+            Some("xhigh"),
+            None,
+        )
+        .unwrap_err();
         assert!(
             wrong_effort.contains(
                 "no enabled child profile matches gpt-5.6-sol (effort xhigh) under codex"
@@ -6999,14 +7107,14 @@ mod tests {
         assert!(wrong_effort.contains("gpt-5.6-sol (effort medium)"));
         assert!(wrong_effort.contains("gpt-5.6-sol (effort max)"));
         let denied =
-            resolve_orchestrate_dispatch(&settings, "claude", Some("claude-haiku-4-5"), None)
+            resolve_orchestrate_dispatch(&settings, "claude", Some("claude-haiku-4-5"), None, None)
                 .unwrap_err();
         assert!(denied.contains("no enabled child profile matches"));
 
         let mut empty = settings;
         empty.child_models.clear();
         assert!(
-            resolve_orchestrate_dispatch(&empty, "codex", None, None)
+            resolve_orchestrate_dispatch(&empty, "codex", None, None, None)
                 .unwrap_err()
                 .contains("enabled profiles: none")
         );
@@ -7898,14 +8006,14 @@ mod tests {
             ProviderKind::Codex,
             Some("gpt-test".into()),
             Some("high".into()),
+            Some("work-codex".into()),
             ApprovalMode::AutoAcceptEdits,
-            "Research".into(),
             PathBuf::from("/p/sub"),
         );
         assert_eq!(child.parent_session_id.as_deref(), Some("parent"));
         assert_eq!(child.project_id.as_deref(), Some("project"));
         assert_eq!(child.model.as_deref(), Some("gpt-test"));
-        assert_eq!(child.title, "Research");
+        assert_eq!(child.profile_id.as_deref(), Some("work-codex"));
         assert_eq!(child.approval_mode, ApprovalMode::AutoAcceptEdits);
         assert_eq!(child.option_selections.len(), 1);
         assert_eq!(child.option_selections[0].id, "reasoningEffort");

--- a/crates/ui/src/orchestrate_settings.rs
+++ b/crates/ui/src/orchestrate_settings.rs
@@ -32,6 +32,7 @@ struct IdentityRowState {
 struct ChildRowState {
     provider: ProviderKind,
     model: String,
+    profile_id: Option<String>,
     effort: Entity<InputState>,
     description: Entity<InputState>,
 }
@@ -191,6 +192,7 @@ impl OrchestrateSettingsPanel {
             self.child_rows.push(ChildRowState {
                 provider: entry.provider,
                 model: entry.model,
+                profile_id: entry.profile_id,
                 effort,
                 description,
             });
@@ -336,6 +338,7 @@ impl OrchestrateSettingsPanel {
         let profile = OrchestrateChildModel {
             provider: option.provider,
             model: option.id.clone(),
+            profile_id: option.profile_id.clone(),
             enabled: true,
             effort: option.effort.clone(),
             description: OrchestrateSettings::builtin_child_definition(
@@ -352,6 +355,7 @@ impl OrchestrateSettingsPanel {
                     entry.provider == profile.provider
                         && entry.model == profile.model
                         && entry.effort == profile.effort
+                        && entry.profile_id == profile.profile_id
                 }) {
                     settings.orchestrate.child_models.push(profile);
                 }
@@ -468,10 +472,16 @@ impl OrchestrateSettingsPanel {
         }
     }
 
-    fn model_name(&self, provider: ProviderKind, model: &str, cx: &App) -> String {
+    fn model_name(
+        &self,
+        provider: ProviderKind,
+        model: &str,
+        profile_id: Option<&str>,
+        cx: &App,
+    ) -> String {
         self.identity_model_picker
             .read(cx)
-            .display_name(provider, model, cx)
+            .display_name(provider, model, profile_id, cx)
     }
 
     /// A status message in the shared rail language: a soft neutral fill with a
@@ -674,7 +684,7 @@ impl OrchestrateSettingsPanel {
         // Per-model identities: one grouped list, rows split by inset hairlines.
         let mut rows: Vec<AnyElement> = Vec::new();
         for (index, row) in self.identity_rows.iter().enumerate() {
-            let name = self.model_name(row.provider, &row.model, cx);
+            let name = self.model_name(row.provider, &row.model, None, cx);
             let provider = row.provider;
             let model = row.model.clone();
             let reset_model = row.model.clone();
@@ -775,10 +785,28 @@ impl OrchestrateSettingsPanel {
                 continue;
             };
             let provider = row.provider;
-            let name = self.model_name(provider, &row.model, cx);
+            let name = self.model_name(provider, &row.model, row.profile_id.as_deref(), cx);
             let effort = profile.effort.clone().unwrap_or_else(|| {
                 tcode_i18n::tr!("orchestrate.children.effort_default").into_owned()
             });
+            let subtitle = if let Some(id) = row.profile_id.as_deref() {
+                let profile_settings = self.app_state.read(cx).profile_settings(id);
+                let profile_name = profile_settings
+                    .display_name
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|name| !name.is_empty())
+                    .unwrap_or(id);
+                format!(
+                    "{} · {} · {} · {}",
+                    provider_label(provider),
+                    row.model,
+                    effort,
+                    profile_name
+                )
+            } else {
+                format!("{} · {} · {}", provider_label(provider), row.model, effort)
+            };
             rows.push(
                 v_flex()
                     .w_full()
@@ -801,12 +829,7 @@ impl OrchestrateSettingsPanel {
                                             .font_family("monospace")
                                             .text_size(px(11.))
                                             .text_color(cx.theme().muted_foreground)
-                                            .child(format!(
-                                                "{} · {} · {}",
-                                                provider_label(provider),
-                                                row.model,
-                                                effort,
-                                            )),
+                                            .child(subtitle),
                                     ),
                             )
                             .child(

--- a/crates/ui/src/provider_model_picker.rs
+++ b/crates/ui/src/provider_model_picker.rs
@@ -26,6 +26,7 @@ pub(crate) struct ModelOption {
     pub id: String,
     pub name: String,
     pub effort: Option<String>,
+    pub profile_id: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -43,7 +44,7 @@ pub(crate) struct ProviderModelPicker {
     trigger_id: &'static str,
     trigger_kind: TriggerKind,
     selected_provider: ProviderKind,
-    selected: Option<(ProviderKind, String)>,
+    selected: Option<(ProviderKind, String, Option<String>)>,
     excluded: Vec<(ProviderKind, String)>,
     _app_subscription: Subscription,
 }
@@ -77,6 +78,7 @@ impl ProviderModelPicker {
         trigger_id: &'static str,
         provider: ProviderKind,
         model: impl Into<String>,
+        profile_id: Option<String>,
         cx: &mut Context<Self>,
     ) -> Self {
         let app_subscription = cx.observe(&app_state, |_, _, cx| cx.notify());
@@ -87,7 +89,7 @@ impl ProviderModelPicker {
             trigger_id,
             trigger_kind: TriggerKind::Selection,
             selected_provider: provider,
-            selected: Some((provider, model)),
+            selected: Some((provider, model, profile_id)),
             excluded: Vec::new(),
             _app_subscription: app_subscription,
         }
@@ -104,9 +106,10 @@ impl ProviderModelPicker {
         &mut self,
         provider: ProviderKind,
         model: impl Into<String>,
+        profile_id: Option<String>,
         cx: &mut Context<Self>,
     ) {
-        let selected = (provider, model.into());
+        let selected = (provider, model.into(), profile_id);
         if self.selected.as_ref() != Some(&selected) {
             self.selected_provider = provider;
             self.selected = Some(selected);
@@ -117,28 +120,41 @@ impl ProviderModelPicker {
     fn options(&self, cx: &App) -> Vec<ModelOption> {
         let state = self.app_state.read(cx);
         let mut options = Vec::new();
-        for provider in [ProviderKind::Codex, ProviderKind::ClaudeCode] {
-            let catalog = state.models_for(provider);
-            for model in state.resolved_models(provider) {
+        for profile in state.all_profiles() {
+            let catalog = state.models_for(profile.kind);
+            let profile_id = (!tcode_core::settings::Settings::is_builtin_profile_id(&profile.id))
+                .then_some(profile.id.clone());
+            for model in state.picker_models_for_profile(&profile.id) {
                 let effort = catalog
                     .iter()
                     .find(|spec| spec.id == model.id)
                     .and_then(default_reasoning_effort);
                 options.push(ModelOption {
-                    provider,
+                    provider: profile.kind,
                     id: model.id,
                     name: model.name,
                     effort,
+                    profile_id: profile_id.clone(),
                 });
             }
         }
         options
     }
 
-    pub(crate) fn display_name(&self, provider: ProviderKind, model: &str, cx: &App) -> String {
+    pub(crate) fn display_name(
+        &self,
+        provider: ProviderKind,
+        model: &str,
+        profile_id: Option<&str>,
+        cx: &App,
+    ) -> String {
         self.options(cx)
             .into_iter()
-            .find(|option| option.provider == provider && option.id == model)
+            .find(|option| {
+                option.provider == provider
+                    && option.id == model
+                    && option.profile_id.as_deref() == profile_id
+            })
             .map(|option| option.name)
             .unwrap_or_else(|| model.to_string())
     }
@@ -151,12 +167,14 @@ impl ProviderModelPicker {
                 .icon(IconName::Plus)
                 .label(label.clone()),
             TriggerKind::Selection => {
-                let (provider, model) = self
+                let (provider, model, profile_id) = self
                     .selected
                     .as_ref()
-                    .map(|(provider, model)| (*provider, model.as_str()))
-                    .unwrap_or((self.selected_provider, ""));
-                let display = self.display_name(provider, model, cx);
+                    .map(|(provider, model, profile_id)| {
+                        (*provider, model.as_str(), profile_id.as_deref())
+                    })
+                    .unwrap_or((self.selected_provider, "", None));
+                let display = self.display_name(provider, model, profile_id, cx);
                 Button::new(self.trigger_id).outline().compact().child(
                     h_flex()
                         .w(px(230.))
@@ -212,10 +230,45 @@ impl Render for ProviderModelPicker {
                             .child(tcode_i18n::tr!("model_picker.no_models")),
                     );
                 } else {
+                    let show_headers = available.iter().any(|option| option.profile_id.is_some());
+                    let mut previous_profile_id: Option<Option<String>> = None;
                     for (index, option) in available.into_iter().enumerate() {
-                        let is_selected = selected.as_ref().is_some_and(|(provider, model)| {
-                            *provider == option.provider && model == &option.id
-                        });
+                        if show_headers && previous_profile_id.as_ref() != Some(&option.profile_id)
+                        {
+                            let label = option.profile_id.as_deref().map_or_else(
+                                || provider_label(option.provider).to_string(),
+                                |id| {
+                                    let settings =
+                                        picker.read(cx).app_state.read(cx).profile_settings(id);
+                                    settings
+                                        .display_name
+                                        .as_deref()
+                                        .map(str::trim)
+                                        .filter(|name| !name.is_empty())
+                                        .unwrap_or(id)
+                                        .to_string()
+                                },
+                            );
+                            rows = rows.child(
+                                div()
+                                    .flex_none()
+                                    .px_2()
+                                    .pt_2()
+                                    .pb_1()
+                                    .text_size(px(11.))
+                                    .text_color(cx.theme().muted_foreground)
+                                    .child(label),
+                            );
+                            previous_profile_id = Some(option.profile_id.clone());
+                        }
+                        let is_selected =
+                            selected
+                                .as_ref()
+                                .is_some_and(|(provider, model, profile_id)| {
+                                    *provider == option.provider
+                                        && model == &option.id
+                                        && profile_id == &option.profile_id
+                                });
                         let picker = picker.clone();
                         let popover = cx.entity();
                         rows = rows.child(
@@ -252,8 +305,11 @@ impl Render for ProviderModelPicker {
                                     picker.update(cx, |picker, cx| {
                                         picker.selected_provider = selected.provider;
                                         if matches!(picker.trigger_kind, TriggerKind::Selection) {
-                                            picker.selected =
-                                                Some((selected.provider, selected.id.clone()));
+                                            picker.selected = Some((
+                                                selected.provider,
+                                                selected.id.clone(),
+                                                selected.profile_id.clone(),
+                                            ));
                                         }
                                         cx.emit(ModelSelected(selected));
                                     });

--- a/crates/ui/src/provider_model_picker.rs
+++ b/crates/ui/src/provider_model_picker.rs
@@ -1,8 +1,9 @@
 //! Reusable native-provider model picker used by settings surfaces.
 //!
-//! The provider tabs, resolved model catalog, offline/custom-model handling,
-//! and selection event live here so Orchestrate and other settings do not grow
-//! subtly different pickers.
+//! The profile tabs (one per provider profile, built-in or user-created),
+//! resolved model catalog, offline/custom-model handling, and selection event
+//! live here so Orchestrate and other settings do not grow subtly different
+//! pickers.
 
 use gpui::{
     App, Context, Entity, EventEmitter, InteractiveElement as _, IntoElement, ParentElement as _,
@@ -15,6 +16,7 @@ use gpui_component::{
 };
 
 use agent::{OptionDescriptor, ProviderKind};
+use tcode_core::settings::Settings;
 use tcode_runtime::app::AppState;
 
 use crate::provider_card::provider_glyph;
@@ -43,7 +45,8 @@ pub(crate) struct ProviderModelPicker {
     popover_id: &'static str,
     trigger_id: &'static str,
     trigger_kind: TriggerKind,
-    selected_provider: ProviderKind,
+    /// The active tab: a profile id (built-in or user-created).
+    selected_profile: String,
     selected: Option<(ProviderKind, String, Option<String>)>,
     excluded: Vec<(ProviderKind, String)>,
     _app_subscription: Subscription,
@@ -65,7 +68,7 @@ impl ProviderModelPicker {
             popover_id,
             trigger_id,
             trigger_kind: TriggerKind::Add(label.into()),
-            selected_provider: ProviderKind::Codex,
+            selected_profile: Settings::builtin_profile_id(ProviderKind::Codex).to_string(),
             selected: None,
             excluded: Vec::new(),
             _app_subscription: app_subscription,
@@ -88,7 +91,7 @@ impl ProviderModelPicker {
             popover_id,
             trigger_id,
             trigger_kind: TriggerKind::Selection,
-            selected_provider: provider,
+            selected_profile: selection_profile_id(provider, profile_id.as_deref()),
             selected: Some((provider, model, profile_id)),
             excluded: Vec::new(),
             _app_subscription: app_subscription,
@@ -111,7 +114,7 @@ impl ProviderModelPicker {
     ) {
         let selected = (provider, model.into(), profile_id);
         if self.selected.as_ref() != Some(&selected) {
-            self.selected_provider = provider;
+            self.selected_profile = selection_profile_id(provider, selected.2.as_deref());
             self.selected = Some(selected);
             cx.notify();
         }
@@ -122,8 +125,8 @@ impl ProviderModelPicker {
         let mut options = Vec::new();
         for profile in state.all_profiles() {
             let catalog = state.models_for(profile.kind);
-            let profile_id = (!tcode_core::settings::Settings::is_builtin_profile_id(&profile.id))
-                .then_some(profile.id.clone());
+            let profile_id =
+                (!Settings::is_builtin_profile_id(&profile.id)).then_some(profile.id.clone());
             for model in state.picker_models_for_profile(&profile.id) {
                 let effort = catalog
                     .iter()
@@ -173,7 +176,10 @@ impl ProviderModelPicker {
                     .map(|(provider, model, profile_id)| {
                         (*provider, model.as_str(), profile_id.as_deref())
                     })
-                    .unwrap_or((self.selected_provider, "", None));
+                    .unwrap_or_else(|| {
+                        let kind = self.app_state.read(cx).profile_kind(&self.selected_profile);
+                        (kind, "", None)
+                    });
                 let display = self.display_name(provider, model, profile_id, cx);
                 Button::new(self.trigger_id).outline().compact().child(
                     h_flex()
@@ -200,19 +206,27 @@ impl Render for ProviderModelPicker {
         Popover::new(self.popover_id)
             .trigger(self.trigger(cx))
             .content(move |_, _, cx| {
-                let (options, selected_provider, selected, excluded) = {
+                let (options, profiles, selected_profile, selected, excluded) = {
                     let picker = picker.read(cx);
                     (
                         picker.options(cx),
-                        picker.selected_provider,
+                        picker.app_state.read(cx).all_profiles(),
+                        picker.selected_profile.clone(),
                         picker.selected.clone(),
                         picker.excluded.clone(),
                     )
                 };
+                // A deleted profile falls back to the first tab (built-ins
+                // always exist, so the list is never empty).
+                let current_profile = if profiles.iter().any(|p| p.id == selected_profile) {
+                    selected_profile
+                } else {
+                    profiles.first().map(|p| p.id.clone()).unwrap_or_default()
+                };
                 let available: Vec<_> = options
                     .into_iter()
                     .filter(|option| {
-                        option.provider == selected_provider
+                        option_profile_id(option) == current_profile
                             && !excluded.iter().any(|(provider, model)| {
                                 *provider == option.provider && model == &option.id
                             })
@@ -230,37 +244,7 @@ impl Render for ProviderModelPicker {
                             .child(tcode_i18n::tr!("model_picker.no_models")),
                     );
                 } else {
-                    let show_headers = available.iter().any(|option| option.profile_id.is_some());
-                    let mut previous_profile_id: Option<Option<String>> = None;
                     for (index, option) in available.into_iter().enumerate() {
-                        if show_headers && previous_profile_id.as_ref() != Some(&option.profile_id)
-                        {
-                            let label = option.profile_id.as_deref().map_or_else(
-                                || provider_label(option.provider).to_string(),
-                                |id| {
-                                    let settings =
-                                        picker.read(cx).app_state.read(cx).profile_settings(id);
-                                    settings
-                                        .display_name
-                                        .as_deref()
-                                        .map(str::trim)
-                                        .filter(|name| !name.is_empty())
-                                        .unwrap_or(id)
-                                        .to_string()
-                                },
-                            );
-                            rows = rows.child(
-                                div()
-                                    .flex_none()
-                                    .px_2()
-                                    .pt_2()
-                                    .pb_1()
-                                    .text_size(px(11.))
-                                    .text_color(cx.theme().muted_foreground)
-                                    .child(label),
-                            );
-                            previous_profile_id = Some(option.profile_id.clone());
-                        }
                         let is_selected =
                             selected
                                 .as_ref()
@@ -303,7 +287,7 @@ impl Render for ProviderModelPicker {
                                 .on_click(move |_, window, cx| {
                                     let selected = option.clone();
                                     picker.update(cx, |picker, cx| {
-                                        picker.selected_provider = selected.provider;
+                                        picker.selected_profile = option_profile_id(&selected);
                                         if matches!(picker.trigger_kind, TriggerKind::Selection) {
                                             picker.selected = Some((
                                                 selected.provider,
@@ -319,12 +303,25 @@ impl Render for ProviderModelPicker {
                     }
                 }
 
+                // One tab per profile: the two built-ins first, then the user's
+                // profiles in their card order.
                 let mut tabs = h_flex().w_full().p_1().gap_1();
-                for (tab_index, provider) in [ProviderKind::Codex, ProviderKind::ClaudeCode]
-                    .into_iter()
-                    .enumerate()
-                {
-                    let is_selected = provider == selected_provider;
+                for (tab_index, profile) in profiles.iter().enumerate() {
+                    let is_selected = profile.id == current_profile;
+                    let label = if Settings::is_builtin_profile_id(&profile.id) {
+                        provider_label(profile.kind).to_string()
+                    } else {
+                        profile
+                            .settings
+                            .display_name
+                            .as_deref()
+                            .map(str::trim)
+                            .filter(|name| !name.is_empty())
+                            .unwrap_or(&profile.id)
+                            .to_string()
+                    };
+                    let kind = profile.kind;
+                    let profile_id = profile.id.clone();
                     let picker = picker.clone();
                     let popover = cx.entity();
                     tabs = tabs.child(
@@ -339,11 +336,11 @@ impl Render for ProviderModelPicker {
                             .cursor_pointer()
                             .when(is_selected, |tab| tab.bg(cx.theme().accent).font_medium())
                             .hover(|tab| tab.bg(cx.theme().accent))
-                            .child(provider_glyph(provider).xsmall())
-                            .child(div().text_size(px(13.)).child(provider_label(provider)))
+                            .child(provider_glyph(kind).xsmall())
+                            .child(div().text_size(px(13.)).child(label))
                             .on_click(move |_, _, cx| {
                                 picker.update(cx, |picker, cx| {
-                                    picker.selected_provider = provider;
+                                    picker.selected_profile = profile_id.clone();
                                     cx.notify();
                                 });
                                 popover.update(cx, |_, cx| cx.notify());
@@ -368,6 +365,19 @@ impl Render for ProviderModelPicker {
                 .rounded(crate::material::radius_overlay())
             })
     }
+}
+
+/// The profile a selection belongs to: its explicit profile id, or the kind's
+/// built-in profile.
+fn selection_profile_id(provider: ProviderKind, profile_id: Option<&str>) -> String {
+    profile_id
+        .map(str::to_string)
+        .unwrap_or_else(|| Settings::builtin_profile_id(provider).to_string())
+}
+
+/// The profile tab an option files under (see [`selection_profile_id`]).
+fn option_profile_id(option: &ModelOption) -> String {
+    selection_profile_id(option.provider, option.profile_id.as_deref())
 }
 
 fn default_reasoning_effort(spec: &agent::ModelSpec) -> Option<String> {

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -88,6 +88,7 @@ impl SettingsPage {
                 "title-model-dropdown",
                 title_generation.provider,
                 title_generation.model,
+                title_generation.profile_id,
                 cx,
             )
         });
@@ -95,7 +96,12 @@ impl SettingsPage {
             cx.observe(&app_state, |this, _, cx| {
                 let selection = this.app_state.read(cx).settings.title_generation.clone();
                 this.title_model_picker.update(cx, |picker, cx| {
-                    picker.set_selected(selection.provider, selection.model, cx);
+                    picker.set_selected(
+                        selection.provider,
+                        selection.model,
+                        selection.profile_id,
+                        cx,
+                    );
                 });
                 cx.notify();
             }),
@@ -105,6 +111,7 @@ impl SettingsPage {
                     move |settings| {
                         settings.title_generation.provider = selected.provider;
                         settings.title_generation.model = selected.id;
+                        settings.title_generation.profile_id = selected.profile_id;
                     },
                     cx,
                 );


### PR DESCRIPTION
## Why

User-created provider profiles (#55) work in the composer's model picker, but the **Settings** model picker (`ProviderModelPicker`, shared by Settings → Orchestrate "Add" pickers and the title-generation picker) hardcoded `[Codex, ClaudeCode]` and only enumerated the built-in catalogs. A profile like a Kimi endpoint on the Claude protocol could not be added to the orchestrate fleet or drive title generation — and even a stored selection carried no `profile_id`, so it would have launched against the built-in endpoint instead of the profile's base URL/key.

## What

- **`ProviderModelPicker`**: enumerates `all_profiles()`; the tab row grows with the profile list (Codex, Claude, Kimi, … — built-ins first, user profiles labeled by `display_name`), each tab listing only that profile's models via `picker_models_for_profile`, matching the composer's one-rail-per-profile semantics.
- **Settings structs**: `OrchestrateChildModel` and `TitleGenerationSettings` gain an optional, serde-backward-compatible `profile_id` (`None` = built-in profile).
- **Dispatch path**: the `dispatch` MCP tool accepts an optional `profile` param; resolution matches (provider, model, effort, profile) with built-in preferred when unnamed, the fleet table names the profile (`` — profile `id` ``), and child sessions carry `meta.profile_id` so the launch path uses the profile's endpoint/env. Unknown or deleted profiles error / fall back cleanly.
- **Title generation**: the picker stores `profile_id` and `title_session_meta` applies it (dropping ids that no longer resolve).

## Tests

- serde back-compat + round-trip for both settings structs
- dispatch resolution: profile selection, built-in preference, unknown-profile error
- `title_session_meta` sets / drops `profile_id`
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
