### PR TITLE
fix(ui): stabilize streaming markdown layout, intrinsic user bubbles, scrollable tables

### DIFF
--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -602,7 +602,12 @@ impl MdState {
     fn sync(&mut self, text: String, cx: &mut App) {
         match md_sync(&self.synced, &text) {
             MdSync::Noop => {}
-            MdSync::Push(_) | MdSync::Reset(_) => {
+            MdSync::Push(delta) => {
+                self.state
+                    .update(cx, |state, cx| state.push_str(&delta, cx));
+                self.synced = Arc::from(text);
+            }
+            MdSync::Reset(_) => {
                 self.state.update(cx, |state, cx| state.set_text(&text, cx));
                 self.synced = Arc::from(text);
             }
@@ -789,6 +794,7 @@ impl ChatView {
     /// `pinned` carries the ids of the last user / last assistant message in the
     /// whole timeline: their action rows stay visible instead of waiting for a
     /// hover, so Copy is never invisible-and-hover-only.
+    #[allow(clippy::too_many_arguments)]
     fn render_turn(
         &self,
         index: usize,
@@ -796,6 +802,7 @@ impl ChatView {
         cwd: &Path,
         entries: &[Arc<TimelineEntry>],
         pinned: (Option<&str>, Option<&str>),
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let mut column = v_flex().w_full().gap_4();
@@ -858,6 +865,7 @@ impl ChatView {
                             *context_len,
                             *steering,
                             pinned.0 == Some(entry.id.as_str()),
+                            window,
                             cx,
                         ));
                     }
@@ -959,6 +967,7 @@ impl ChatView {
                 *context_len,
                 *steering,
                 pinned.0 == Some(entry.id.as_str()),
+                window,
                 cx,
             ));
         }
@@ -1075,6 +1084,7 @@ impl ChatView {
         context_len: Option<usize>,
         steering: Option<SteeringStatus>,
         pinned: bool,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
         // An `/orchestrate` turn folds an injected context prefix (guidance +
@@ -1085,6 +1095,16 @@ impl ChatView {
             .filter(|len| *len <= text.len() && text.is_char_boundary(*len))
             .map(|len| &text[..len]);
         let visible = user_visible_text(text, context_len);
+        let text_style = window.text_style();
+        let text_width = visible.lines().fold(px(0.), |width, line| {
+            let run = text_style.to_run(line.len());
+            width.max(
+                window
+                    .text_system()
+                    .layout_line(line, px(15.), &[run], None)
+                    .width,
+            )
+        });
 
         let group_key = SharedString::from(format!("user-{entry_id}"));
         let mut actions = h_flex()
@@ -1129,6 +1149,8 @@ impl ChatView {
             .child({
                 let pending = steering == Some(SteeringStatus::Pending);
                 div()
+                    .w(text_width + px(32.))
+                    .flex_none()
                     .max_w_3_4()
                     .px_4()
                     .py_3()
@@ -2718,7 +2740,7 @@ impl Render for ChatView {
         let item_cwd = cwd.clone();
         let timeline = list(
             self.list_state.clone(),
-            cx.processor(move |this, index: usize, _window, cx| {
+            cx.processor(move |this, index: usize, window, cx| {
                 let Some(item) = this.turn_items.get(index) else {
                     return div().into_any_element();
                 };
@@ -2744,6 +2766,7 @@ impl Render for ChatView {
                     &item_cwd,
                     &entries,
                     (last_user_id.as_deref(), last_assistant_id.as_deref()),
+                    window,
                     cx,
                 );
                 h_flex()

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -11,10 +11,10 @@ use std::{
 use gpui::{
     AnyElement, App, AvailableSpace, Axis, Bounds, Element, ElementId, Entity, FontStyle,
     FontWeight, GlobalElementId, HighlightStyle, InspectorElementId, InteractiveElement as _,
-    IntoElement, LayoutId, Length, ListSizingBehavior, ListState, ObjectFit, Overflow,
-    ParentElement as _, Pixels, ScrollHandle, SharedString, StatefulInteractiveElement as _, Style,
-    StyleRefinement, Styled as _, StyledImage as _, Window, div, img, prelude::FluentBuilder as _,
-    px, relative, rems, size,
+    IntoElement, LayoutId, ListSizingBehavior, ListState, ObjectFit, ParentElement as _, Pixels,
+    ScrollHandle, SharedString, StatefulInteractiveElement as _, Style, StyleRefinement,
+    Styled as _, StyledImage as _, Window, div, img, prelude::FluentBuilder as _, px, relative,
+    rems, size,
 };
 use gpui_component::{
     ActiveTheme as _, StyledExt as _, h_flex, highlighter::HighlightTheme, scroll::ScrollableMask,
@@ -142,21 +142,18 @@ pub(super) fn render_root(
     let blocks = children.clone();
     let state = state.clone();
     let style = style.clone();
-    // `Infer` asks its item renderer for min-content width during request-layout.
-    // Pinning each block to the last real parent width prevents those narrow,
-    // wrapped heights from poisoning ListState while this one measuring frame
-    // establishes the exact full document height.
-    div()
-        .id("root")
-        .w_full()
-        .child(
-            gpui::list(list_state, move |ix, window, cx| {
-                render_root_block(&blocks, ix, measurements.width, &state, &style, window, cx)
-            })
-            .with_sizing_behavior(ListSizingBehavior::Infer)
-            .w_full(),
-        )
-        .into_any_element()
+    // `Infer` asks for min-content width during request-layout. Pin the list and
+    // its blocks to the last real parent width so that intrinsic probes cannot
+    // invalidate ListState at a narrow width while this frame measures height.
+    let list = gpui::list(list_state, move |ix, window, cx| {
+        render_root_block(&blocks, ix, measurements.width, &state, &style, window, cx)
+    })
+    .with_sizing_behavior(ListSizingBehavior::Infer)
+    .w_full()
+    .when(measurements.width > px(0.), |list| {
+        list.w(measurements.width)
+    });
+    div().id("root").w_full().child(list).into_any_element()
 }
 
 fn render_root_block(
@@ -966,23 +963,11 @@ fn render_table(
     window: &mut Window,
     cx: &mut App,
 ) -> AnyElement {
-    const DEFAULT_LENGTH: usize = 5;
-
-    let mut col_lens = Vec::new();
+    let mut column_count = 0;
     for row in &table.children {
-        for (ix, cell) in row.children.iter().enumerate() {
-            if col_lens.len() <= ix {
-                col_lens.push(DEFAULT_LENGTH);
-            }
-            col_lens[ix] = col_lens[ix].max(cell.children.text().chars().count());
-        }
+        column_count = column_count.max(row.children.len());
     }
-
-    if matches!(style.table.overflow.x, Some(Overflow::Scroll)) {
-        render_scroll_table(table, col_lens.len(), options, view, style, window, cx)
-    } else {
-        render_wrap_table(table, &col_lens, options, view, style, cx)
-    }
+    render_scroll_table(table, column_count, options, view, style, window, cx)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -997,30 +982,50 @@ fn render_scroll_table(
 ) -> AnyElement {
     const CELL_PAD_PX: f32 = 16.;
     const CELL_MIN_PX: f32 = 48.;
-    const CELL_MAX_PX: f32 = 480.;
 
     let text_style = window.text_style();
     let font_size = text_style.font_size.to_pixels(window.rem_size());
     let mut widths = vec![CELL_MIN_PX; column_count];
-    for row in &table.children {
+    for (row_ix, row) in table.children.iter().enumerate() {
         for (ix, cell) in row.children.iter().enumerate() {
             let Some(slot) = widths.get_mut(ix) else {
                 continue;
             };
-            let mut width = 0_f32;
-            for line in cell.children.text().split('\n') {
-                let line = line.trim();
-                if line.is_empty() {
-                    continue;
+            let mut width = Pixels::ZERO;
+            let mut line_width = Pixels::ZERO;
+            for child in &cell.children.children {
+                let mut run_style = text_style.clone();
+                if row_ix == 0 {
+                    run_style.font_weight = FontWeight::SEMIBOLD;
                 }
-                let run = text_style.to_run(line.len());
-                let line_width = window
-                    .text_system()
-                    .layout_line(line, font_size, &[run], None)
-                    .width;
-                width = width.max(f32::from(line_width));
+                for (_, mark) in &child.marks {
+                    if mark.bold {
+                        run_style.font_weight = FontWeight::BOLD;
+                    }
+                    if mark.italic {
+                        run_style.font_style = FontStyle::Italic;
+                    }
+                    if mark.code {
+                        run_style.font_family = cx.theme().mono_font_family.clone();
+                    }
+                }
+                for (line_ix, fragment) in child.text.split('\n').enumerate() {
+                    if line_ix > 0 {
+                        width = width.max(line_width);
+                        line_width = Pixels::ZERO;
+                    }
+                    if fragment.is_empty() {
+                        continue;
+                    }
+                    let run = run_style.to_run(fragment.len());
+                    line_width += window
+                        .text_system()
+                        .layout_line(fragment, font_size, &[run], None)
+                        .width;
+                }
             }
-            *slot = slot.max((width + CELL_PAD_PX).clamp(CELL_MIN_PX, CELL_MAX_PX));
+            width = width.max(line_width);
+            *slot = slot.max(f32::from(width) + CELL_PAD_PX);
         }
     }
     let total_width = widths.iter().sum::<f32>();
@@ -1049,7 +1054,6 @@ fn render_scroll_table(
                         .flex_basis(px(widths.get(ix).copied().unwrap_or(CELL_MIN_PX)))
                         .flex_grow(widths.get(ix).copied().unwrap_or(CELL_MIN_PX))
                         .flex_shrink_0()
-                        .overflow_hidden()
                         .whitespace_nowrap()
                         .flex()
                         .px_2()
@@ -1084,6 +1088,19 @@ fn render_scroll_table(
         .use_keyed_state(scroll_key, cx, |_, _| ScrollHandle::default())
         .read(cx)
         .clone();
+    let track = v_flex()
+        .min_w_full()
+        .w(px(total_width))
+        .border_1()
+        .border_color(cx.theme().border)
+        .rounded(cx.theme().radius)
+        .overflow_hidden()
+        .children(rows);
+    #[cfg(test)]
+    let track = {
+        let selector = format!("markdown-table-track-{}", options.path);
+        track.debug_selector(move || selector.clone())
+    };
     div()
         .id(options.path.clone())
         .w_full()
@@ -1096,100 +1113,8 @@ fn render_scroll_table(
             format!("{}-viewport", options.path),
             &scroll,
             &style.table,
-            v_flex()
-                .min_w_full()
-                .w(px(total_width))
-                .border_1()
-                .border_color(cx.theme().border)
-                .rounded(cx.theme().radius)
-                .overflow_hidden()
-                .children(rows),
+            track,
         ))
-        .into_any_element()
-}
-
-fn render_wrap_table(
-    table: &Table,
-    col_lens: &[usize],
-    options: &RenderOptions,
-    view: &Entity<MarkdownState>,
-    style: &TextViewStyle,
-    cx: &mut App,
-) -> AnyElement {
-    const MAX_LENGTH: usize = 150;
-
-    let row_count = table.children.len();
-    let rows = table
-        .children
-        .iter()
-        .enumerate()
-        .map(|(row_ix, row)| {
-            div()
-                .id(("table-row", row_ix))
-                .w_full()
-                .flex()
-                .flex_row()
-                .when(row_ix == 0, |this| {
-                    this.bg(cx.theme().tokens.muted)
-                        .font_weight(FontWeight::SEMIBOLD)
-                })
-                .when(row_ix + 1 < row_count, |this| {
-                    this.border_b_1().border_color(cx.theme().border)
-                })
-                .children(row.children.iter().enumerate().map(|(ix, cell)| {
-                    let align = table.column_align(ix);
-                    let len = col_lens
-                        .get(ix)
-                        .copied()
-                        .unwrap_or(MAX_LENGTH)
-                        .min(MAX_LENGTH);
-                    div()
-                        .id(("table-cell", ix))
-                        .overflow_hidden()
-                        .min_w_16()
-                        .w(Length::Definite(relative(len as f32)))
-                        .flex()
-                        .px_2()
-                        .py_1()
-                        .when(align == ColumnumnAlign::Center, |this| this.text_center())
-                        .when(align == ColumnumnAlign::Right, |this| this.text_right())
-                        .when(align == ColumnumnAlign::Center, |this| {
-                            this.justify_center()
-                        })
-                        .when(align == ColumnumnAlign::Right, |this| this.justify_end())
-                        .when(ix + 1 < row.children.len(), |this| {
-                            this.border_r_1().border_color(cx.theme().border)
-                        })
-                        .refine_style(&style.table_cell)
-                        .child(render_paragraph(
-                            &cell.children,
-                            &format!("{}-{row_ix}-{ix}", options.path),
-                            view,
-                            style,
-                            cx,
-                        ))
-                }))
-        })
-        .collect::<Vec<_>>();
-
-    div()
-        .id(options.path.clone())
-        .w_full()
-        .pb(if options.is_last {
-            rems(0.)
-        } else {
-            style.paragraph_gap
-        })
-        .child(
-            v_flex()
-                .w_full()
-                .border_1()
-                .border_color(cx.theme().border)
-                .rounded(cx.theme().radius)
-                .overflow_hidden()
-                .children(rows)
-                .refine_style(&style.table),
-        )
         .into_any_element()
 }
 

--- a/crates/ui/src/markdown/state.rs
+++ b/crates/ui/src/markdown/state.rs
@@ -56,7 +56,7 @@ impl MarkdownState {
             return;
         }
         self.text.push_str(text);
-        self.reparse(cx);
+        self.reparse_append(cx);
     }
 
     /// Replace the canonical source and synchronously reparse it.
@@ -66,7 +66,7 @@ impl MarkdownState {
         }
         self.text.clear();
         self.text.push_str(text);
-        self.reparse(cx);
+        self.reparse_reset(cx);
     }
 
     /// Return the currently selected rendered text.
@@ -113,13 +113,43 @@ impl MarkdownState {
         cx.notify();
     }
 
-    fn reparse(&mut self, cx: &mut Context<Self>) {
+    fn prepare_reparse(&mut self, cx: &mut Context<Self>) {
         // Don't interrupt an active drag-selection; the window-level endpoints
         // stay valid for append-only growth and per-inline ranges repaint.
         if !self.is_selecting {
             self.reset_selection();
             window_selection::clear_selection_for_view(self.entity_id, cx);
         }
+    }
+
+    fn reparse_append(&mut self, cx: &mut Context<Self>) {
+        self.prepare_reparse(cx);
+        let parsed = super::parse(&self.text);
+        let old_blocks = root_blocks(&self.parsed);
+        let new_blocks = root_blocks(&parsed);
+        let unchanged = old_blocks
+            .iter()
+            .zip(new_blocks)
+            .take_while(|(old, new)| old == new)
+            .count();
+        let old_count = old_blocks.len();
+        let new_count = new_blocks.len();
+        self.parsed = parsed;
+
+        if unchanged < old_count || unchanged < new_count {
+            // An append can only affect the old trailing block and blocks added
+            // after it. Preserve the measured prefix and invalidate that suffix.
+            self.list_state
+                .splice(unchanged..old_count, new_count - unchanged);
+            // `splice` creates unmeasured items but does not re-arm measure_all.
+            self.list_state.remeasure_items(unchanged..new_count);
+            self.measured_content_height = None;
+        }
+        cx.notify();
+    }
+
+    fn reparse_reset(&mut self, cx: &mut Context<Self>) {
+        self.prepare_reparse(cx);
         self.parsed = super::parse(&self.text);
         let block_count = root_block_count(&self.parsed);
         // Even an edit that preserves the number of root blocks can change
@@ -238,6 +268,11 @@ impl MarkdownState {
     pub(super) fn source(&self) -> &str {
         &self.text
     }
+
+    #[cfg(test)]
+    pub(super) fn has_measured_block(&self, index: usize) -> bool {
+        self.list_state.bounds_for_item(index).is_some()
+    }
 }
 
 fn with_trailing_newline(mut text: String) -> String {
@@ -251,6 +286,13 @@ fn root_block_count(node: &BlockNode) -> usize {
     match node {
         BlockNode::Root { children, .. } => children.len(),
         _ => 1,
+    }
+}
+
+fn root_blocks(node: &BlockNode) -> &[BlockNode] {
+    match node {
+        BlockNode::Root { children, .. } => children,
+        _ => std::slice::from_ref(node),
     }
 }
 

--- a/crates/ui/src/markdown/view.rs
+++ b/crates/ui/src/markdown/view.rs
@@ -291,6 +291,56 @@ mod tests {
     }
 
     #[gpui::test]
+    fn streamed_append_preserves_earlier_block_measurements(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        cx.update(crate::markdown::init);
+        let (view, cx) =
+            cx.add_window_view(|_, cx| TestRoot::new("stable block\n\nstreaming block", cx));
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        assert!(view.read_with(cx, |root, cx| {
+            root.markdown.read(cx).has_measured_block(0)
+        }));
+        view.update(cx, |root, cx| {
+            root.markdown.update(cx, |markdown, cx| {
+                markdown.push_str(" delta", cx);
+                assert!(markdown.has_measured_block(0));
+                assert!(!markdown.has_measured_block(1));
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn wide_table_keeps_its_intrinsic_width_inside_viewport(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        cx.update(crate::markdown::init);
+        let (_, cx) = cx.add_window_view(|_, cx| {
+            TestRoot::new(
+                "| column | value |\n| --- | --- |\n| this-cell-is-deliberately-much-wider-than-the-markdown-viewport | another-wide-value |",
+                cx,
+            )
+        });
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        let track = cx
+            .debug_bounds("markdown-table-track-root-0")
+            .expect("table track was painted");
+        assert!(
+            track.size.width > px(320.),
+            "wide table collapsed to viewport width {:?}",
+            track.size.width
+        );
+    }
+
+    #[gpui::test]
     fn clipped_markdown_cannot_start_selection(cx: &mut TestAppContext) {
         cx.update(gpui_component::init);
         cx.update(crate::markdown::init);


### PR DESCRIPTION
Three related markdown/chat rendering fixes:

**Streaming width/height jumps.** Every streamed delta was classified as an append but handled via `set_text`, resetting all cached item heights; the subsequent `Infer` request-layout could probe at min-content width, and the list accepted that narrow width — briefly rendering earlier blocks tall-and-narrow until the next real-bounds frame. Appends now preserve the measured unchanged root-block prefix and splice/remeasure only the affected suffix; the measuring list is pinned to the last positive real width during intrinsic probes. Genuine width changes still trigger full remeasurement.

**User bubble width.** User bubbles now size to shaped text width + padding, capped at `max_w_3_4`, instead of always stretching to the cap. Content stays selectable markdown.

**Table overflow.** Tables now lay out at natural (uncapped) column widths inside per-table horizontal scroll containers — no more cell truncation. The former wrap-table path is unified into the scroll path.

Tests: new unit tests for cached-prefix preservation and wide-table intrinsic layout; tcode-ui 133 passed, workspace green (fmt/clippy/test). Launch-smoke-tested on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)