### PR TITLE
ui(settings): unify settings with the chat visual grammar, single-surface dropdowns

### DIFF
--- a/crates/ui/src/orchestrate_settings.rs
+++ b/crates/ui/src/orchestrate_settings.rs
@@ -581,6 +581,9 @@ impl OrchestrateSettingsPanel {
             );
         let panel = cx.entity();
         let dropdown = Popover::new("orchestrate-child-approval-popover")
+            // Single panel surface at the 14px overlay radius; content transparent.
+            .rounded(crate::material::radius_overlay())
+            .shadow_xl()
             .trigger(trigger)
             .content(move |_, _, cx| {
                 let option = |mode: ChildApprovalMode,
@@ -616,38 +619,34 @@ impl OrchestrateSettingsPanel {
                         })
                         .into_any_element()
                 };
-                crate::material::overlay_contour(
-                    v_flex()
-                        .p_1()
-                        .min_w(px(180.))
-                        .gap_0p5()
-                        .child(option(
-                            ChildApprovalMode::Orchestrator,
-                            "orchestrate-child-approval-orchestrator",
-                            tcode_i18n::tr!("orchestrate.child_approval.orchestrator")
-                                .into_owned()
-                                .into(),
-                            cx,
-                        ))
-                        .child(option(
-                            ChildApprovalMode::AlwaysAllow,
-                            "orchestrate-child-approval-always-allow",
-                            tcode_i18n::tr!("orchestrate.child_approval.always_allow")
-                                .into_owned()
-                                .into(),
-                            cx,
-                        ))
-                        .child(option(
-                            ChildApprovalMode::Manual,
-                            "orchestrate-child-approval-manual",
-                            tcode_i18n::tr!("orchestrate.child_approval.manual")
-                                .into_owned()
-                                .into(),
-                            cx,
-                        )),
-                    cx,
-                )
-                .rounded(crate::material::radius_overlay())
+                v_flex()
+                    .p_1()
+                    .min_w(px(180.))
+                    .gap_0p5()
+                    .child(option(
+                        ChildApprovalMode::Orchestrator,
+                        "orchestrate-child-approval-orchestrator",
+                        tcode_i18n::tr!("orchestrate.child_approval.orchestrator")
+                            .into_owned()
+                            .into(),
+                        cx,
+                    ))
+                    .child(option(
+                        ChildApprovalMode::AlwaysAllow,
+                        "orchestrate-child-approval-always-allow",
+                        tcode_i18n::tr!("orchestrate.child_approval.always_allow")
+                            .into_owned()
+                            .into(),
+                        cx,
+                    ))
+                    .child(option(
+                        ChildApprovalMode::Manual,
+                        "orchestrate-child-approval-manual",
+                        tcode_i18n::tr!("orchestrate.child_approval.manual")
+                            .into_owned()
+                            .into(),
+                        cx,
+                    ))
             });
 
         self.group(cx)

--- a/crates/ui/src/provider_card.rs
+++ b/crates/ui/src/provider_card.rs
@@ -654,6 +654,9 @@ impl ProviderCard {
         let app_state = self.app_state.clone();
 
         Popover::new("update-popover")
+            // Single panel surface at the 14px overlay radius; content transparent.
+            .rounded(crate::material::radius_overlay())
+            .shadow_xl()
             .trigger(
                 Button::new("update-available")
                     .ghost()
@@ -665,9 +668,10 @@ impl ProviderCard {
                 let app_state = app_state.clone();
                 let command = command.clone();
                 let muted = cx.theme().muted_foreground;
+                // The Popover panel supplies the fill, border, shadow and p_3
+                // padding; the pane itself stays transparent (single surface).
                 let mut pane = v_flex()
                     .w(px(320.))
-                    .p_3()
                     .gap_2()
                     .child(
                         div()
@@ -747,8 +751,7 @@ impl ProviderCard {
                                 ),
                         );
                 }
-                crate::material::overlay_contour(pane, cx)
-                    .rounded(crate::material::radius_overlay())
+                pane
             })
             .into_any_element()
     }

--- a/crates/ui/src/provider_model_picker.rs
+++ b/crates/ui/src/provider_model_picker.rs
@@ -204,6 +204,11 @@ impl Render for ProviderModelPicker {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let picker = cx.entity();
         Popover::new(self.popover_id)
+            // T3 overlay contour: one panel surface (popover fill + hairline +
+            // shadow_xl at the 14px overlay radius). The pane content is transparent
+            // so the popup reads as a single card, matching the composer picker.
+            .rounded(crate::material::radius_overlay())
+            .shadow_xl()
             .trigger(self.trigger(cx))
             .content(move |_, _, cx| {
                 let (options, profiles, selected_profile, selected, excluded) = {
@@ -348,21 +353,17 @@ impl Render for ProviderModelPicker {
                     );
                 }
 
-                crate::material::overlay_contour(
-                    v_flex()
-                        .w(px(390.))
-                        .child(tabs)
-                        .child(crate::material::faded_hairline(cx))
-                        .child(
-                            div()
-                                .w_full()
-                                .h(px(300.))
-                                .overflow_y_scrollbar()
-                                .child(div().size_full().child(rows)),
-                        ),
-                    cx,
-                )
-                .rounded(crate::material::radius_overlay())
+                v_flex()
+                    .w(px(390.))
+                    .child(tabs)
+                    .child(crate::material::faded_hairline(cx))
+                    .child(
+                        div()
+                            .w_full()
+                            .h(px(300.))
+                            .overflow_y_scrollbar()
+                            .child(div().size_full().child(rows)),
+                    )
             })
     }
 }

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -46,8 +46,9 @@ const TRAFFIC_LIGHT_INSET: f32 = 8.;
 
 /// Width of the settings left-nav column (matches the sidebar width).
 const NAV_WIDTH: f32 = 255.;
