### PR TITLE
fix(sidebar): reveal row actions on direct focus only

### DIFF
--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -793,10 +793,12 @@ impl SessionsSidebar {
             .rounded(cx.theme().radius * 0.5)
             .cursor_pointer()
             // Opacity (rather than `visibility: hidden`) keeps this in Root's
-            // tab-stop registry so keyboard focus can reveal it.
+            // tab-stop registry so keyboard focus can reveal it. `focus`, not
+            // `in_focus`: a click-focused ancestor row would otherwise pin the
+            // control visible.
             .opacity(0.)
             .group_hover(group_key.clone(), |s| s.opacity(1.))
-            .in_focus(|s| s.opacity(1.).bg(cx.theme().sidebar_accent))
+            .focus(|s| s.opacity(1.).bg(cx.theme().sidebar_accent))
             .hover(|s| s.bg(cx.theme().sidebar_accent))
             .tooltip(|window, cx| {
                 Tooltip::new(tcode_i18n::tr!("sidebar.create_thread").into_owned())
@@ -1102,10 +1104,12 @@ impl SessionsSidebar {
                             .rounded(cx.theme().radius * 0.5)
                             .cursor_pointer()
                             // Keep the archived action registered as a tab stop;
-                            // keyboard focus itself reveals the zero-opacity icon.
+                            // the icon reveals only when the button itself is
+                            // focused (`in_focus` would pin it visible while the
+                            // click-focused row stays selected).
                             .opacity(0.)
                             .group_hover(row_key.clone(), |s| s.opacity(1.))
-                            .in_focus(|s| s.opacity(1.).bg(cx.theme().sidebar_accent))
+                            .focus(|s| s.opacity(1.).bg(cx.theme().sidebar_accent))
                             .hover(|s| s.bg(cx.theme().sidebar_accent))
                             .tooltip(|window, cx| {
                                 Tooltip::new(tcode_i18n::tr!("sidebar.archive").into_owned())


### PR DESCRIPTION
Selecting a sidebar conversation pinned its archive icon permanently visible (regression from the a11y pass, #89). `in_focus` styles apply whenever the element is inside the focused subtree — and clicking a row focuses the row via its new a11y tab stop, so every hidden action inside the selected row satisfied `within_focused`. Switching to `focus()` (direct focus only, verified against vendored gpui: `is_focused` vs `within_focused`) keeps the intended behaviors — hover reveal for mouse, reveal-on-Tab for keyboard — without pinning icons on the selected row.

Gates: fmt / clippy / tcode-ui tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)