### PR TITLE
fix(ui): lock markdown scroll gestures to dominant axis

### DIFF
--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -6,19 +6,19 @@ use std::{
     collections::{HashMap, VecDeque},
     ops::Range,
     sync::Arc,
+    time::{Duration, Instant},
 };
 
 use gpui::{
-    AnyElement, App, AvailableSpace, Axis, Bounds, Element, ElementId, Entity, FontStyle,
-    FontWeight, GlobalElementId, HighlightStyle, InspectorElementId, InteractiveElement as _,
-    IntoElement, LayoutId, ListSizingBehavior, ListState, ObjectFit, ParentElement as _, Pixels,
-    ScrollHandle, SharedString, StatefulInteractiveElement as _, Style, StyleRefinement,
-    Styled as _, StyledImage as _, Window, div, img, prelude::FluentBuilder as _, px, relative,
-    rems, size,
+    AnyElement, App, AvailableSpace, Bounds, Element, ElementId, Entity, FontStyle, FontWeight,
+    GlobalElementId, HighlightStyle, InspectorElementId, InteractiveElement as _, IntoElement,
+    LayoutId, ListSizingBehavior, ListState, ObjectFit, ParentElement as _, Pixels, ScrollHandle,
+    ScrollWheelEvent, SharedString, StatefulInteractiveElement as _, Style, StyleRefinement,
+    Styled as _, StyledImage as _, TouchPhase, Window, div, img, prelude::FluentBuilder as _, px,
+    relative, rems, size,
 };
 use gpui_component::{
-    ActiveTheme as _, StyledExt as _, h_flex, highlighter::HighlightTheme, scroll::ScrollableMask,
-    tooltip::Tooltip, v_flex,
+    ActiveTheme as _, StyledExt as _, h_flex, highlighter::HighlightTheme, tooltip::Tooltip, v_flex,
 };
 
 use crate::highlight;
