### PR TITLE
feat(orchestrate): route child approvals to the decision layer

### DIFF
--- a/assets/orchestrate/codex.md
+++ b/assets/orchestrate/codex.md
@@ -18,11 +18,12 @@ The fleet table below is the authoritative allow list — user-configured profil
 
 ## Tools
 
-- `dispatch {provider, model?, effort?, access?, title, brief, cwd?}` → new child thread, `brief` is its first message, returns `thread_id`. Visible in the user's sidebar. `model` + `effort` must name an enabled profile from the fleet table exactly (omit both → the provider's first enabled profile). `access`: `read_only` for reviews/investigation (no file changes; anything beyond pauses for user approval), `workspace_write` for implementation with auto-approved workspace edits, `full` (default).
+- `dispatch {provider, model?, effort?, access?, title, brief, cwd?}` → new child thread, `brief` is its first message, returns `thread_id`. Visible in the user's sidebar. `model` + `effort` must name an enabled profile from the fleet table exactly (omit both → the provider's first enabled profile). `access`: `read_only` for reviews/investigation (no file changes; anything beyond pauses for approval, routed per Settings → Orchestrate → child approvals), `workspace_write` for implementation with auto-approved workspace edits, `full` (default).
 - `status {thread_id?}` → running/completed/failed + output tail + token usage. No `thread_id` = all children.
 - `send {thread_id, message}` → follow-up to a child that still has useful context (fix instructions, mid-course corrections, one focused retry). Injected into the child's live turn when one is running, otherwise sent as its next turn — the response says which.
 - `result {thread_id}` → full final message of a completed child, with token usage.
 - `cancel {thread_id}` → stop a child.
+- `approve {thread_id, request_id?, decision}` → answer a child's pending permission approval (`approve` | `approve_for_session` | `deny`). When Settings → Orchestrate routes child approvals to you (the default), a child that hits a permission gate pauses and you receive an `[orchestrate]` message with the `request_id` — decide promptly, and deny anything outside the brief's scope.
 
 ## Callbacks — never poll, never busy-wait
 

--- a/assets/orchestrate/fable.md
+++ b/assets/orchestrate/fable.md
@@ -18,11 +18,12 @@ The fleet table below is the authoritative allow list — user-configured profil
 
 ## Tools
 
-- `dispatch {provider, model?, effort?, access?, title, brief, cwd?}` → creates a child thread, sends `brief` as its first message, returns `thread_id`. The child appears in the user's sidebar; they can watch it live. `model` + `effort` must name an enabled profile exactly as listed in the fleet table (omit both to get the provider's first enabled profile). `access` gates what the child may do: `read_only` for reviews and investigation (the child cannot change files; anything beyond that pauses for user approval), `workspace_write` for implementation with edits auto-approved inside the workspace, `full` (default) for no prompts.
+- `dispatch {provider, model?, effort?, access?, title, brief, cwd?}` → creates a child thread, sends `brief` as its first message, returns `thread_id`. The child appears in the user's sidebar; they can watch it live. `model` + `effort` must name an enabled profile exactly as listed in the fleet table (omit both to get the provider's first enabled profile). `access` gates what the child may do: `read_only` for reviews and investigation (the child cannot change files; anything beyond that pauses for approval, routed per Settings → Orchestrate → child approvals), `workspace_write` for implementation with edits auto-approved inside the workspace, `full` (default) for no prompts.
 - `status {thread_id?}` → running/completed/failed, an output tail, and token usage. Omit `thread_id` for all your children.
 - `send {thread_id, message}` → follow-up message to a child (feedback, a mid-course correction, one focused retry). Steered into the child's live turn immediately when one is running, otherwise sent as its next turn — the response says which. Prefer this over dispatching a fresh child when the child's context is useful.
 - `result {thread_id}` → the completed child's full final message plus token usage.
 - `cancel {thread_id}` → stop a child.
+- `approve {thread_id, request_id?, decision}` → answer a child's pending permission approval (`approve` | `approve_for_session` | `deny`). When Settings → Orchestrate routes child approvals to you (the default), a child that hits a permission gate pauses and you receive an `[orchestrate]` message with the `request_id` — decide promptly, and deny anything outside the brief's scope.
 
 ## The callback contract — do not poll, do not self-schedule
 

--- a/assets/orchestrate/generic.md
+++ b/assets/orchestrate/generic.md
@@ -18,11 +18,12 @@ The fleet table below is the authoritative allow list — user-configured profil
 
 ## Tools
 
