### PR TITLE
fix(ui): include table borders in scroll range

### DIFF
--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -36,6 +36,7 @@ use super::{
 const CODE_CACHE_CAPACITY: usize = 64;
 const BLOCK_OVERDRAW: Pixels = px(300.);
 const SCROLL_GESTURE_TIMEOUT: Duration = Duration::from_millis(250);
+const TABLE_BORDER_PX: f32 = 1.;
 type HighlightRuns = Vec<(Range<usize>, HighlightStyle)>;
 type SharedHighlightRuns = Arc<HighlightRuns>;
 type LinkRuns = Vec<(Range<usize>, super::nodes::LinkMark)>;
@@ -1016,6 +1017,15 @@ fn render_table(
     render_scroll_table(table, column_count, options, view, style, window, cx)
 }
 
+fn table_track_width(column_widths: &[f32]) -> f32 {
+    // Column widths cover text and horizontal cell padding. GPUI lays each
+    // vertical separator outside that flex basis, while the track's border-box
+    // consumes its two outer borders. Include both so the tracked child bounds
+    // contain every painted cell: N - 1 separators plus 2 outer borders.
+    column_widths.iter().sum::<f32>()
+        + TABLE_BORDER_PX * (column_widths.len().saturating_sub(1).saturating_add(2) as f32)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn render_scroll_table(
     table: &Table,
@@ -1074,7 +1084,7 @@ fn render_scroll_table(
             *slot = slot.max(f32::from(width) + CELL_PAD_PX);
         }
     }
-    let total_width = widths.iter().sum::<f32>();
+    let total_width = table_track_width(&widths);
     let row_count = table.children.len();
     let rows = table
         .children
@@ -1095,7 +1105,7 @@ fn render_scroll_table(
                 })
                 .children(row.children.iter().enumerate().map(|(ix, cell)| {
                     let align = table.column_align(ix);
-                    div()
+                    let rendered_cell = div()
                         .id(("table-cell", ix))
                         .flex_basis(px(widths.get(ix).copied().unwrap_or(CELL_MIN_PX)))
                         .flex_grow(widths.get(ix).copied().unwrap_or(CELL_MIN_PX))
@@ -1120,7 +1130,11 @@ fn render_scroll_table(
                             view,
                             style,
                             cx,
-                        ))
+                        ));
+                    #[cfg(test)]
+                    let rendered_cell = rendered_cell
+                        .debug_selector(move || format!("markdown-table-cell-{row_ix}-{ix}"));
+                    rendered_cell
                 }))
         })
         .collect::<Vec<_>>();
@@ -1228,6 +1242,12 @@ mod tests {
         assert_eq!(code_lines("a\n\n"), ["a", ""]);
         // Empty code renders zero lines rather than one phantom.
         assert_eq!(code_lines(""), Vec::<&str>::new());
+    }
+
+    #[test]
+    fn table_track_width_includes_cell_and_outer_borders() {
+        assert_eq!(table_track_width(&[48., 72., 96.]), 220.);
+        assert_eq!(table_track_width(&[]), 2.);
     }
 
     #[test]

--- a/crates/ui/src/markdown/view.rs
+++ b/crates/ui/src/markdown/view.rs
@@ -341,6 +341,81 @@ mod tests {
     }
 
     #[gpui::test]
+    fn wide_table_track_contains_the_last_cell(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        cx.update(crate::markdown::init);
+        let header = (0..20).map(|ix| format!("column-{ix}")).collect::<Vec<_>>();
+        let separator = vec!["---"; header.len()];
+        let values = (0..header.len())
+            .map(|ix| format!("value-{ix}"))
+            .collect::<Vec<_>>();
+        let markdown = format!(
+            "| {} |\n| {} |\n| {} |",
+            header.join(" | "),
+            separator.join(" | "),
+            values.join(" | ")
+        );
+        let (_, cx) = cx.add_window_view(|_, cx| TestRoot::new(&markdown, cx));
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        let track = cx
+            .debug_bounds("markdown-table-track-root-0")
+            .expect("table track was painted");
+        let last_cell = cx
+            .debug_bounds("markdown-table-cell-0-19")
+            .expect("last table cell was painted");
+        assert_eq!(
+            last_cell.right() + px(1.),
+            track.right(),
+            "last cell {:?} did not end at the track's inner right edge {:?}",
+            last_cell,
+            track
+        );
+    }
+
+    #[gpui::test]
+    fn streaming_table_growth_updates_track_width(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        cx.update(crate::markdown::init);
+        let (view, cx) =
+            cx.add_window_view(|_, cx| TestRoot::new("| column |\n| --- |\n| streaming", cx));
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        let initial_width = cx
+            .debug_bounds("markdown-table-track-root-0")
+            .expect("initial table track was painted")
+            .size
+            .width;
+
+        view.update(cx, |root, cx| {
+            root.markdown.update(cx, |markdown, cx| {
+                markdown.push_str("-cell-that-grows-much-wider |", cx);
+            });
+        });
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        let grown_width = cx
+            .debug_bounds("markdown-table-track-root-0")
+            .expect("grown table track was painted")
+            .size
+            .width;
+
+        assert!(
+            grown_width > initial_width,
+            "streamed table width stayed at {initial_width:?} instead of growing: {grown_width:?}"
+        );
+    }
+
+    #[gpui::test]
     fn clipped_markdown_cannot_start_selection(cx: &mut TestAppContext) {
         cx.update(gpui_component::init);
         cx.update(crate::markdown::init);


### PR DESCRIPTION
Wide markdown tables couldn't be scrolled all the way to their right edge: the scroll track's `total_width` summed cell text + padding but omitted the N−1 one-pixel column separators and the two outer borders, so GPUI clamped scrolling short of the painted content — a 20-column fixture reproduced an exact 20px gap (painted edge 1870px vs tracked 1850px).

The track width now includes separators and outer borders. Regression tests: geometry (final cell ends flush with the track's inner right edge) and streaming (appended table content enlarges the track). Confirmed the axis-lock helper only routes gestures and never computes/clamps offsets.

Gates: fmt / clippy -D warnings / workspace tests green (tcode-ui 148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)