@@ -35,6 +35,7 @@ use super::{
 
 const CODE_CACHE_CAPACITY: usize = 64;
 const BLOCK_OVERDRAW: Pixels = px(300.);
+const SCROLL_GESTURE_TIMEOUT: Duration = Duration::from_millis(250);
 type HighlightRuns = Vec<(Range<usize>, HighlightStyle)>;
 type SharedHighlightRuns = Arc<HighlightRuns>;
 type LinkRuns = Vec<(Range<usize>, super::nodes::LinkMark)>;
@@ -66,6 +67,53 @@ struct CodeWidthCacheKey {
 struct CodeWidthCache {
     entries: HashMap<CodeWidthCacheKey, Pixels>,
     order: VecDeque<CodeWidthCacheKey>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ScrollGestureAxis {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Default)]
+struct HorizontalScrollState {
+    scroll: ScrollHandle,
+    locked_axis: Option<ScrollGestureAxis>,
+    last_event_at: Option<Instant>,
+}
+
+impl HorizontalScrollState {
+    fn route_gesture(
+        &mut self,
+        delta_x: f32,
+        delta_y: f32,
+        phase: TouchPhase,
+        now: Instant,
+    ) -> ScrollGestureAxis {
+        let continuous = self
+            .last_event_at
+            .is_some_and(|last| now.saturating_duration_since(last) <= SCROLL_GESTURE_TIMEOUT);
+        if phase == TouchPhase::Started || !continuous || self.locked_axis.is_none() {
+            self.locked_axis = Some(dominant_scroll_axis(delta_x, delta_y));
+        }
+
+        let axis = self.locked_axis.unwrap_or(ScrollGestureAxis::Vertical);
+        if matches!(phase, TouchPhase::Ended | TouchPhase::Cancelled) {
+            self.locked_axis = None;
+            self.last_event_at = None;
+        } else {
+            self.last_event_at = Some(now);
+        }
+        axis
+    }
+}
+
+fn dominant_scroll_axis(delta_x: f32, delta_y: f32) -> ScrollGestureAxis {
+    if delta_x.abs() > delta_y.abs() {
+        ScrollGestureAxis::Horizontal
+    } else {
+        ScrollGestureAxis::Vertical
+    }
 }
 
 thread_local! {
@@ -926,10 +974,7 @@ fn render_code_block(
     }
     let scroll_key: SharedString =
         format!("markdown-code-scroll-{}-{}", view.entity_id(), options.path).into();
-    let scroll = window
-        .use_keyed_state(scroll_key, cx, |_, _| ScrollHandle::default())
-        .read(cx)
-        .clone();
+    let scroll = window.use_keyed_state(scroll_key, cx, |_, _| HorizontalScrollState::default());
     let track = v_flex()
         .min_w_full()
         .w(max_width + px(24.))
@@ -945,6 +990,7 @@ fn render_code_block(
             format!("{}-viewport", options.path),
             &scroll,
             &StyleRefinement::default(),
+            cx,
             div()
                 .p_3()
                 .rounded(cx.theme().radius)
@@ -1084,10 +1130,7 @@ fn render_scroll_table(
         options.path
     )
     .into();
-    let scroll = window
-        .use_keyed_state(scroll_key, cx, |_, _| ScrollHandle::default())
-        .read(cx)
-        .clone();
+    let scroll = window.use_keyed_state(scroll_key, cx, |_, _| HorizontalScrollState::default());
     let track = v_flex()
         .min_w_full()
         .w(px(total_width))
@@ -1113,6 +1156,7 @@ fn render_scroll_table(
             format!("{}-viewport", options.path),
             &scroll,
             &style.table,
+            cx,
             track,
         ))
         .into_any_element()
@@ -1120,19 +1164,49 @@ fn render_scroll_table(
 
 fn horizontal_scroll_area(
     id: impl Into<gpui::ElementId>,
-    scroll: &ScrollHandle,
+    state: &Entity<HorizontalScrollState>,
     style: &StyleRefinement,
+    cx: &App,
     child: impl IntoElement,
 ) -> impl IntoElement {
+    let scroll = state.read(cx).scroll.clone();
+    let state = state.clone();
     div()
         .id(id)
         .w_full()
         .relative()
         .refine_style(style)
         .overflow_hidden()
-        .track_scroll(scroll)
+        .track_scroll(&scroll)
         .child(child)
-        .child(ScrollableMask::new(Axis::Horizontal, scroll))
+        .on_scroll_wheel(move |event: &ScrollWheelEvent, window, cx| {
+            let delta = event.delta.pixel_delta(window.line_height());
+            let can_scroll_horizontally = state.read(cx).scroll.max_offset().x > Pixels::ZERO;
+            if !can_scroll_horizontally {
+                return;
+            }
+
+            let axis = state.update(cx, |state, cx| {
+                let axis = state.route_gesture(
+                    f32::from(delta.x),
+                    f32::from(delta.y),
+                    event.touch_phase,
+                    Instant::now(),
+                );
+                if axis == ScrollGestureAxis::Horizontal {
+                    let mut offset = state.scroll.offset();
+                    offset.x += delta.x;
+                    if offset != state.scroll.offset() {
+                        state.scroll.set_offset(offset);
+                        cx.notify();
+                    }
+                }
+                axis
+            });
+            if axis == ScrollGestureAxis::Horizontal {
+                cx.stop_propagation();
+            }
+        })
 }
 
 #[cfg(test)]
@@ -1154,5 +1228,68 @@ mod tests {
         assert_eq!(code_lines("a\n\n"), ["a", ""]);
         // Empty code renders zero lines rather than one phantom.
         assert_eq!(code_lines(""), Vec::<&str>::new());
+    }
+
+    #[test]
+    fn scroll_axis_uses_strict_horizontal_dominance() {
+        assert_eq!(dominant_scroll_axis(8., 3.), ScrollGestureAxis::Horizontal);
+        assert_eq!(dominant_scroll_axis(3., 8.), ScrollGestureAxis::Vertical);
+        assert_eq!(dominant_scroll_axis(8., 8.), ScrollGestureAxis::Vertical);
+    }
+
+    #[test]
+    fn scroll_axis_sticks_for_a_continuous_gesture() {
+        let start = Instant::now();
+        let mut state = HorizontalScrollState::default();
+        assert_eq!(
+            state.route_gesture(12., 4., TouchPhase::Started, start),
+            ScrollGestureAxis::Horizontal
+        );
+        assert_eq!(
+            state.route_gesture(2., 8., TouchPhase::Moved, start + Duration::from_millis(50)),
+            ScrollGestureAxis::Horizontal
+        );
+
+        let mut state = HorizontalScrollState::default();
+        assert_eq!(
+            state.route_gesture(4., 12., TouchPhase::Started, start),
+            ScrollGestureAxis::Vertical
+        );
+        assert_eq!(
+            state.route_gesture(8., 2., TouchPhase::Moved, start + Duration::from_millis(50)),
+            ScrollGestureAxis::Vertical
+        );
+    }
+
+    #[test]
+    fn scroll_axis_unlocks_after_timeout_or_end() {
+        let start = Instant::now();
+        let mut state = HorizontalScrollState::default();
+        state.route_gesture(12., 4., TouchPhase::Moved, start);
+        assert_eq!(
+            state.route_gesture(
+                2.,
+                8.,
+                TouchPhase::Moved,
+                start + Duration::from_millis(251)
+            ),
+            ScrollGestureAxis::Vertical
+        );
+
+        state.route_gesture(
+            2.,
+            8.,
+            TouchPhase::Ended,
+            start + Duration::from_millis(252),
+        );
+        assert_eq!(
+            state.route_gesture(
+                8.,
+                2.,
+                TouchPhase::Moved,
+                start + Duration::from_millis(253)
+            ),
+            ScrollGestureAxis::Horizontal
+        );
     }
 }


### PR DESCRIPTION
Fixes the v0.1.24 regression where horizontally scrolling a wide markdown table stutters because the chat timeline's vertical scroll keeps intercepting the gesture.

Mechanism: `gpui_component::ScrollableMask` decided axis dominance independently per wheel event, so a trackpad gesture flip-flopped between the table (horizontal) and the timeline (vertical) mid-swipe. Code blocks share the same horizontal-scroll helper and had the same latent bug.

Fix (in the shared helper, so tables and code blocks both benefit):
- Strict axis-dominance routing per gesture; ties stay vertical (conversation wins).
- Symmetric gesture locking via `touch_phase` plus a 250ms continuity window: once a horizontal swipe starts it owns the whole gesture (propagation stopped, including at scroll boundaries); a vertical gesture is never captured mid-flight.
- Non-overflowing containers never capture.
- Table measurement/width-pinning, selection, and layout untouched.

Unit tests cover dominance, stickiness in both directions, timeout unlock, and phase reset. Gates: fmt / clippy -D warnings / workspace tests (553 passed) green. Note: real-trackpad feel could not be exercised by the automated run — logic is unit-tested; please confirm feel on a dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)