### PR TITLE
fix(sidebar): orchestrate child-thread indicator + stable width across fullscreen

### DIFF
--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -107,11 +107,15 @@ pub struct AppShell {
     right_width: Rc<Cell<Pixels>>,
     /// Whether the open right panel has already been given its width.
     right_sized: bool,
+    /// Stable expanded-sidebar width. The resizable component otherwise scales
+    /// every panel proportionally when the window enters or leaves fullscreen.
+    sidebar_width: Rc<Cell<Pixels>>,
     _subscriptions: Vec<Subscription>,
 }
 
 /// The right panel's default width (`docs/DESIGN.md`).
 const RIGHT_PANEL_WIDTH: f32 = 560.;
+const SIDEBAR_WIDTH: f32 = 255.;
 
 impl AppShell {
     pub fn new(app_state: Entity<AppState>, window: &mut Window, cx: &mut Context<Self>) -> Self {
@@ -176,6 +180,7 @@ impl AppShell {
             split: cx.new(|_| ResizableState::default()),
             right_width: Rc::new(Cell::new(px(RIGHT_PANEL_WIDTH))),
             right_sized: false,
+            sidebar_width: Rc::new(Cell::new(px(SIDEBAR_WIDTH))),
             _subscriptions: vec![subscription, event_subscription],
         }
     }
@@ -365,6 +370,18 @@ impl Render for AppShell {
         // and the sidebar is only a panel when it is expanded.
         let right_ix = if collapsed { 1 } else { 2 };
 
+        // gpui-component preserves panel *ratios* when its container changes
+        // width. Fullscreen is a container resize, but the sidebar is a fixed
+        // navigation column: restore its remembered pixel width before layout.
+        if !collapsed {
+            let width = self.sidebar_width.get();
+            self.split.update(cx, |state, cx| {
+                if state.sizes().first().is_some_and(|size| *size != width) {
+                    state.resize_panel(0, width, window, cx);
+                }
+            });
+        }
+
         // Give the right panel its width once the group knows about it (the
         // panel count is synced while the group renders, so this lands on the
         // frame after it opens — the group notifies, so that frame comes).
@@ -409,13 +426,18 @@ impl Render for AppShell {
             );
 
         // Remember a dragged width so re-opening the panel restores it.
-        let remembered = self.right_width.clone();
+        let remembered_right = self.right_width.clone();
+        let remembered_sidebar = self.sidebar_width.clone();
         let group = |id: &'static str| {
             h_resizable(id)
                 .with_state(&self.split)
                 .on_resize(move |state, _, cx| {
-                    if let Some(size) = state.read(cx).sizes().get(right_ix) {
-                        remembered.set(*size);
+                    let sizes = state.read(cx).sizes();
+                    if !collapsed && let Some(size) = sizes.first() {
+                        remembered_sidebar.set(*size);
+                    }
+                    if let Some(size) = sizes.get(right_ix) {
+                        remembered_right.set(*size);
                     }
                 })
         };
@@ -440,7 +462,7 @@ impl Render for AppShell {
                 .child(
                     resizable_panel()
                         .flex_none()
-                        .size(px(255.))
+                        .size(px(SIDEBAR_WIDTH))
                         .size_range(px(220.)..px(380.))
                         .child(self.sidebar.clone()),
                 )

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -54,8 +54,21 @@ fn truncated_sidebar_label() -> gpui::Div {
     div().flex_1().min_w_0().truncate()
 }
 
-fn active_child_count_badge(count: usize, cx: &mut Context<SessionsSidebar>) -> gpui::Div {
+fn child_count_badge(
+    session_id: &str,
+    total: usize,
+    active: usize,
+    cx: &mut Context<SessionsSidebar>,
+) -> gpui::Stateful<gpui::Div> {
+    let label = if active > 0 {
+        format!("{active}/{total}")
+    } else {
+        total.to_string()
+    };
     div()
+        .id(gpui::SharedString::from(format!(
+            "child-count-{session_id}"
+        )))
         .flex_none()
         .min_w(px(18.))
         .px_1()
@@ -65,14 +78,23 @@ fn active_child_count_badge(count: usize, cx: &mut Context<SessionsSidebar>) -> 
         .text_center()
         .text_size(px(10.))
         .font_semibold()
-        .text_color(cx.theme().success)
-        .child(count.to_string())
+        .text_color(if active > 0 {
+            cx.theme().success
+        } else {
+            cx.theme().muted_foreground
+        })
+        .tooltip(move |window, cx| {
+            Tooltip::new(tcode_i18n::tr!("sidebar.child_threads", count = total).into_owned())
+                .build(window, cx)
+        })
+        .child(label)
 }
 
 #[derive(Debug, PartialEq, Eq)]
 struct ThreadRenderState {
     is_child: bool,
     show_unread: bool,
+    direct_children: usize,
     active_direct_children: usize,
 }
 
@@ -87,6 +109,10 @@ fn derive_thread_render_state(
         .parent_session_id
         .as_ref()
         .is_some_and(|parent_id| sessions.iter().any(|session| session.id == *parent_id));
+    let direct_children = sessions
+        .iter()
+        .filter(|session| session.parent_session_id.as_deref() == Some(meta.id.as_str()))
+        .count();
     let active_direct_children = sessions
         .iter()
         .filter(|session| session.parent_session_id.as_deref() == Some(meta.id.as_str()))
@@ -98,6 +124,7 @@ fn derive_thread_render_state(
         // Orphaned child metadata is still child metadata and must not surface
         // completion unread state as an ordinary-thread blue dot.
         show_unread: meta.parent_session_id.is_none() && unread && !working,
+        direct_children,
         active_direct_children,
     }
 }
@@ -841,13 +868,10 @@ impl SessionsSidebar {
         };
         let is_child = render_state.is_child;
         let show_unread = render_state.show_unread;
+        let direct_children = render_state.direct_children;
         let active_direct_children = render_state.active_direct_children;
-        let has_direct_children = self
-            .app_state
-            .read(cx)
-            .sessions
-            .iter()
-            .any(|session| session.parent_session_id.as_deref() == Some(session_id.as_str()));
+        let has_direct_children = direct_children > 0;
+        let children_collapsed = self.collapsed_parents.contains(&session_id);
 
         // Inline rename takes over the whole row's content area.
         let renaming = self
@@ -935,6 +959,18 @@ impl SessionsSidebar {
                         .text_color(cx.theme().muted_foreground)
                         .child("↳"),
                 )
+            })
+            .when(has_direct_children, |row| {
+                row.child(
+                    Icon::new(if children_collapsed {
+                        IconName::ChevronRight
+                    } else {
+                        IconName::ChevronDown
+                    })
+                    .flex_none()
+                    .size_3()
+                    .text_color(cx.theme().muted_foreground),
+                )
             });
 
         // Row body: rename input, or the (unread dot + worktree glyph + title).
@@ -946,8 +982,13 @@ impl SessionsSidebar {
                     .on_mouse_down_out(cx.listener(|this, _, _, cx| this.cancel_rename(cx)))
                     .child(Input::new(&input).small()),
             )
-            .when(active_direct_children > 0, |row| {
-                row.child(active_child_count_badge(active_direct_children, cx))
+            .when(has_direct_children, |row| {
+                row.child(child_count_badge(
+                    &session_id,
+                    direct_children,
+                    active_direct_children,
+                    cx,
+                ))
             })
         } else {
             row.when(show_unread, |row| {
@@ -973,8 +1014,13 @@ impl SessionsSidebar {
                     .text_color(cx.theme().sidebar_foreground)
                     .child(meta.title.clone()),
             )
-            .when(active_direct_children > 0, |row| {
-                row.child(active_child_count_badge(active_direct_children, cx))
+            .when(has_direct_children, |row| {
+                row.child(child_count_badge(
+                    &session_id,
+                    direct_children,
+                    active_direct_children,
+                    cx,
+                ))
             })
             .when(!working, |row| {
                 // Right slot: relative time, replaced by an archive button on hover.
@@ -1447,6 +1493,7 @@ mod tests {
             matches!(id, "child-working" | "grandchild-working")
         });
 
+        assert_eq!(state.direct_children, 2);
         assert_eq!(state.active_direct_children, 1);
     }
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -57,6 +57,8 @@ Canonical values live in `themes/tcode.json` (embedded at build time).
 - Composer: floating card, radius 16, 1px border, subtle shadow; bottom control
   row ≈44px.
 - Sidebar thread rows ≈30px, 13px text, 4px-radius hover bg.
+- Parent thread rows always show a disclosure chevron and total-child badge;
+  when children are active, the badge reads active/total in the success color.
 
 ## Scrolling contract
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -85,6 +85,7 @@ sidebar:
   show_more: "Show more"
   show_less: "Show less"
   working: "Working"
+  child_threads: "%{count} child threads"
   waiting_approval: "Approval"
   waiting_approval_tooltip: "Waiting for approval"
   archive: "Archive thread"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -85,6 +85,7 @@ sidebar:
   show_more: "显示更多"
   show_less: "收起"
   working: "工作中"
+  child_threads: "%{count} 个子对话"
   waiting_approval: "待审批"
   waiting_approval_tooltip: "正在等待审批"
   archive: "归档对话"


### PR DESCRIPTION
Two sidebar fixes:

**Orchestrate child-thread visibility.** Parent rows with child threads now always show a disclosure chevron (right = collapsed, down = expanded) and a child-count badge — `active/total` in success color while children are active, muted total otherwise, with a localized tooltip. Previously a collapsed parent looked like an ordinary empty conversation.

**macOS sidebar width jump on fullscreen.** `gpui-component`'s `ResizableState::adjust_to_container_size` rescales panels proportionally on container resizes, so entering/leaving fullscreen changed the sidebar's width. The shell now remembers the sidebar's pixel width (default 255px or the user-dragged value; `on_resize` only fires on real drags — verified in component source) and restores it on render after container resizes.

Gates: fmt / clippy -D warnings / workspace tests (517 passed) all green locally; app launch-tested on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)