-/// Max width of the settings content column.
-const CONTENT_MAX_WIDTH: f32 = 720.;
+/// Max width of the settings content column — matches the chat timeline column
+/// (`chat::CONTENT_MAX_WIDTH`) so the reading measure is identical across routes.
+const CONTENT_MAX_WIDTH: f32 = 768.;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Section {
@@ -406,7 +407,9 @@ impl SettingsPage {
                 div().flex_none().child(
                     gpui_component::h_flex()
                         .id("settings-back")
-                        .h(px(44.))
+                        // Mirror the main sidebar footer (the "Settings" entry that
+                        // enters this route): same 40px height, muted leading icon.
+                        .h(px(40.))
                         .items_center()
                         .gap_2()
                         .px_3()
@@ -414,7 +417,11 @@ impl SettingsPage {
                         .hover(|s| s.bg(cx.theme().sidebar_accent))
                         .text_size(px(13.))
                         .text_color(cx.theme().sidebar_foreground)
-                        .child(Icon::new(IconName::ArrowLeft).size_4())
+                        .child(
+                            Icon::new(IconName::ArrowLeft)
+                                .size_4()
+                                .text_color(cx.theme().muted_foreground),
+                        )
                         .child(tcode_i18n::tr!("settings.back"))
                         .on_click(cx.listener(|this, _, _, cx| {
                             this.app_state
@@ -900,6 +907,11 @@ impl SettingsPage {
         let trigger = self.dropdown_trigger("cu-image-mode-dropdown", label, cx);
         let this = cx.entity();
         let dropdown = Popover::new("cu-image-mode-popover")
+            // T3 overlay contour: one panel surface (popover fill + hairline +
+            // shadow_xl at the 14px overlay radius). The content stays transparent
+            // so the popup is a single card, not a card nested in the panel.
+            .rounded(crate::material::radius_overlay())
+            .shadow_xl()
             .trigger(trigger)
             .content(move |_, _, cx| {
                 let this = this.clone();
@@ -942,35 +954,31 @@ impl SettingsPage {
                         })
                         .into_any_element()
                 };
-                crate::material::overlay_contour(
-                    v_flex()
-                        .p_1()
-                        .min_w(px(260.))
-                        .gap_0p5()
-                        .child(option(
-                            ImageMode::Auto,
-                            "computer_use.image_mode.auto",
-                            "computer_use.image_mode.auto_desc",
-                            &this,
-                            cx,
-                        ))
-                        .child(option(
-                            ImageMode::Always,
-                            "computer_use.image_mode.always",
-                            "computer_use.image_mode.always_desc",
-                            &this,
-                            cx,
-                        ))
-                        .child(option(
-                            ImageMode::Never,
-                            "computer_use.image_mode.never",
-                            "computer_use.image_mode.never_desc",
-                            &this,
-                            cx,
-                        )),
-                    cx,
-                )
-                .rounded(crate::material::radius_overlay())
+                v_flex()
+                    .p_1()
+                    .min_w(px(260.))
+                    .gap_0p5()
+                    .child(option(
+                        ImageMode::Auto,
+                        "computer_use.image_mode.auto",
+                        "computer_use.image_mode.auto_desc",
+                        &this,
+                        cx,
+                    ))
+                    .child(option(
+                        ImageMode::Always,
+                        "computer_use.image_mode.always",
+                        "computer_use.image_mode.always_desc",
+                        &this,
+                        cx,
+                    ))
+                    .child(option(
+                        ImageMode::Never,
+                        "computer_use.image_mode.never",
+                        "computer_use.image_mode.never_desc",
+                        &this,
+                        cx,
+                    ))
             });
         self.row_frame(cx)
             .child(self.row_labels(
@@ -1295,6 +1303,9 @@ impl SettingsPage {
 
         let this = cx.entity();
         let dropdown = Popover::new("theme-popover")
+            // Single panel surface at the 14px overlay radius (see image_mode_row).
+            .rounded(crate::material::radius_overlay())
+            .shadow_xl()
             .trigger(trigger)
             .content(move |_, _, cx| {
                 let this = this.clone();
@@ -1328,35 +1339,31 @@ impl SettingsPage {
                         })
                         .into_any_element()
                 };
-                crate::material::overlay_contour(
-                    v_flex()
-                        .p_1()
-                        .min_w(px(160.))
-                        .gap_0p5()
-                        .child(option(
-                            ThemeMode::System,
-                            tcode_i18n::tr!("settings.theme.system").into_owned().into(),
-                            mode == ThemeMode::System,
-                            &this,
-                            cx,
-                        ))
-                        .child(option(
-                            ThemeMode::Light,
-                            tcode_i18n::tr!("settings.theme.light").into_owned().into(),
-                            mode == ThemeMode::Light,
-                            &this,
-                            cx,
-                        ))
-                        .child(option(
-                            ThemeMode::Dark,
-                            tcode_i18n::tr!("settings.theme.dark").into_owned().into(),
-                            mode == ThemeMode::Dark,
-                            &this,
-                            cx,
-                        )),
-                    cx,
-                )
-                .rounded(crate::material::radius_overlay())
+                v_flex()
+                    .p_1()
+                    .min_w(px(160.))
+                    .gap_0p5()
+                    .child(option(
+                        ThemeMode::System,
+                        tcode_i18n::tr!("settings.theme.system").into_owned().into(),
+                        mode == ThemeMode::System,
+                        &this,
+                        cx,
+                    ))
+                    .child(option(
+                        ThemeMode::Light,
+                        tcode_i18n::tr!("settings.theme.light").into_owned().into(),
+                        mode == ThemeMode::Light,
+                        &this,
+                        cx,
+                    ))
+                    .child(option(
+                        ThemeMode::Dark,
+                        tcode_i18n::tr!("settings.theme.dark").into_owned().into(),
+                        mode == ThemeMode::Dark,
+                        &this,
+                        cx,
+                    ))
             });
 
         self.row_frame(cx)
@@ -1378,11 +1385,13 @@ impl SettingsPage {
         };
         let trigger = self.dropdown_trigger("language-dropdown", label, cx);
         let page = cx.entity();
-        let dropdown =
-            Popover::new("language-popover")
-                .trigger(trigger)
-                .content(move |_, _, cx| {
-                    let option =
+        let dropdown = Popover::new("language-popover")
+            // Single panel surface at the 14px overlay radius (see image_mode_row).
+            .rounded(crate::material::radius_overlay())
+            .shadow_xl()
+            .trigger(trigger)
+            .content(move |_, _, cx| {
+                let option =
                     |value: Option<&'static str>,
                      key: &'static str,
                      cx: &mut Context<gpui_component::popover::PopoverState>| {
@@ -1414,26 +1423,22 @@ impl SettingsPage {
                                 popover.update(cx, |state, cx| state.dismiss(window, cx));
                             })
                     };
-                    crate::material::overlay_contour(
-                        v_flex()
-                            .p_1()
-                            .min_w(px(160.))
-                            .gap_0p5()
-                            .child(option(None, "settings.language.system", cx))
-                            .child(option(
-                                Some(LANGUAGE_ENGLISH),
-                                "settings.language.english",
-                                cx,
-                            ))
-                            .child(option(
-                                Some(LANGUAGE_SIMPLIFIED_CHINESE),
-                                "settings.language.chinese",
-                                cx,
-                            )),
+                v_flex()
+                    .p_1()
+                    .min_w(px(160.))
+                    .gap_0p5()
+                    .child(option(None, "settings.language.system", cx))
+                    .child(option(
+                        Some(LANGUAGE_ENGLISH),
+                        "settings.language.english",
                         cx,
-                    )
-                    .rounded(crate::material::radius_overlay())
-                });
+                    ))
+                    .child(option(
+                        Some(LANGUAGE_SIMPLIFIED_CHINESE),
+                        "settings.language.chinese",
+                        cx,
+                    ))
+            });
         self.row_frame(cx)
             .child(self.row_labels(
                 tcode_i18n::tr!("settings.language.title"),


### PR DESCRIPTION
Settings-page consistency pass per docs/visual-redesign.md:

- **Reading measure**: settings content column 720 → 768px, matching the chat timeline exactly (identical centered measure + gutters across routes).
- **Card-in-a-card dropdowns fixed** (settings menus, model picker, orchestrate approval menu, provider-update popover). Root cause: gpui-component `Popover` already applies `popover_style + p_3` to its panel; settings wrapped content in `material::overlay_contour` *inside* that panel — two stacked surfaces. All dropdowns now use the composer-picker idiom: transparent content, `.rounded(radius_overlay()).shadow_xl()` on the Popover builder, one clean overlay surface.
- **Nav symmetry**: settings Back row now mirrors the sidebar's settings-entry row (40px, muted icon). No resizing added (deliberate). Nav material/selection already matched the main sidebar.

No new strings; no documented dimensions changed. Gates: fmt / clippy -D warnings / workspace tests green. Visually verified in the running app on the most complex dropdown (model picker: single rounded panel, no inner card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)