### PR TITLE
ui(settings): chat's floating-card grammar + window material continuity

### DIFF
--- a/crates/ui/src/material.rs
+++ b/crates/ui/src/material.rs
@@ -109,6 +109,25 @@ pub fn overlay_contour(el: Div, cx: &App) -> Div {
         .shadow_xl()
 }
 
+/// A floating content card in chat's composer-console idiom: near-opaque
+/// `popover` fill, a hairline border, `radius_card` corners and the composer
+/// console's soft `shadow_md`, so the card reads as genuinely lifted off the
+/// T1 paper — the same depth chat's cards carry. This is the group container
+/// every settings surface now wears (docs/visual-redesign.md §5.5, 2026-07
+/// revision), replacing the old flat, shadowless System-Settings box, and it
+/// suits any other on-paper grouping that wants chat's card depth.
+///
+/// The composer field itself deliberately does NOT share this: it keeps the
+/// 16px `radius_composer` and its focus-reactive `input` border, so its inline
+/// spec stays untouched.
+pub fn floating_card(el: Div, cx: &App) -> Div {
+    el.rounded(radius_card())
+        .border_1()
+        .border_color(cx.theme().border)
+        .bg(cx.theme().popover)
+        .shadow_md()
+}
+
 /// The sidebar brand wordmark — bold "tcode" + the "DEV" channel pill. The main
 /// sidebar's app row (`sidebar.rs`) and the settings left-nav header are
 /// round-trip counterparts, so this shares the exact chrome without either side

--- a/crates/ui/src/orchestrate_settings.rs
+++ b/crates/ui/src/orchestrate_settings.rs
@@ -713,20 +713,17 @@ impl OrchestrateSettingsPanel {
             .into_any_element()
     }
 
-    /// One grouped-list container: popover fill, a single hairline border,
-    /// input-radius corners, no shadow.
+    /// One grouped-list container: a floating card in chat's composer-console
+    /// idiom — popover fill, a hairline border, card-radius corners and a soft
+    /// shadow (docs/visual-redesign.md §5.5, 2026-07 revision). Shared with the
+    /// General/Providers surfaces via `material::floating_card`.
     fn group(&self, cx: &Context<Self>) -> gpui::Div {
-        v_flex()
-            .w_full()
-            .rounded(crate::material::radius_input())
-            .border_1()
-            .border_color(cx.theme().border)
-            .bg(cx.theme().popover)
-            .overflow_hidden()
+        crate::material::floating_card(v_flex().w_full(), cx).overflow_hidden()
     }
 
-    /// Assemble rows into a group, split by inset hairlines (indented past the
-    /// row's left padding, never after the last row).
+    /// Assemble rows into a group, split by faint inset hairlines (indented past
+    /// the row's left padding, dropped to 60%, never after the last row) — these
+    /// are dense editable rows that need a visible boundary.
     fn grouped(&self, rows: Vec<AnyElement>, cx: &Context<Self>) -> gpui::Div {
         let mut group = self.group(cx);
         let last = rows.len().saturating_sub(1);
@@ -737,7 +734,7 @@ impl OrchestrateSettingsPanel {
                     div()
                         .w_full()
                         .pl_3()
-                        .child(div().w_full().h(px(1.)).bg(cx.theme().border)),
+                        .child(div().w_full().h(px(1.)).bg(cx.theme().border.opacity(0.6))),
                 );
             }
         }

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -607,17 +607,17 @@ impl SettingsPage {
             .child(
                 v_flex()
                     .child(self.section_label(tcode_i18n::tr!("settings.appearance_section"), cx))
-                    .child(self.grouped(appearance, cx)),
+                    .child(self.grouped_plain(appearance, cx)),
             )
             .child(
                 v_flex()
                     .child(self.section_label(tcode_i18n::tr!("settings.conversation_section"), cx))
-                    .child(self.grouped(conversation, cx)),
+                    .child(self.grouped_plain(conversation, cx)),
             )
             .child(
                 v_flex()
                     .child(self.section_label(tcode_i18n::tr!("settings.workspace_section"), cx))
-                    .child(self.grouped(workspace, cx)),
+                    .child(self.grouped_plain(workspace, cx)),
             )
     }
 
