### PR TITLE
fix(ui): reserve steering border in user bubble width

### DIFF
--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -1225,8 +1225,11 @@ impl ChatView {
                 let pending = steering == Some(SteeringStatus::Pending);
                 div()
                     // Ceil past sub-pixel snapping plus 1px slack — an exact
-                    // fractional fit can still wrap the final glyph.
-                    .w((text_width + px(32.)).ceil() + px(1.))
+                    // fractional fit can still wrap the final glyph. The extra
+                    // 2px always reserves the pending state's border (sizes are
+                    // border-box), so the width holds steady across steering
+                    // states and the last glyph never wraps while pending.
+                    .w((text_width + px(32.)).ceil() + px(3.))
                     .flex_none()
                     .max_w_3_4()
                     .px_4()


### PR DESCRIPTION
While a steer is pending (引导中), the user bubble gains a 1px dashed border. gpui/taffy sizes are border-box, so the border eats 2px of content width that the intrinsic-width formula didn't reserve — the last glyph wraps to a second line (most visible with CJK). Once the steer is accepted (已引导) the border disappears and the bubble renders correctly, matching the reported symptom exactly.

The bubble width now always reserves the 2px so the content area is identical in both states — which also removes a 2px width jump at the moment a steer is accepted.

Gates: fmt / clippy / tcode-ui tests (147) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)