### PR TITLE
fix(ui): flatten the vibrancy canvas while fullscreen

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -300,7 +300,8 @@ fn main() {
             // The theme's canvas color is translucent so the macOS vibrancy
             // material shows through (docs/visual-redesign.md). Elsewhere the
             // window is opaque and that alpha would composite against black,
-            // so flatten the canvas onto each mode's solid base first.
+            // so flatten the canvas onto each mode's solid base first. (macOS
+            // fullscreen flattens at paint time instead: material::opaque_canvas.)
             let theme_json: Cow<'_, str> = if vibrancy_enabled() {
                 Cow::Borrowed(TCODE_THEME)
             } else {

--- a/crates/ui/src/material.rs
+++ b/crates/ui/src/material.rs
@@ -23,6 +23,16 @@ fn rgba(r: u8, g: u8, b: u8, a: u8) -> Hsla {
     .into()
 }
 
+/// The canvas flattened to full opacity. Painted under the glass tiers only
+/// while the window is fullscreen: a fullscreen Space has nothing but black
+/// behind the vibrancy material, and the canvas alpha compositing against it
+/// muddies every surface above. Same fallback Windows Acrylic's `FallbackColor`
+/// and macOS "Reduce Transparency" apply. Windowed, the canvas stays
+/// translucent and Root owns it (docs/visual-redesign.md §0).
+pub fn opaque_canvas(cx: &App) -> Hsla {
+    cx.theme().background.opacity(1.)
+}
+
 /// T1 paper: the near-opaque reading plane the chat workspace, right panel and
 /// full-page routes paint over the vibrancy canvas. Warm paper in light mode,
 /// blue-carbon in dark.

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -295,6 +295,7 @@ impl Render for AppShell {
         let notification_layer = Root::render_notification_layer(window, cx);
         let route = self.app_state.read(cx).route;
         let palette_open = self.app_state.read(cx).palette_open;
+        let fullscreen = window.is_fullscreen();
         // Focus the palette's search input on the open transition.
         if palette_open && !self.palette_was_open {
             self.palette.update(cx, |p, cx| p.focus(window, cx));
@@ -319,12 +320,21 @@ impl Render for AppShell {
             return div()
                 .id("app-shell")
                 .size_full()
-                .bg(crate::material::content_surface(cx))
-                // T1 paper floats above the glass canvas.
-                .shadow_sm()
+                // Fullscreen flattens the canvas under the paper (see the
+                // workspace root below).
+                .when(fullscreen, |this| {
+                    this.bg(crate::material::opaque_canvas(cx))
+                })
                 .text_color(cx.theme().foreground)
                 .on_action(cx.listener(Self::on_toggle_palette))
-                .child(self.settings_page.clone())
+                .child(
+                    div()
+                        .size_full()
+                        .bg(crate::material::content_surface(cx))
+                        // T1 paper floats above the glass canvas.
+                        .shadow_sm()
+                        .child(self.settings_page.clone()),
+                )
                 .child(self.toasts.clone())
                 .children(sheet_layer)
                 .children(dialog_layer)
@@ -441,6 +451,13 @@ impl Render for AppShell {
         div()
             .id("app-shell")
             .size_full()
+            // Fullscreen only: a fullscreen Space has nothing but black behind
+            // the vibrancy material, which muddies the translucent canvas —
+            // cover it with its opaque base. Windowed, paint nothing here:
+            // Root owns the glass canvas (docs/visual-redesign.md §0).
+            .when(fullscreen, |this| {
+                this.bg(crate::material::opaque_canvas(cx))
+            })
             .text_color(cx.theme().foreground)
             .on_action(cx.listener(Self::on_toggle_palette))
             .child(

--- a/docs/visual-redesign.md
+++ b/docs/visual-redesign.md
@@ -17,7 +17,10 @@
   `NSVisualEffectView`；合成后 alpha < 1 的区域透出桌面毛玻璃。
 - 全窗口仅一层 blur；悬浮层半透明与其下窗口内容做普通 alpha 合成。
 - gpui-component `Root` 用 `colors.background` 涂画布，支持 8 位 hex alpha。
-  **AppShell 不得重复涂 `background`**（已移除）。
+  **AppShell 不得重复涂 `background`**（已移除）——全屏例外：全屏 Space 的
+  vibrancy 背景是纯黑，AppShell 根节点仅在全屏时垫一层不透明基色
+  （`material::opaque_canvas`，把画布 alpha 提到 1），窗口模式仍由 Root 独自涂玻璃。
+  与 Windows Acrylic `FallbackColor`、macOS「降低透明度」同一降级策略。
 - 非 macOS：窗口 Opaque；main.rs 的 `flatten_canvas_for_opaque_window`
   把画布色压平为实色（与 JSON 字面量保持同步）。
 
@@ -25,7 +28,7 @@
 
 | 层 | 用途 | 谁来涂 | 策略 |
 |---|---|---|---|
-| T0 玻璃机壳 | 侧栏、窗口边缘 | Root（`background`） | 唯一刻意透明层 ~78% |
+| T0 玻璃机壳 | 侧栏、窗口边缘 | Root（`background`） | 唯一刻意透明层 ~78%；全屏时压平为实色 |
 | T1 纸面 | 聊天区、右面板、设置页 | shell.rs（`material::content_surface`） | 近实 94-95% |
 | T2 浮起 | 气泡、卡片、输入域 | 组件（muted/secondary 叠色） | 半透明墨色叠加 |
 | T3 悬浮 | popover/menu/dialog/drawer/toast | `popover.background` | ≥97% + 发丝边 + 大软阴影 |


### PR DESCRIPTION
## Problem

On macOS, a fullscreen window owns its Space, so the vibrancy material has nothing behind it — the compositor feeds it pure black. The theme's canvas color is 78% opaque (`#F2F4F7C7` / `#15171CC7`), and the remaining 22% lets that black bleed through, dirtying the frosted-glass sidebar and window edges and dropping overall contrast.

## Approach

The same fallback strategy as Windows Acrylic's `FallbackColor` and macOS "Reduce Transparency": **flatten the canvas to its solid base while fullscreen**.

- `material.rs`: new `opaque_canvas()` — the canvas color with alpha forced to 1.
- `shell.rs`: both root nodes (workspace and settings) paint this opaque base only when `window.is_fullscreen()`; while windowed they paint nothing, so `Root` keeps sole ownership of the glass canvas (avoids double-layering the translucent color, which would muddy it).
- No event hook needed: the fullscreen transition always fires `windowDidResize`, which re-renders.
- `visual-redesign.md` §0 documents the fullscreen exception.

## Verification

- `cargo check` / `clippy` clean.
- Manually verified: entering fullscreen switches the glass regions to the clean solid base, exiting restores the vibrancy; the settings page behaves the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)