@@ -813,7 +813,7 @@ impl SettingsPage {
             col = col.child(
                 v_flex()
                     .child(self.section_label(group.project.name.clone(), cx))
-                    .child(self.grouped(rows, cx)),
+                    .child(self.grouped_plain(rows, cx)),
             );
         }
         col
@@ -883,7 +883,7 @@ impl SettingsPage {
             .child(
                 v_flex()
                     .child(self.section_label(tcode_i18n::tr!("computer_use.section"), cx))
-                    .child(self.grouped(rows, cx)),
+                    .child(self.grouped_plain(rows, cx)),
             )
             .child(self.permissions_group(
                 &[
@@ -918,7 +918,7 @@ impl SettingsPage {
         v_flex().gap(px(24.)).child(
             v_flex()
                 .child(self.section_label(tcode_i18n::tr!("browser.section"), cx))
-                .child(self.grouped(rows, cx)),
+                .child(self.grouped_plain(rows, cx)),
         )
     }
 
@@ -1064,7 +1064,10 @@ impl SettingsPage {
             .iter()
             .map(|kind| self.permission_row(*kind, cx))
             .collect();
-        let mut stack = v_flex().w_full().gap_2().child(self.grouped(rows, cx));
+        let mut stack = v_flex()
+            .w_full()
+            .gap_2()
+            .child(self.grouped_plain(rows, cx));
         // A fresh Screen Recording grant only takes effect after a restart; offer
         // an explicit relaunch when we've detected one is pending.
         if self.sr_restart_hint && kinds.contains(&PermissionKind::ScreenRecording) {
@@ -1224,30 +1227,28 @@ impl SettingsPage {
             .into_any_element()
     }
 
-    /// One grouped-list container: a clean box on the paper plane — popover
-    /// fill, a single hairline border, input-radius corners, no shadow.
+    /// One grouped-list container: a floating card on the paper plane, in
+    /// chat's composer-console idiom — popover fill, a hairline border,
+    /// card-radius corners and a soft shadow so it reads as lifted, not a flat
+    /// System-Settings box (docs/visual-redesign.md §5.5, 2026-07 revision).
     fn group(&self, cx: &Context<Self>) -> gpui::Div {
-        v_flex()
-            .w_full()
-            .rounded(crate::material::radius_input())
-            .border_1()
-            .border_color(cx.theme().border)
-            .bg(cx.theme().popover)
-            .overflow_hidden()
+        crate::material::floating_card(v_flex().w_full(), cx).overflow_hidden()
     }
 
-    /// Inset hairline between two rows — flush right, indented past the row's
-    /// left padding so it never reads as a full-bleed rule.
+    /// Faint inset hairline between two rows — flush right, indented past the
+    /// row's left padding, and dropped to 60% so it whispers rather than rules.
+    /// Only dense lists (Providers) use it; sparse surfaces separate with air.
     fn row_divider(&self, cx: &Context<Self>) -> AnyElement {
         div()
             .w_full()
             .pl_3()
-            .child(div().w_full().h(px(1.)).bg(cx.theme().border))
+            .child(div().w_full().h(px(1.)).bg(cx.theme().border.opacity(0.6)))
             .into_any_element()
     }
 
-    /// Assemble rows into a group, inset-divided between neighbours (never after
-    /// the last).
+    /// Assemble rows into a group with faint inset hairlines between neighbours
+    /// (never after the last) — for dense lists where rows need a visible
+    /// boundary.
     fn grouped(&self, rows: Vec<AnyElement>, cx: &Context<Self>) -> gpui::Div {
         let mut group = self.group(cx);
         let last = rows.len().saturating_sub(1);
@@ -1256,6 +1257,17 @@ impl SettingsPage {
             if index != last {
                 group = group.child(self.row_divider(cx));
             }
+        }
+        group
+    }
+
+    /// Assemble rows into a group with NO dividers — chat separates content
+    /// with breathing room, not rules. The default for sparse settings surfaces
+    /// (General, Browser, Computer Use, Archived, permissions).
+    fn grouped_plain(&self, rows: Vec<AnyElement>, cx: &Context<Self>) -> gpui::Div {
+        let mut group = self.group(cx);
+        for row in rows {
+            group = group.child(row);
         }
         group
     }
@@ -1287,7 +1299,9 @@ impl SettingsPage {
             .w_full()
             .min_h(px(44.))
             .px_3()
-            .py_2()
+            // Divider-less cards lean on row air for separation: a touch more
+            // vertical padding gives neighbours room to breathe.
+            .py_2p5()
             .gap_3()
             .items_center()
     }
@@ -1553,9 +1567,12 @@ impl Render for SettingsPage {
             self.debug_acp_dialog_pending = false;
             self.open_acp_dialog(window, cx);
         }
+        // No opaque full-page fill: the nav must sit on the same translucent
+        // glass canvas the chat sidebar does (its `sidebar` token shows the
+        // T0 blur through its own translucency), so navigating chat↔settings
+        // never flips the window material. Only the content column is paper.
         gpui_component::h_flex()
             .size_full()
-            .bg(cx.theme().background)
             .text_color(cx.theme().foreground)
             .child(self.render_nav(window, cx))
             .child(
@@ -1564,6 +1581,9 @@ impl Render for SettingsPage {
                     .min_w_0()
                     .h_full()
                     .bg(crate::material::content_surface(cx))
+                    // T1 paper floats above the glass canvas — the same shadow
+                    // the chat column carries, so the reading plane is identical.
+                    .shadow_sm()
                     .child(self.render_header(window, cx))
                     .child(self.render_content(window, cx)),
             )

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -328,6 +328,12 @@ impl Render for AppShell {
             .update(cx, |preview, cx| preview.sync_visibility(cx));
 
         // The full-page settings route replaces the chat workspace entirely.
+        // It composes exactly like the chat workspace below — Root owns the
+        // translucent glass canvas; the settings page paints its own nav
+        // (translucent `sidebar`) and content paper (`content_surface`) so the
+        // window material is byte-identical across navigation. Painting an
+        // opaque paper across the whole window here (behind the nav) is what
+        // made settings feel like "a different app".
         if route == Route::Settings {
             return div()
                 .id("app-shell")
@@ -344,10 +350,11 @@ impl Render for AppShell {
                 .child(crate::markdown::TextSelectionController)
                 .child(
                     div()
+                        .id("workspace")
+                        .flex_1()
                         .size_full()
-                        .bg(crate::material::content_surface(cx))
-                        // T1 paper floats above the glass canvas.
-                        .shadow_sm()
+                        .min_h_0()
+                        .overflow_hidden()
                         .child(self.settings_page.clone()),
                 )
                 .child(self.toasts.clone())

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -244,8 +244,14 @@ palette, or leaving Chat hides every WebView that no longer owns the panel.
 ### Settings (full-page route)
 Left nav (sidebar width): General / Providers / Orchestrate + "← Back" pinned
 bottom. Header: "Settings" + "Restore defaults" bordered button (confirm).
-Rows: bold 14px title + 13px muted description left, control right (dropdown /
-toggle / text input), hairline separators. General: Language, Theme
+Groups are **floating cards** in chat's composer-console idiom, not flat
+System-Settings boxes (`material::floating_card`: popover fill, hairline border,
+radius 12, subtle `shadow_md`); the 768px content column and window material
+(T0 blur + translucent paper) are identical to chat, so navigating in/out never
+flips the material. Rows: bold 15px title + 13px muted description left, control
+right (dropdown / toggle / text input). Sparse surfaces separate rows with
+breathing room and no rules; only dense lists (Providers, Orchestrate) carry the
+faintest inset hairline. General: Language, Theme
 (System/Light/Dark, live), thread-title provider/model, Word wrap in diffs,
 Delete confirmation, task-panel behavior, and provider update checks. The title
 model defaults to Codex `gpt-5.6-luna`; its isolated background request always

--- a/docs/visual-redesign.md
+++ b/docs/visual-redesign.md
@@ -123,10 +123,21 @@ material.rs 常量，禁止再写魔法数字：
 
 ## 5.5 修订版组件准则（2026-07 用户验收后追加，优先级高于下文冲突条款）
 
-- **设置类界面 = macOS System Settings 分组语法**：一个分组一个圆角容器
-  （popover 填充 + 发丝边 + 10px 圆角、无阴影），行与行用**内缩发丝线**分隔，
-  行本身透明无卡片；组间 20-24px 留白 + 组外 11px 大写标题。
-  ❌ 禁止成片的灰色 T2 平板卡无间隔堆叠（AI slop）。
+- **设置类界面 = 对话的浮起卡片语法**（2026-07 第三轮用户反馈修订,取代此前
+  System Settings 条款）：设置分组不再是扁平无阴影的 System-Settings 盒子——
+  用户验收认为那仍读作"另一套设计语言"。改为与 chat 的 composer 控制台／卡片
+  同一套 surface/depth 词汇：每个分组是一张**浮起卡片**（`material::floating_card`：
+  `popover` 填充 + 发丝边 `border` + `radius_card` 12px 圆角 + `shadow_md` 柔和阴影），
+  像 chat 的卡片一样真正浮在 T1 纸面上。行与行**优先用留白分隔、不画线**（对话即
+  以间距而非导轨分隔内容）；只有确实密集的列表（Providers、Orchestrate 可编辑行）
+  才用**最淡的内缩发丝线**（`border` 60%）。组间 20-24px 留白 + 组外 11px 大写标题。
+  ❌ 仍禁止成片的灰色 T2 平板卡无间隔堆叠（AI slop）——浮起卡片是白／popover 实底、
+  有真实景深，不是灰平板。
+- **窗口材质跨路由不变**：chat↔settings 导航必须保持同一套 T0 玻璃模糊 + 半透纸面
+  合成，仅内容变化。settings 路由不得在导航栏／内容之下铺任何不透明整窗层
+  （历史 bug：shell 在设置页整窗涂 `content_surface`，导致左侧 nav 坐在实底纸上而非
+  玻璃画布，材质在导航瞬间翻转）。settings nav 用与主侧栏相同的半透 `sidebar` token
+  直接坐在画布上；内容列用 `content_surface` + `shadow_sm` 浮起，与 chat 列一致。
 - **changed-files/diff 清单 = 安静清单**：与正文列对齐、无容器无导轨，
   小型大写标题行 + hover 着色的文件行。导轨语言只属于**状态性**事件
   （错误/成功/工具日志）与 toast。


### PR DESCRIPTION
Round 3 — the direction change that closes the "switching to settings feels like a different app" complaint. Two mechanisms, both fixed:

**Window material continuity (the big one).** The settings route wrapped the whole window — including the left nav — in opaque `content_surface` paper, while the chat route composes a translucent sidebar over the blurred glass canvas. The window's left edge flipped from glass to paper on every navigation. The settings route (still a full-page route — deliberately kept) now mirrors chat's composition exactly: nav on `sidebar` token directly over the glass canvas, paper + `shadow_sm` only on the content area, fullscreen opaque-canvas flattening preserved. Side-by-side captures confirm identical wallpaper bleed-through on both routes.

**Floating-card grammar.** Settings groups leave the flat System-Settings form box for chat's card vocabulary via a shared `material::floating_card`: `popover` fill, hairline border, `radius_card` (12px — 16px stays reserved for the composer hero), the composer's `shadow_md`. Sparse pages (General/Browser/Computer Use/Archived) drop row dividers for breathing room; dense pages (Providers/Orchestrate) keep the faintest inset hairline. All round-1/2 wins retained (768px column, semantic groups, ghost triggers, semantic chips, sidebar-family nav, a11y — keyboard tests green).

docs/visual-redesign.md §5.5 amended (System-Settings clause superseded, material-continuity rule added); DESIGN.md updated.

Gates: fmt / clippy -D warnings / workspace tests green (term PTY flake re-run clean in isolation). AFTER screenshots reviewed and accepted by the orchestrator: /tmp/tcode-settings3-{general,providers,orchestrate,material-chat,material-settings}.png.

🤖 Generated with [Claude Code](https://claude.com/claude-code)