### PR TITLE
chore(deps): bump sysinfo to 0.39.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5403,6 +5403,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5444,6 +5454,17 @@ dependencies = [
  "bitflags 2.13.0",
  "block2 0.6.2",
  "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
  "objc2-foundation 0.3.2",
 ]
 
@@ -8157,6 +8178,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.39.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8392,7 +8428,7 @@ dependencies = [
  "alacritty_terminal",
  "async-channel",
  "libc",
- "sysinfo",
+ "sysinfo 0.39.6",
 ]
 
 [[package]]
@@ -10801,7 +10837,7 @@ dependencies = [
  "rand 0.8.6",
  "screencapturekit",
  "screencapturekit-sys",
- "sysinfo",
+ "sysinfo 0.31.4",
  "tao-core-video-sys",
  "windows 0.61.3",
  "windows-capture",

--- a/crates/term/Cargo.toml
+++ b/crates/term/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 alacritty_terminal = { git = "https://github.com/zed-industries/alacritty", rev = "9d9640d4" }
 async-channel = "2"
-sysinfo = "0.31"
+sysinfo = "0.39"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/term/src/pty_info.rs
+++ b/crates/term/src/pty_info.rs
@@ -61,11 +61,11 @@ impl PtyInfo {
             return None;
         }
         let pid = Pid::from_u32(pid);
-        let refresh = ProcessRefreshKind::new()
+        let refresh = ProcessRefreshKind::nothing()
             .with_cwd(UpdateKind::Always)
             .with_exe(UpdateKind::Always);
         let mut system = System::new();
-        system.refresh_processes_specifics(ProcessesToUpdate::Some(&[pid]), refresh);
+        system.refresh_processes_specifics(ProcessesToUpdate::Some(&[pid]), false, refresh);
         let process = system.process(pid)?;
         Some(ProcessInfo {
             name: process.name().to_string_lossy().into_owned(),


### PR DESCRIPTION
Supersedes #71 with the required API migration in `crates/term/src/pty_info.rs`:
- `ProcessRefreshKind::new()` → `nothing()`
- `refresh_processes_specifics` gained a remove-dead-processes flag (`false` for this targeted one-PID refresh)

Local `cargo check -p term` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)