### PR TITLE
fix(ci): extract zip difftastic assets on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,17 @@ jobs:
           actual="$(openssl dgst -sha256 "$DIFFT_ASSET" | awk '{print $NF}')"
           test "$actual" = "$DIFFT_SHA256"
           mkdir .difftastic
-          tar -xf "$DIFFT_ASSET" -C .difftastic
+          # Windows assets are zip archives; Git-bash GNU tar cannot read them.
+          case "$DIFFT_ASSET" in
+            *.zip)
+              if command -v unzip >/dev/null 2>&1; then
+                unzip -q "$DIFFT_ASSET" -d .difftastic
+              else
+                7z x -y "-o.difftastic" "$DIFFT_ASSET" >/dev/null
+              fi
+              ;;
+            *) tar -xf "$DIFFT_ASSET" -C .difftastic ;;
+          esac
           test -f ".difftastic/${{ matrix.platform == 'windows' && 'difft.exe' || 'difft' }}"
 
       - name: Build release binary


### PR DESCRIPTION
The v0.1.24 release run failed on both Windows jobs at the new "Download and verify difftastic" step: the Windows assets are `.zip` archives and Git-bash GNU `tar` cannot extract them (macOS/Linux `.tar.gz` assets were fine — those four platform jobs succeeded). Extract zips with `unzip` when available, falling back to 7-Zip (preinstalled on GitHub Windows runners).

After merge, v0.1.24 will be re-tagged on the fixed commit and the release re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)