-- `dispatch {provider, model?, effort?, access?, title, brief, cwd?}` → creates a child thread and sends `brief` as its first message; returns `thread_id`. The child is visible in the user's sidebar. `model` + `effort` must name an enabled profile from the fleet table exactly (omit both for the provider's first enabled profile). `access`: `read_only` for reviews/investigation (no file changes; anything beyond pauses for user approval), `workspace_write` for implementation with auto-approved workspace edits, `full` (default).
+- `dispatch {provider, model?, effort?, access?, title, brief, cwd?}` → creates a child thread and sends `brief` as its first message; returns `thread_id`. The child is visible in the user's sidebar. `model` + `effort` must name an enabled profile from the fleet table exactly (omit both for the provider's first enabled profile). `access`: `read_only` for reviews/investigation (no file changes; anything beyond pauses for approval, routed per Settings → Orchestrate → child approvals), `workspace_write` for implementation with auto-approved workspace edits, `full` (default).
 - `status {thread_id?}` → running/completed/failed plus the latest output tail and token usage. Omit `thread_id` for all children.
 - `send {thread_id, message}` → follow-up to a child with useful context (feedback, mid-course corrections, one focused retry). Delivered into the child's live turn when one is running, otherwise sent as its next turn — the response says which.
 - `result {thread_id}` → completed child's full final message, with token usage.
 - `cancel {thread_id}` → stop a child.
+- `approve {thread_id, request_id?, decision}` → answer a child's pending permission approval (`approve` | `approve_for_session` | `deny`). When Settings → Orchestrate routes child approvals to you (the default), a child that hits a permission gate pauses and you receive an `[orchestrate]` message with the `request_id` — decide promptly, and deny anything outside the brief's scope.
 
 ## Callbacks — do not poll
 

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -259,6 +259,19 @@ const DEFAULT_SONNET_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better
 const DEFAULT_OPUS_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better): cost efficiency 4, intelligence 7, taste 8. First choice for user-facing work: UI, copy, API design, and anything where taste matters more than grinding depth. Also a strong independent reviewer of plans and implementations.";
 const DEFAULT_FABLE_CHILD_DEFINITION: &str = "Ratings (1–10, higher is better): cost efficiency 2, intelligence 9, taste 9. Highest-judgment escalation for framing, architecture, ambiguous tradeoffs, taste-critical surfaces, and final review. The scarcest resource in the fleet: dispatch to it only when nothing cheaper is adequate.";
 
+/// Who answers permission requests raised by dispatched child threads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ChildApprovalMode {
+    /// The parent (decision-layer) model answers via the orchestrate `approve` tool.
+    #[default]
+    Orchestrator,
+    /// Auto-approve every child request for the session.
+    AlwaysAllow,
+    /// The user answers in the child's composer (legacy behavior).
+    Manual,
+}
+
 /// Settings for tcode's built-in orchestration layer.
 ///
 /// There is deliberately no main-model allow list. Every model may orchestrate;
@@ -272,6 +285,8 @@ pub struct OrchestrateSettings {
     pub model_identities: Vec<OrchestratorIdentity>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub child_models: Vec<OrchestrateChildModel>,
+    #[serde(default)]
+    pub child_approval: ChildApprovalMode,
 }
 
 fn default_orchestrator_identity() -> String {
@@ -336,6 +351,7 @@ impl Default for OrchestrateSettings {
                     description: DEFAULT_FABLE_CHILD_DEFINITION.into(),
                 },
             ],
+            child_approval: ChildApprovalMode::default(),
         }
     }
 }
@@ -843,6 +859,27 @@ mod tests {
         let json = serde_json::to_string(&settings).unwrap();
         let back: Settings = serde_json::from_str(&json).unwrap();
         assert_eq!(back.orchestrate, settings.orchestrate);
+    }
+
+    #[test]
+    fn orchestrate_child_approval_defaults_and_round_trips() {
+        let legacy: OrchestrateSettings = serde_json::from_str("{}").unwrap();
+        assert_eq!(legacy.child_approval, ChildApprovalMode::Orchestrator);
+
+        for mode in [ChildApprovalMode::AlwaysAllow, ChildApprovalMode::Manual] {
+            let settings = OrchestrateSettings {
+                child_approval: mode,
+                ..Default::default()
+            };
+            let json = serde_json::to_string(&settings).unwrap();
+            assert!(json.contains(match mode {
+                ChildApprovalMode::AlwaysAllow => r#""child_approval":"always_allow""#,
+                ChildApprovalMode::Manual => r#""child_approval":"manual""#,
+                ChildApprovalMode::Orchestrator => unreachable!(),
+            }));
+            let back: OrchestrateSettings = serde_json::from_str(&json).unwrap();
+            assert_eq!(back.child_approval, mode);
+        }
     }
 
     #[test]

