### PR TITLE
ui(settings): join the sidebar family, group rhythm, ghost triggers, semantic chips

### DIFF
--- a/crates/ui/src/material.rs
+++ b/crates/ui/src/material.rs
@@ -12,7 +12,7 @@ use gpui::{
     Pixels, Rgba, Role, SharedString, Stateful, StatefulInteractiveElement as _, Styled as _, div,
     linear_color_stop, linear_gradient, px,
 };
-use gpui_component::ActiveTheme as _;
+use gpui_component::{ActiveTheme as _, StyledExt as _};
 
 fn rgba(r: u8, g: u8, b: u8, a: u8) -> Hsla {
     Rgba {
@@ -107,6 +107,53 @@ pub fn overlay_contour(el: Div, cx: &App) -> Div {
         .border_1()
         .border_color(cx.theme().border)
         .shadow_xl()
+}
+
+/// The sidebar brand wordmark — bold "tcode" + the "DEV" channel pill. The main
+/// sidebar's app row (`sidebar.rs`) and the settings left-nav header are
+/// round-trip counterparts, so this shares the exact chrome without either side
+/// reimplementing it. Neutral helper: sidebar.rs keeps its own inline copy, this
+/// only lets the settings nav wear the same treatment.
+pub fn brand_wordmark(cx: &App) -> impl IntoElement {
+    gpui_component::h_flex()
+        .items_center()
+        .gap_2()
+        .child(
+            div()
+                .text_size(px(14.))
+                .font_bold()
+                .text_color(cx.theme().sidebar_foreground)
+                .child("tcode"),
+        )
+        .child(
+            div()
+                .px_1()
+                .py(px(1.))
+                .rounded_sm()
+                .bg(cx.theme().muted)
+                .text_color(cx.theme().muted_foreground)
+                .text_size(px(9.))
+                .font_semibold()
+                .child("DEV"),
+        )
+}
+
+/// A compact metadata chip in chat's idiom (the plan/subagent badges in
+/// `chat.rs`): pill radius, 11px medium text, a tinted fill and same-hue
+/// foreground. Callers pass the semantic 12%-tint background and its foreground.
+/// It hugs its content (`flex_none`) so it never stretches into a full-width
+/// validation bar.
+pub fn semantic_chip(label: impl Into<SharedString>, bg: Hsla, fg: Hsla) -> Div {
+    div()
+        .flex_none()
+        .px_2()
+        .py(px(1.))
+        .rounded_full()
+        .bg(bg)
+        .text_size(px(11.))
+        .font_medium()
+        .text_color(fg)
+        .child(label.into())
 }
 
 /// Gives a raw clickable surface the same keyboard and accessibility treatment

--- a/crates/ui/src/orchestrate_settings.rs
+++ b/crates/ui/src/orchestrate_settings.rs
@@ -562,8 +562,10 @@ impl OrchestrateSettingsPanel {
             }
             ChildApprovalMode::Manual => tcode_i18n::tr!("orchestrate.child_approval.manual"),
         };
+        // Ghost, not outline: a quiet resting trigger that only tints on hover,
+        // consistent with the General page dropdowns and the composer picker.
         let trigger = Button::new("orchestrate-child-approval-dropdown")
-            .outline()
+            .ghost()
             .compact()
             .child(
                 h_flex()
@@ -967,26 +969,22 @@ impl OrchestrateSettingsPanel {
                                             .child(subtitle),
                                     ),
                             )
-                            .child(
-                                div()
-                                    .rounded_full()
-                                    .when(profile.enabled, |status| {
-                                        status
-                                            .bg(cx.theme().success.opacity(0.12))
-                                            .text_color(cx.theme().success_foreground)
-                                    })
-                                    .when(!profile.enabled, |status| {
-                                        status
-                                            .bg(cx.theme().muted)
-                                            .text_color(cx.theme().muted_foreground)
-                                    })
-                                    .text_size(px(11.))
-                                    .child(if profile.enabled {
-                                        tcode_i18n::tr!("orchestrate.children.enabled")
-                                    } else {
-                                        tcode_i18n::tr!("orchestrate.children.disabled")
-                                    }),
-                            )
+                            .child({
+                                let (bg, fg) = if profile.enabled {
+                                    (
+                                        cx.theme().success.opacity(0.12),
+                                        cx.theme().success_foreground,
+                                    )
+                                } else {
+                                    (cx.theme().muted, cx.theme().muted_foreground)
+                                };
+                                let label = if profile.enabled {
+                                    tcode_i18n::tr!("orchestrate.children.enabled")
+                                } else {
+                                    tcode_i18n::tr!("orchestrate.children.disabled")
+                                };
+                                crate::material::semantic_chip(label, bg, fg)
+                            })
                             .child(
                                 Switch::new(("orchestrate-child-enabled", index))
                                     .checked(profile.enabled)

--- a/crates/ui/src/provider_card.rs
+++ b/crates/ui/src/provider_card.rs
@@ -594,13 +594,19 @@ impl ProviderCard {
             ),
             StatusDot::Amber => (cx.theme().muted, muted),
         };
+        // A compact metadata chip in chat's idiom (11px, tinted fill, pill
+        // radius, tight padding) that hugs its content — not a full-width
+        // green/orange bar that reads as web-form validation.
         let mut line = h_flex()
-            .flex_wrap()
+            .flex_none()
             .items_center()
             .gap_1()
+            .px_2()
+            .py(px(1.))
             .rounded_full()
             .bg(status_bg)
-            .text_size(px(13.))
+            .text_size(px(11.))
+            .font_medium()
             .text_color(status_fg);
 
         match &summary.email {
@@ -646,7 +652,9 @@ impl ProviderCard {
         if !summary.detail.is_empty() {
             line = line.child(div().child(format!("· {}", summary.detail)));
         }
-        line.into_any_element()
+        // Row wrapper so the chip left-aligns and hugs its content instead of
+        // being stretched to the column width by the surrounding v_flex.
+        h_flex().w_full().min_w_0().child(line).into_any_element()
     }
 
     /// The update-available icon + its popover (T3 §3).
@@ -1237,15 +1245,7 @@ impl Render for ProviderCard {
 // ---------------------------------------------------------------------------
 
 fn tag(label: String, background: gpui::Hsla, foreground: gpui::Hsla) -> AnyElement {
-    div()
-        .flex_none()
-        .px_1()
-        .rounded_full()
-        .bg(background)
-        .text_size(px(11.))
-        .text_color(foreground)
-        .child(label)
-        .into_any_element()
+    crate::material::semantic_chip(label, background, foreground).into_any_element()
 }
 
 /// The provider's glyph (the same asset the composer's picker rail uses).

--- a/crates/ui/src/provider_model_picker.rs
+++ b/crates/ui/src/provider_model_picker.rs
@@ -11,8 +11,12 @@ use gpui::{
     prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
-    ActiveTheme as _, Icon, IconName, Sizable as _, StyledExt as _, button::Button, h_flex,
-    popover::Popover, scroll::ScrollableElement as _, v_flex,
+    ActiveTheme as _, Icon, IconName, Sizable as _, StyledExt as _,
+    button::{Button, ButtonVariants as _},
+    h_flex,
+    popover::Popover,
+    scroll::ScrollableElement as _,
+    v_flex,
 };
 
 use agent::{OptionDescriptor, ProviderKind};
@@ -181,7 +185,11 @@ impl ProviderModelPicker {
                         (kind, "", None)
                     });
                 let display = self.display_name(provider, model, profile_id, cx);
-                Button::new(self.trigger_id).outline().compact().child(
+                // Ghost, not outline: a quiet resting trigger (glyph + value +
+                // muted chevron) that only tints on hover, matching the
+                // composer's model picker. The "Add" variant stays an outlined
+                // action button.
+                Button::new(self.trigger_id).ghost().compact().child(
                     h_flex()
                         .w(px(230.))
                         .items_center()

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -294,12 +294,13 @@ impl SettingsPage {
                 .aria_selected(active)
                 .child(
                     gpui_component::h_flex()
-                        .h(px(34.))
+                        // Match the main sidebar thread rows: 30px tall, 13px
+                        // label, a tight 6px rounded rect tinted when active and
+                        // a neutral hover only when not.
+                        .h(px(30.))
                         .items_center()
                         .gap_2()
                         .px_2()
-                        // Match the main sidebar: 6px rounded rect, tinted when
-                        // active, neutral hover only when not.
                         .rounded(px(6.))
                         .cursor_pointer()
                         .when(active, |s| s.bg(cx.theme().list_active))
@@ -307,7 +308,7 @@ impl SettingsPage {
                         .child(Icon::new(icon).size_4().text_color(fg))
                         .child(
                             div()
-                                .text_sm()
+                                .text_size(px(13.))
                                 .when(active, |d| d.font_medium())
                                 .text_color(fg)
                                 .child(label.clone()),
@@ -343,13 +344,9 @@ impl SettingsPage {
                     window,
                     cx,
                 )
-                .child(
-                    div()
-                        .text_sm()
-                        .font_bold()
-                        .text_color(cx.theme().sidebar_foreground)
-                        .child("tcode"),
-                ),
+                // Same brand chrome as the main sidebar's app row (DEV pill
+                // included) so the settings nav reads as the same family.
+                .child(crate::material::brand_wordmark(cx)),
             )
             .child(
                 v_flex()
@@ -446,32 +443,44 @@ impl SettingsPage {
     // -- content ------------------------------------------------------------
 
     fn render_header(&self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
+        // The 52px strip spans the paper full-width (drag area), but its title
+        // and actions ride the same centered 768px column as the content below,
+        // the way the chat header aligns with its timeline column.
         window_drag_area(
             "settings-header-drag",
             gpui_component::h_flex()
                 .flex_none()
                 .h(px(52.))
+                .w_full()
                 .px_6()
+                .justify_center()
                 .items_center(),
             window,
             cx,
         )
         .child(
-            div()
-                .flex_1()
-                .text_size(px(15.))
-                .font_medium()
-                .child(tcode_i18n::tr!("settings.title")),
-        )
-        .child(
-            Button::new("restore-defaults")
-                .outline()
-                .small()
-                .icon(IconName::Undo)
-                .label(tcode_i18n::tr!("settings.restore"))
-                .on_click(cx.listener(|this, _, window, cx| {
-                    this.confirm_restore(window, cx);
-                })),
+            gpui_component::h_flex()
+                .w(px(CONTENT_MAX_WIDTH))
+                .max_w_full()
+                .items_center()
+                .gap_3()
+                .child(
+                    div()
+                        .flex_1()
+                        .text_size(px(15.))
+                        .font_medium()
+                        .child(tcode_i18n::tr!("settings.title")),
+                )
+                .child(
+                    Button::new("restore-defaults")
+                        .outline()
+                        .small()
+                        .icon(IconName::Undo)
+                        .label(tcode_i18n::tr!("settings.restore"))
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.confirm_restore(window, cx);
+                        })),
+                ),
         )
         .into_any_element()
     }
@@ -548,18 +557,15 @@ impl SettingsPage {
 
     fn render_general(&self, cx: &mut Context<Self>) -> gpui::Div {
         let settings = self.app_state.read(cx).settings.clone();
-        let rows = vec![
+        // One mega-group on empty paper reads generic. Split the rows into three
+        // semantic groups (System-Settings rhythm): 20-24px between groups, each
+        // under an 11px caption.
+        let appearance = vec![
             self.language_row(settings.language.as_deref(), cx),
             self.theme_row(settings.theme_mode, cx),
+        ];
+        let conversation = vec![
             self.title_generation_row(cx),
-            self.toggle_row(
-                "word-wrap",
-                tcode_i18n::tr!("settings.word_wrap.title"),
-                tcode_i18n::tr!("settings.word_wrap.description"),
-                settings.word_wrap_diffs,
-                cx,
-                |s, checked| s.word_wrap_diffs = checked,
-            ),
             self.toggle_row(
                 "delete-confirm",
                 tcode_i18n::tr!("settings.delete_confirmation.title"),
@@ -576,6 +582,16 @@ impl SettingsPage {
                 cx,
                 |s, checked| s.auto_open_task_panel = checked,
             ),
+        ];
+        let workspace = vec![
+            self.toggle_row(
+                "word-wrap",
+                tcode_i18n::tr!("settings.word_wrap.title"),
+                tcode_i18n::tr!("settings.word_wrap.description"),
+                settings.word_wrap_diffs,
+                cx,
+                |s, checked| s.word_wrap_diffs = checked,
+            ),
             self.toggle_row(
                 "provider-update-checks",
                 tcode_i18n::tr!("settings.provider_updates.title"),
@@ -587,8 +603,22 @@ impl SettingsPage {
             ),
         ];
         v_flex()
-            .child(self.section_label(tcode_i18n::tr!("settings.general_section"), cx))
-            .child(self.grouped(rows, cx))
+            .gap(px(24.))
+            .child(
+                v_flex()
+                    .child(self.section_label(tcode_i18n::tr!("settings.appearance_section"), cx))
+                    .child(self.grouped(appearance, cx)),
+            )
+            .child(
+                v_flex()
+                    .child(self.section_label(tcode_i18n::tr!("settings.conversation_section"), cx))
+                    .child(self.grouped(conversation, cx)),
+            )
+            .child(
+                v_flex()
+                    .child(self.section_label(tcode_i18n::tr!("settings.workspace_section"), cx))
+                    .child(self.grouped(workspace, cx)),
+            )
     }
 
     fn title_generation_row(&self, cx: &mut Context<Self>) -> AnyElement {
@@ -1100,21 +1130,12 @@ impl SettingsPage {
             )
         } else {
             (
-                cx.theme().warning.opacity(0.15),
+                cx.theme().warning.opacity(0.12),
                 cx.theme().warning_foreground,
                 tcode_i18n::tr!("permissions.missing"),
             )
         };
-        div()
-            .flex_none()
-            .px_2()
-            .py_0p5()
-            .rounded_full()
-            .bg(bg)
-            .text_size(px(11.))
-            .text_color(fg)
-            .child(label)
-            .into_any_element()
+        crate::material::semantic_chip(label, bg, fg).into_any_element()
     }
 
     fn restart_banner(&self, cx: &mut Context<Self>) -> AnyElement {
@@ -1330,7 +1351,11 @@ impl SettingsPage {
         label: impl Into<SharedString>,
         cx: &Context<Self>,
     ) -> Button {
-        Button::new(id).outline().compact().child(
+        // Ghost, not outline: transparent at rest (value + muted chevron) with a
+        // light tint only on hover — the same quiet trigger the composer's model
+        // picker uses. An outlined trigger reads as a card nested inside the
+        // already-bordered group.
+        Button::new(id).ghost().compact().child(
             gpui_component::h_flex()
                 .w(px(160.))
                 .items_center()

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -145,6 +145,9 @@ settings:
   restore_description: "Reset language, theme, thread-title model, diff, provider, and orchestrate settings to their defaults. Your projects and conversations will not be changed."
   cancel: "Cancel"
   general_section: "GENERAL"
+  appearance_section: "APPEARANCE"
+  conversation_section: "CONVERSATION"
+  workspace_section: "WORKSPACE"
   providers_section: "PROVIDERS"
   orchestrate_section: "ORCHESTRATE"
   language:

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -145,6 +145,9 @@ settings:
   restore_description: "将语言、主题、对话命名模型、diff、提供商和 Orchestrate 设置恢复为默认值。项目和对话不会受到影响。"
   cancel: "取消"
   general_section: "通用"
+  appearance_section: "外观"
+  conversation_section: "对话"
+  workspace_section: "工作区"
   providers_section: "提供商"
   orchestrate_section: "ORCHESTRATE"
   language:


### PR DESCRIPTION
Round 2 of settings unification, directed by an eyes-on chat-vs-settings comparison (round 1's changes were real but too subtle). Five changes:

1. **Settings nav joins the sidebar family**: shared `material::brand_wordmark` helper renders the same `tcode`+DEV header chrome as the main sidebar; nav rows tightened to the sidebar's 30px/13px geometry. (sidebar.rs untouched — helper extracted to material.rs.)
2. **Ghost dropdown triggers**: closed triggers switch from outlined mini-cards (the residual "card in a card" at rest) to the composer picker's `Button::ghost()` idiom — transparent at rest, tint on hover. Open menus unchanged.
3. **General page rhythm**: the 7-row mega-group is now three semantic groups (外观 / 对话 / 工作区) with 24px spacing and 11px captions; locale keys added to both en/zh-CN (parity test green).
4. **Header tied to the content column**: title + Restore Defaults now align to the same centered 768px grid as the groups (strip stays full-width as the drag area).
5. **Providers semantic chips**: shared `material::semantic_chip` (11px, tinted, content-hugging) replaces the full-width validation bars; consolidated with provider-card tags and orchestrate chips.

AFTER screenshots reviewed and accepted: /tmp/tcode-settings2-general.png, /tmp/tcode-settings2-providers.png, /tmp/tcode-settings2-chat-sidebar.png. A11y preserved (triggers remain focusable Buttons; rows keep accessible_clickable; keyboard test green).

Gates: fmt / clippy -D warnings / tcode-ui 145 tests green on the rebased branch (known term-crate PTY flake excluded; untouched by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)