### PR TITLE
perf(ci): drop the macOS release build and shrink build caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CARGO_TERM_COLOR: always
+      # Smaller target/ keeps the per-repo 10 GB Actions cache pool under its
+      # limit; full debug info was evicting the Windows/Linux/release caches.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
       RUST_BACKTRACE: 1
       TCODE_LIVE_TESTS: 0
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Disable Windows Defender real-time scanning
+        if: runner.os == 'Windows'
+        shell: pwsh
+        continue-on-error: true
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
 
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@stable
@@ -64,19 +73,12 @@ jobs:
         run: cargo fmt --all --check
 
       - name: Run Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
       - name: Run workspace tests (Linux under Xvfb)
         if: runner.os == 'Linux'
-        run: xvfb-run -a cargo test --workspace
+        run: xvfb-run -a cargo test --workspace --locked
 
       - name: Run workspace tests
         if: runner.os != 'Linux'
-        run: cargo test --workspace
-
-      - name: Build release binary (macOS)
-        if: runner.os == 'macOS'
-        env:
-          CARGO_PROFILE_RELEASE_LTO: thin
-          CARGO_PROFILE_RELEASE_STRIP: symbols
-        run: time cargo build --release --locked
+        run: cargo test --workspace --locked


### PR DESCRIPTION
## Problem

CI's macOS-only `cargo build --release` step spent ~11 min per run and doubled the macOS cache entry to ~2.4 GB per lockfile hash. The repo's Actions cache pool is capped at 10 GB and currently sits at ~10.7 GB, so LRU eviction was constantly kicking out the Windows/Linux CI caches and all six `release-*` caches. Result: frequent cold builds (Windows ~14 min instead of ~7; release builds always cold).

## Changes

- **Remove the macOS release build step.** Its only remaining uses were the `--locked` lockfile-sync check and acting as a release-profile canary; the former is kept by passing `--locked` to clippy and the test runs (zero cost), the latter moves to tag time where the release workflow is per-platform re-runnable anyway.
- **`CARGO_PROFILE_DEV_DEBUG: line-tables-only`** — much smaller `target/` and cache entries (faster save/restore, no more pool eviction) while test backtraces keep file:line info.
- **Disable Windows Defender real-time scanning** before building (`continue-on-error` in case the image already has it off) — real-time scanning is a well-known tax on Rust's many small file writes.

## Expected effect

All three CI caches plus the release caches fit inside the 10 GB pool again, warm-cache Windows runs return to ~7 min, and the macOS job drops from ~22 min to ~10 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)