--- a/crates/orchestrate-mcp/src/lib.rs
+++ b/crates/orchestrate-mcp/src/lib.rs
@@ -35,6 +35,12 @@ pub enum OrchestrateOp {
         parent_id: String,
         thread_id: String,
     },
+    Approve {
+        parent_id: String,
+        thread_id: String,
+        request_id: Option<String>,
+        decision: String,
+    },
 }
 
 #[derive(Debug)]

--- a/crates/orchestrate-mcp/src/tools.rs
+++ b/crates/orchestrate-mcp/src/tools.rs
@@ -48,6 +48,13 @@ struct SendParams {
 struct ThreadParams {
     thread_id: String,
 }
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ApproveParams {
+    thread_id: String,
+    #[serde(default)]
+    request_id: Option<String>,
+    decision: String,
+}
 
 #[derive(Clone)]
 pub struct OrchestrateTools {
@@ -139,6 +146,23 @@ impl OrchestrateTools {
             .run(OrchestrateOp::Cancel {
                 parent_id: self.parent_id.clone(),
                 thread_id: p.thread_id,
+            })
+            .await)
+    }
+
+    #[tool(
+        description = "Answer a child thread's pending permission approval. decision is one of approve (this request only), approve_for_session (stop asking for similar requests this session), or deny. request_id may be omitted when the child has exactly one pending request."
+    )]
+    async fn approve(
+        &self,
+        Parameters(p): Parameters<ApproveParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Ok(self
+            .run(OrchestrateOp::Approve {
+                parent_id: self.parent_id.clone(),
+                thread_id: p.thread_id,
+                request_id: p.request_id,
+                decision: p.decision,
             })
             .await)
     }
@@ -250,6 +274,9 @@ mod tests {
             .map(|tool| tool.name.to_string())
             .collect();
         names.sort();
-        assert_eq!(names, ["cancel", "dispatch", "result", "send", "status"]);
+        assert_eq!(
+            names,
+            ["approve", "cancel", "dispatch", "result", "send", "status"]
+        );
     }
 }

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -23,8 +23,8 @@ use tcode_core::provider_models::{ResolvedModel, picker_models, resolve_models};
 use tcode_core::provider_status::ProviderSnapshot;
 use tcode_core::session::{EntryContent, ReviewComment, Timeline, implement_prompt, plan_title};
 use tcode_core::settings::{
-    EnvVar, OrchestrateSettings, ProjectSort, ProviderProfile, ProviderSettings, ResolvedProfile,
-    Settings, provider_label,
+    ChildApprovalMode, EnvVar, OrchestrateSettings, ProjectSort, ProviderProfile, ProviderSettings,
+    ResolvedProfile, Settings, provider_label,
 };
 use tcode_services::acp_registry::{
     Registry, RegistryAgent, cached, install, load, platform_key, resolve_recipe, uninstall,
@@ -1243,6 +1243,33 @@ impl AppState {
                 }
                 Ok(serde_json::json!({ "ok": true }))
             }
+            OrchestrateOp::Approve {
+                parent_id,
+                thread_id,
+                request_id,
+                decision,
+            } => {
+                self.require_child(&parent_id, &thread_id)?;
+                let pending = self.pending_approvals_for(&thread_id);
+                let request = match request_id {
+                    Some(request_id) => pending
+                        .into_iter()
+                        .find(|request| request.id == request_id)
+                        .ok_or_else(|| "no pending approval with that request_id".to_string())?,
+                    None => match pending.as_slice() {
+                        [request] => request.clone(),
+                        [] => return Err("no pending approval".into()),
+                        _ => {
+                            return Err("multiple pending approvals; request_id is required".into());
+                        }
+                    },
+                };
+                let decision = resolve_approval_decision(&decision)?;
+                let request_id = request.id;
+                self.respond_session_approval(&thread_id, request_id.clone(), decision)?;
+                cx.notify();
+                Ok(serde_json::json!({ "ok": true, "request_id": request_id }))
+            }
         }
     }
 
@@ -1253,6 +1280,42 @@ impl AppState {
                 meta.id == thread_id && meta.parent_session_id.as_deref() == Some(parent_id)
             })
             .ok_or_else(|| "unknown thread or not a child of this parent".into())
