### PR TITLE
fix: sidebar drag regression, short-bubble wrap, pi version probe

### DIFF
--- a/crates/services/src/provider_probe.rs
+++ b/crates/services/src/provider_probe.rs
@@ -49,6 +49,12 @@ pub async fn run_capture_env(
         return None;
     }
     let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !text.is_empty() {
+        return Some(text);
+    }
+    // Some CLIs (pi among them) print `--version` output to stderr; a clean
+    // exit with empty stdout is still a successful run.
+    let text = String::from_utf8_lossy(&output.stderr).trim().to_string();
     (!text.is_empty()).then_some(text)
 }
 

--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -1224,7 +1224,9 @@ impl ChatView {
             .child({
                 let pending = steering == Some(SteeringStatus::Pending);
                 div()
-                    .w(text_width + px(32.))
+                    // Ceil past sub-pixel snapping plus 1px slack — an exact
+                    // fractional fit can still wrap the final glyph.
+                    .w((text_width + px(32.)).ceil() + px(1.))
                     .flex_none()
                     .max_w_3_4()
                     .px_4()

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -110,6 +110,11 @@ pub struct AppShell {
     /// Stable expanded-sidebar width. The resizable component otherwise scales
     /// every panel proportionally when the window enters or leaves fullscreen.
     sidebar_width: Rc<Cell<Pixels>>,
+    /// Viewport width last seen by render; a change arms the restore below.
+    last_viewport_width: Option<Pixels>,
+    /// Keep restoring the sidebar width until the panel reports it, then stop
+    /// so the restore never fights an in-progress drag.
+    sidebar_restore_pending: bool,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -181,6 +186,8 @@ impl AppShell {
             right_width: Rc::new(Cell::new(px(RIGHT_PANEL_WIDTH))),
             right_sized: false,
             sidebar_width: Rc::new(Cell::new(px(SIDEBAR_WIDTH))),
+            last_viewport_width: None,
+            sidebar_restore_pending: false,
             _subscriptions: vec![subscription, event_subscription],
         }
     }
@@ -372,14 +379,32 @@ impl Render for AppShell {
 
         // gpui-component preserves panel *ratios* when its container changes
         // width. Fullscreen is a container resize, but the sidebar is a fixed
-        // navigation column: restore its remembered pixel width before layout.
-        if !collapsed {
+        // navigation column: restore its remembered pixel width when the window
+        // width changes. Only then — an every-frame restore would snap the
+        // panel back mid-drag (`on_resize` records the width only on mouse-up).
+        // The rescale lands on the frame where the group measures its new
+        // container, which can trail the viewport change — so keep restoring
+        // until the width matches, then stop.
+        let viewport_width = window.viewport_size().width;
+        if self.last_viewport_width != Some(viewport_width) {
+            self.last_viewport_width = Some(viewport_width);
+            self.sidebar_restore_pending = true;
+        }
+        if self.sidebar_restore_pending && !collapsed {
             let width = self.sidebar_width.get();
-            self.split.update(cx, |state, cx| {
-                if state.sizes().first().is_some_and(|size| *size != width) {
-                    state.resize_panel(0, width, window, cx);
-                }
-            });
+            let restored = self
+                .split
+                .update(cx, |state, cx| match state.sizes().first() {
+                    Some(size) if *size != width => {
+                        state.resize_panel(0, width, window, cx);
+                        false
+                    }
+                    Some(_) => true,
+                    None => false,
+                });
+            if restored {
+                self.sidebar_restore_pending = false;
+            }
         }
 
         // Give the right panel its width once the group knows about it (the


### PR DESCRIPTION
Three targeted fixes for issues found using v0.1.24:

**Sidebar can't be dragged** (regression from #80): the remembered-width restore ran on every render frame, and since `on_resize` only records the width on mouse-up, each in-progress drag frame was snapped back. The restore is now armed only when the viewport width actually changes (the fullscreen/rescale trigger it was built for) and keeps applying just until the panel reports the restored width, so it can never fight a drag.

**Short user messages wrap their last character** (regression from #83): the intrinsic bubble width from `layout_line` could lose to sub-pixel snapping, wrapping the final glyph — most visible with CJK, where any 1px deficit moves exactly one character. Width is now ceiled with 1px slack.

**pi shows "installed but failed to run"**: pi prints `--version` to stderr; `run_capture_env` treated a clean exit with empty stdout as failure. It now falls back to stderr (verified locally against pi 0.80.10).

Gates: fmt / clippy (services+ui) / services+ui tests green locally; full workspace gate on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)