+    }
+
+    fn pending_approvals_for(&self, session_id: &str) -> Vec<agent::ApprovalRequest> {
+        if let Some(active) = self.active.as_ref().filter(|a| a.meta.id == session_id) {
+            let pending = active.timeline.pending_approvals.clone();
+            if !pending.is_empty() {
+                return pending;
+            }
+        }
+        self.sessions_awaiting_approval
+            .get(session_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn respond_session_approval(
+        &mut self,
+        session_id: &str,
+        request_id: String,
+        decision: ApprovalDecision,
+    ) -> Result<(), String> {
+        let session = self
+            .active
+            .as_ref()
+            .filter(|session| session.meta.id == session_id)
+            .or_else(|| self.background.get(session_id))
+            .ok_or_else(|| "session is not loaded".to_string())?;
+        let Runtime::Live(commands) = &session.runtime else {
+            return Err("session is not live".into());
+        };
+        commands
+            .try_send(SessionCommand::RespondApproval {
+                request_id,
+                decision,
+            })
+            .map_err(|err| format!("failed to respond to approval: {err}"))
     }
 
     fn ensure_child_loaded(&mut self, thread_id: &str) -> Result<(), String> {
@@ -1319,16 +1382,16 @@ impl AppState {
 
     fn child_status_json(&self, meta: &SessionMeta) -> serde_json::Value {
         let (state, final_message, usage) = self.child_result(meta);
-        let waiting_approval = self
-            .pending_approval_for(&meta.id)
-            .as_ref()
-            .map(approval_request_summary);
+        let pending_approval = self.pending_approval_for(&meta.id);
+        let waiting_approval = pending_approval.as_ref().map(approval_request_summary);
+        let approval_request_id = pending_approval.as_ref().map(|request| request.id.as_str());
         let mut status = serde_json::json!({
             "thread_id": meta.id,
             "title": meta.title,
             "provider": match meta.provider { ProviderKind::ClaudeCode => "claude", ProviderKind::Codex => "codex", ProviderKind::Acp => "acp" },
             "state": state,
             "waiting_approval": waiting_approval,
+            "approval_request_id": approval_request_id,
             "last_output_tail": tail_chars(&final_message, 600),
             "updated_at": meta.updated_at,
         });
@@ -4132,6 +4195,17 @@ impl AppState {
         else {
             return;
         };
+        if self.settings.orchestrate.child_approval == ChildApprovalMode::AlwaysAllow {
+            if let Err(err) = self.respond_session_approval(
+                child_id,
+                request.id.clone(),
+                ApprovalDecision::ApproveForSession,
+            ) {
+                log::warn!("failed to auto-approve child {child_id}: {err}");
+            }
+            cx.notify();
+            return;
+        }
         if !self
             .callback_approval_requests
             .insert((child_id.to_string(), request.id.clone()))
@@ -4139,11 +4213,20 @@ impl AppState {
             return;
         }
         let parent_id = child.parent_session_id.as_deref().unwrap();
-        let text = format!(
-            "[orchestrate] thread {child_id} (\"{}\") is waiting for approval: {}.",
-            child.title,
-            approval_request_summary(request)
-        );
+        let text = match self.settings.orchestrate.child_approval {
+            ChildApprovalMode::Orchestrator => format!(
+                "[orchestrate] thread {child_id} (\"{}\") is waiting for approval: {} (request_id: {}). You are the approver: decide with the approve tool (decision: approve | approve_for_session | deny); deny anything outside the brief's scope.",
+                child.title,
+                approval_request_summary(request),
+                request.id
+            ),
+            ChildApprovalMode::Manual => format!(
+                "[orchestrate] thread {child_id} (\"{}\") is waiting for approval: {}.",
+                child.title,
+                approval_request_summary(request)
+            ),
+            ChildApprovalMode::AlwaysAllow => unreachable!(),
+        };
         self.deliver_orchestrate_callback_to_parent(parent_id, text, cx);
     }
 
@@ -6025,6 +6108,18 @@ fn resolve_dispatch_access(access: Option<&str>) -> Result<ApprovalMode, String>
         "workspace_write" => Ok(ApprovalMode::AutoAcceptEdits),
         _ => Err(format!(
             "unknown access: {access}; expected read_only, workspace_write, or full"
+        )),
+    }
+}
+
+fn resolve_approval_decision(decision: &str) -> Result<ApprovalDecision, String> {
+    let decision = decision.trim();
+    match decision.to_ascii_lowercase().as_str() {
+        "approve" => Ok(ApprovalDecision::Approve),
+        "approve_for_session" => Ok(ApprovalDecision::ApproveForSession),
+        "deny" => Ok(ApprovalDecision::Deny),
+        _ => Err(format!(
+            "unknown decision: {decision}; expected approve, approve_for_session, or deny"
         )),
     }
 }
@@ -7940,6 +8035,8 @@ mod tests {
             };
             assert!(text.starts_with("[orchestrate] thread child"));
             assert!(text.contains("waiting for approval: command `touch blocked`"));
+            assert!(text.contains("request_id: approval-1"));
+            assert!(text.contains("decide with the approve tool"));
             assert!(receiver.try_recv().is_err(), "callback was delivered twice");
 
             let status = state.child_status_json(&child);
@@ -7947,6 +8044,219 @@ mod tests {
                 status["waiting_approval"],
                 serde_json::json!("command `touch blocked`")
             );
+            assert_eq!(
+                status["approval_request_id"],
+                serde_json::json!("approval-1")
+            );
+        });
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[gpui::test]
+    fn child_approval_always_allow_responds_without_parent_callback(cx: &mut gpui::TestAppContext) {
+        let root = std::env::temp_dir().join(format!(
+            "tcode-orchestrate-approval-auto-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let store = SessionStore::open_at(root.clone()).unwrap();
+        let state = cx.new(|_| AppState::new(store));
+        let (parent_commands, parent_receiver) = async_channel::unbounded();
+        let (child_commands, child_receiver) = async_channel::unbounded();
+
+        state.update(cx, |state, cx| {
+            state.settings.orchestrate.child_approval = ChildApprovalMode::AlwaysAllow;
+            let mut parent = live_session(ProviderKind::Codex, parent_commands);
+            parent.meta.id = "parent".into();
+            parent.turn_in_flight = true;
+            state.background.insert(parent.meta.id.clone(), parent);
+
+            let mut child = live_session(ProviderKind::Codex, child_commands);
+            child.meta.id = "child".into();
+            child.meta.parent_session_id = Some("parent".into());
+            state.sessions.push(child.meta.clone());
+            state.background.insert(child.meta.id.clone(), child);
+
+            state.on_event(
+                "child",
+                AgentEvent::ApprovalRequested(agent::ApprovalRequest {
+                    id: "approval-auto".into(),
+                    turn_id: None,
+                    kind: agent::ApprovalKind::ExecCommand {
+                        command: "touch allowed".into(),
+                        cwd: None,
+                        reason: None,
+                    },
+                    options: Vec::new(),
+                }),
+                cx,
+            );
+
+            assert!(matches!(
+                child_receiver.try_recv(),
+                Ok(SessionCommand::RespondApproval {
+                    request_id,
+                    decision: ApprovalDecision::ApproveForSession,
+                }) if request_id == "approval-auto"
+            ));
+            assert!(
+                parent_receiver.try_recv().is_err(),
+                "always-allow must not notify the parent"
+            );
+        });
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[gpui::test]
+    fn child_approval_manual_preserves_legacy_notice_without_auto_response(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let root = std::env::temp_dir().join(format!(
+            "tcode-orchestrate-approval-manual-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let store = SessionStore::open_at(root.clone()).unwrap();
+        let state = cx.new(|_| AppState::new(store));
+        let (parent_commands, parent_receiver) = async_channel::unbounded();
+        let (child_commands, child_receiver) = async_channel::unbounded();
+
+        state.update(cx, |state, cx| {
+            state.settings.orchestrate.child_approval = ChildApprovalMode::Manual;
+            let mut parent = live_session(ProviderKind::Codex, parent_commands);
+            parent.meta.id = "parent".into();
+            parent.turn_in_flight = true;
+            state.background.insert(parent.meta.id.clone(), parent);
+
+            let mut child = live_session(ProviderKind::Codex, child_commands);
+            child.meta.id = "child".into();
+            child.meta.title = "Manual child".into();
+            child.meta.parent_session_id = Some("parent".into());
+            state.sessions.push(child.meta.clone());
+            state.background.insert(child.meta.id.clone(), child);
+
+            state.on_event(
+                "child",
+                AgentEvent::ApprovalRequested(agent::ApprovalRequest {
+                    id: "approval-manual".into(),
+                    turn_id: None,
+                    kind: agent::ApprovalKind::ExecCommand {
+                        command: "touch blocked".into(),
+                        cwd: None,
+                        reason: None,
+                    },
+                    options: Vec::new(),
+                }),
+                cx,
+            );
+
+            let SessionCommand::Steer { text, .. } = parent_receiver.try_recv().unwrap() else {
+                panic!("manual approval notice did not reach the parent")
+            };
+            assert_eq!(
+                text,
+                "[orchestrate] thread child (\"Manual child\") is waiting for approval: command `touch blocked`."
+            );
+            assert!(child_receiver.try_recv().is_err());
+        });
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[gpui::test]
+    fn orchestrate_approve_routes_decisions_and_validates_scope(cx: &mut gpui::TestAppContext) {
+        let root = std::env::temp_dir().join(format!(
+            "tcode-orchestrate-approve-op-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let store = SessionStore::open_at(root.clone()).unwrap();
+        let state = cx.new(|_| AppState::new(store));
+        let (commands, receiver) = async_channel::unbounded();
+
+        state.update(cx, |state, cx| {
+            let mut child = live_session(ProviderKind::Codex, commands);
+            child.meta.id = "child".into();
+            child.meta.parent_session_id = Some("parent".into());
+            state.sessions.push(child.meta.clone());
+            state.background.insert(child.meta.id.clone(), child);
+            state.sessions_awaiting_approval.insert(
+                "child".into(),
+                vec![agent::ApprovalRequest {
+                    id: "approval-op".into(),
+                    turn_id: None,
+                    kind: agent::ApprovalKind::ExecCommand {
+                        command: "cargo test".into(),
+                        cwd: None,
+                        reason: None,
+                    },
+                    options: Vec::new(),
+                }],
+            );
+
+            let result = state
+                .handle_orchestrate_op(
+                    orchestrate_mcp::OrchestrateOp::Approve {
+                        parent_id: "parent".into(),
+                        thread_id: "child".into(),
+                        request_id: None,
+                        decision: " APPROVE ".into(),
+                    },
+                    cx,
+                )
+                .unwrap();
+            assert_eq!(
+                result,
+                serde_json::json!({ "ok": true, "request_id": "approval-op" })
+            );
+            assert!(matches!(
+                receiver.try_recv(),
+                Ok(SessionCommand::RespondApproval {
+                    request_id,
+                    decision: ApprovalDecision::Approve,
+                }) if request_id == "approval-op"
+            ));
+
+            let unknown_request = state
+                .handle_orchestrate_op(
+                    orchestrate_mcp::OrchestrateOp::Approve {
+                        parent_id: "parent".into(),
+                        thread_id: "child".into(),
+                        request_id: Some("missing".into()),
+                        decision: "deny".into(),
+                    },
+                    cx,
+                )
+                .unwrap_err();
+            assert_eq!(unknown_request, "no pending approval with that request_id");
+
+            let bad_decision = state
+                .handle_orchestrate_op(
+                    orchestrate_mcp::OrchestrateOp::Approve {
+                        parent_id: "parent".into(),
+                        thread_id: "child".into(),
+                        request_id: Some("approval-op".into()),
+                        decision: "later".into(),
+                    },
+                    cx,
+                )
+                .unwrap_err();
+            assert_eq!(
+                bad_decision,
+                "unknown decision: later; expected approve, approve_for_session, or deny"
+            );
+
+            let non_child = state
+                .handle_orchestrate_op(
+                    orchestrate_mcp::OrchestrateOp::Approve {
+                        parent_id: "other-parent".into(),
+                        thread_id: "child".into(),
+                        request_id: Some("approval-op".into()),
+                        decision: "deny".into(),
+                    },
+                    cx,
+                )
+                .unwrap_err();
+            assert_eq!(non_child, "unknown thread or not a child of this parent");
         });
 
         let _ = std::fs::remove_dir_all(root);

--- a/crates/ui/src/orchestrate_settings.rs
+++ b/crates/ui/src/orchestrate_settings.rs
@@ -2,14 +2,16 @@
 //! allow list. Every main model is eligible; only child dispatch is gated.
 
 use gpui::{
-    AnyElement, App, AppContext as _, Context, Entity, IntoElement, ParentElement as _, Render,
-    Styled as _, Subscription, Window, div, prelude::FluentBuilder as _, px,
+    AnyElement, App, AppContext as _, Context, Entity, InteractiveElement as _, IntoElement,
+    ParentElement as _, Render, StatefulInteractiveElement as _, Styled as _, Subscription, Window,
+    div, prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
     ActiveTheme as _, Icon, IconName, Sizable as _, StyledExt as _,
     button::{Button, ButtonVariants as _},
     h_flex,
     input::{Input, InputEvent, InputState},
+    popover::Popover,
     switch::Switch,
     v_flex,
 };
@@ -20,7 +22,8 @@ use tcode_runtime::app::AppState;
 use crate::provider_card::provider_glyph;
 use crate::provider_model_picker::{ModelOption, ProviderModelPicker};
 use crate::settings::{
-    OrchestrateChildModel, OrchestrateSettings, OrchestratorIdentity, Settings, provider_label,
+    ChildApprovalMode, OrchestrateChildModel, OrchestrateSettings, OrchestratorIdentity, Settings,
+    provider_label,
 };
 
 struct IdentityRowState {
@@ -548,6 +551,139 @@ impl OrchestrateSettingsPanel {
             .into_any_element()
     }
 
+    fn render_child_approval(&self, cx: &mut Context<Self>) -> AnyElement {
+        let selected = self.app_state.read(cx).settings.orchestrate.child_approval;
+        let selected_label = match selected {
+            ChildApprovalMode::Orchestrator => {
+                tcode_i18n::tr!("orchestrate.child_approval.orchestrator")
+            }
+            ChildApprovalMode::AlwaysAllow => {
+                tcode_i18n::tr!("orchestrate.child_approval.always_allow")
+            }
+            ChildApprovalMode::Manual => tcode_i18n::tr!("orchestrate.child_approval.manual"),
+        };
+        let trigger = Button::new("orchestrate-child-approval-dropdown")
+            .outline()
+            .compact()
+            .child(
+                h_flex()
+                    .w(px(180.))
+                    .items_center()
+                    .justify_between()
+                    .gap_2()
+                    .text_size(px(13.))
+                    .child(selected_label)
+                    .child(
+                        Icon::new(IconName::ChevronDown)
+                            .xsmall()
+                            .text_color(cx.theme().muted_foreground),
+                    ),
+            );
+        let panel = cx.entity();
+        let dropdown = Popover::new("orchestrate-child-approval-popover")
+            .trigger(trigger)
+            .content(move |_, _, cx| {
+                let option = |mode: ChildApprovalMode,
+                              id: &'static str,
+                              label: gpui::SharedString,
+                              cx: &mut Context<gpui_component::popover::PopoverState>|
+                 -> AnyElement {
+                    let panel = panel.clone();
+                    let popover = cx.entity();
+                    h_flex()
+                        .id(id)
+                        .w_full()
+                        .px_2()
+                        .py_1()
+                        .gap_2()
+                        .items_center()
+                        .rounded(crate::material::radius_button())
+                        .text_size(px(13.))
+                        .cursor_pointer()
+                        .hover(|style| style.bg(cx.theme().accent))
+                        .child(div().flex_1().child(label))
+                        .when(mode == selected, |row| {
+                            row.child(Icon::new(IconName::Check).xsmall())
+                        })
+                        .on_click(move |_, window, cx| {
+                            panel.update(cx, |panel, cx| {
+                                panel.update_settings(
+                                    |settings| settings.orchestrate.child_approval = mode,
+                                    cx,
+                                );
+                            });
+                            popover.update(cx, |state, cx| state.dismiss(window, cx));
+                        })
+                        .into_any_element()
+                };
+                crate::material::overlay_contour(
+                    v_flex()
+                        .p_1()
+                        .min_w(px(180.))
+                        .gap_0p5()
+                        .child(option(
+                            ChildApprovalMode::Orchestrator,
+                            "orchestrate-child-approval-orchestrator",
+                            tcode_i18n::tr!("orchestrate.child_approval.orchestrator")
+                                .into_owned()
+                                .into(),
+                            cx,
+                        ))
+                        .child(option(
+                            ChildApprovalMode::AlwaysAllow,
+                            "orchestrate-child-approval-always-allow",
+                            tcode_i18n::tr!("orchestrate.child_approval.always_allow")
+                                .into_owned()
+                                .into(),
+                            cx,
+                        ))
+                        .child(option(
+                            ChildApprovalMode::Manual,
+                            "orchestrate-child-approval-manual",
+                            tcode_i18n::tr!("orchestrate.child_approval.manual")
+                                .into_owned()
+                                .into(),
+                            cx,
+                        )),
+                    cx,
+                )
+                .rounded(crate::material::radius_overlay())
+            });
+
+        self.group(cx)
+            .child(
+                h_flex()
+                    .w_full()
+                    .min_h(px(56.))
+                    .px_3()
+                    .py_2()
+                    .gap_3()
+                    .items_center()
+                    .child(
+                        v_flex()
+                            .flex_1()
+                            .min_w_0()
+                            .gap_0p5()
+                            .child(
+                                div()
+                                    .text_size(px(13.))
+                                    .font_medium()
+                                    .child(tcode_i18n::tr!("orchestrate.child_approval.title")),
+                            )
+                            .child(
+                                div()
+                                    .text_size(px(11.))
+                                    .text_color(cx.theme().muted_foreground)
+                                    .child(tcode_i18n::tr!(
+                                        "orchestrate.child_approval.description"
+                                    )),
+                            ),
+                    )
+                    .child(dropdown),
+            )
+            .into_any_element()
+    }
+
     fn section_heading(
         &self,
         title: impl Into<gpui::SharedString>,
@@ -927,6 +1063,7 @@ impl Render for OrchestrateSettingsPanel {
                     .child(tcode_i18n::tr!("settings.orchestrate_section")),
             )
             .child(self.render_intro(cx))
+            .child(self.render_child_approval(cx))
             .child(self.render_identities(cx))
             .child(self.render_children(cx))
     }

--- a/crates/ui/src/settings.rs
+++ b/crates/ui/src/settings.rs
@@ -36,8 +36,9 @@ pub fn apply_locale(override_locale: Option<&str>) {
 }
 
 pub use tcode_core::settings::{
-    EnvVar, OrchestrateChildModel, OrchestrateSettings, OrchestratorIdentity, ProjectSort,
-    ProviderSettings, Settings, ThemeMode, TitleGenerationSettings, provider_key, provider_label,
+    ChildApprovalMode, EnvVar, OrchestrateChildModel, OrchestrateSettings, OrchestratorIdentity,
+    ProjectSort, ProviderSettings, Settings, ThemeMode, TitleGenerationSettings, provider_key,
+    provider_label,
 };
 /// The six accent presets offered by the provider card (T3 §2).
 pub const ACCENT_PRESETS: [&str; 6] = [

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -170,6 +170,12 @@ model_picker:
   no_models: "No models available for this provider."
 orchestrate:
   restore_default: "Restore default"
+  child_approval:
+    title: "Child approvals"
+    description: "Who answers when a dispatched child thread hits a permission gate. Decision-layer routes the request to the lead model, which answers with the approve tool; Always allow auto-approves for the session; Manual waits for you to answer in the child thread."
+    orchestrator: "Decision-layer approval"
+    always_allow: "Always allow"
+    manual: "Manual approval"
   all_models:
     title: "Built-in /orchestrate command"
     description: "These settings control what tcode injects when you send /orchestrate: how the current model understands its lead role, and which configured child models the orchestration MCP may dispatch work to. Every main model can use the command; models without an override inherit the generic identity."

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -170,6 +170,12 @@ model_picker:
   no_models: "此提供方暂无可用模型。"
 orchestrate:
   restore_default: "恢复默认"
+  child_approval:
+    title: "子线程审批"
+    description: "派发的子线程遇到权限门槛时由谁来审批。决策层审批会将请求转交主线程模型,由其通过 approve 工具决定;永久允许会在会话内自动批准;手动审批则等待你在子线程中亲自处理。"
+    orchestrator: "决策层审批"
+    always_allow: "永久允许"
+    manual: "手动审批"
   all_models:
     title: "内建 /orchestrate 命令"
     description: "这里控制发送 /orchestrate 时 tcode 注入的内容：当前模型如何理解自己的主决策角色，以及编排 MCP 可以把任务派发给哪些子模型。所有主模型都能使用该命令；没有专属覆盖时会继承通用自我认知。"


### PR DESCRIPTION
## Summary

When a dispatched orchestrate child thread hits a permission gate, the parent used to receive a notice with no way to answer — a parked child stayed blocked until the user foregrounded it. This PR adds a real decision path, governed by a new **Settings → Orchestrate → Child approvals** setting:

- **Decision-layer approval** (default): the approval request is routed to the lead model as an `[orchestrate]` message carrying the `request_id`; the model answers with a new `approve` MCP tool (`approve` | `approve_for_session` | `deny`).
- **Always allow**: child requests are auto-approved for the session (`ApproveForSession`), no parent callback.
- **Manual approval**: legacy behavior — the notice is delivered and the user answers in the child's composer.

## Changes

- `tcode-core`: `ChildApprovalMode` enum (`orchestrator` default / `always_allow` / `manual`), `#[serde(default)]` so existing settings.json files keep working.
- `tcode-runtime`: `deliver_child_approval_callback` branches on the mode; new `respond_session_approval` helper reaches background children (previously only the foreground session could answer); `OrchestrateOp::Approve` handler with parent scoping, pending-request validation, and decision parsing; `status` JSON now includes `approval_request_id`.
- `orchestrate-mcp`: new `approve {thread_id, request_id?, decision}` tool.
- `tcode-ui`: Child approvals dropdown on the Orchestrate settings panel.
- Locales (en, zh-CN) and orchestrate prompt assets updated.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — includes new tests: settings serde default/round-trip, tool registration, and runtime tests covering all three modes plus `Approve` op happy path and error scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)