### PR TITLE
feat(ui): per-profile provider settings dialog + per-profile status probes

### DIFF
--- a/crates/core/src/provider_models.rs
+++ b/crates/core/src/provider_models.rs
@@ -72,14 +72,7 @@ pub fn resolve_models(
             capabilities: Vec::new(),
         });
     }
-    let rank = |id: &str| {
-        settings
-            .model_order
-            .iter()
-            .position(|model| model == id)
-            .unwrap_or(usize::MAX)
-    };
-    rows.sort_by_key(|row| rank(&row.id));
+    // Favorites float to the top; everything else keeps its catalog order.
     rows.sort_by_key(|row| !row.favorite);
     rows
 }
@@ -93,23 +86,6 @@ pub fn picker_models(
         .into_iter()
         .filter(|row| !row.hidden)
         .collect()
-}
-
-pub fn move_target(rows: &[ResolvedModel], index: usize, up: bool) -> Option<usize> {
-    let row = rows.get(index)?;
-    let candidate = if up { index.checked_sub(1)? } else { index + 1 };
-    let neighbour = rows.get(candidate)?;
-    (neighbour.favorite == row.favorite).then_some(candidate)
-}
-
-pub fn reorder(rows: &[ResolvedModel], from: usize, to: usize) -> Vec<String> {
-    let mut ids: Vec<_> = rows.iter().map(|row| row.id.clone()).collect();
-    if from >= ids.len() || to >= ids.len() {
-        return ids;
-    }
-    let id = ids.remove(from);
-    ids.insert(to, id);
-    ids
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -185,19 +161,6 @@ mod tests {
     }
 
     #[test]
-    fn explicit_order_wins_over_catalog_order() {
-        let settings = ProviderSettings {
-            model_order: vec!["haiku".into(), "opus".into()],
-            ..Default::default()
-        };
-        let rows = resolve_models(&catalog(), &settings, &[]);
-        assert_eq!(
-            rows.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
-            ["haiku", "opus", "sonnet"]
-        );
-    }
-
-    #[test]
     fn hidden_models_stay_in_settings_but_leave_the_picker() {
         let settings = ProviderSettings {
             hidden_models: vec!["sonnet".into()],
@@ -237,45 +200,18 @@ mod tests {
     }
 
     #[test]
-    fn hidden_order_custom_and_favorites_compose() {
+    fn hidden_custom_and_favorites_compose() {
         let settings = ProviderSettings {
             custom_models: vec!["claude-sonnet-5".into()],
             hidden_models: vec!["opus".into()],
-            model_order: vec!["claude-sonnet-5".into(), "haiku".into()],
             ..Default::default()
         };
         let rows = picker_models(&catalog(), &settings, &["haiku".into()]);
+        // Favorite floats up; the rest keep catalog order (custom slugs last);
+        // hidden `opus` is filtered from the picker.
         assert_eq!(
             rows.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
-            ["haiku", "claude-sonnet-5", "sonnet"]
-        );
-    }
-
-    #[test]
-    fn moves_stay_inside_the_favorite_group() {
-        let rows = resolve_models(&catalog(), &ProviderSettings::default(), &["opus".into()]);
-        assert_eq!(move_target(&rows, 0, true), None);
-        assert_eq!(move_target(&rows, 0, false), None);
-        assert_eq!(move_target(&rows, 1, true), None);
-        assert_eq!(move_target(&rows, 1, false), Some(2));
-        assert_eq!(move_target(&rows, 2, true), Some(1));
-        assert_eq!(move_target(&rows, 2, false), None);
-    }
-
-    #[test]
-    fn reorder_rewrites_the_full_id_sequence() {
-        let rows = resolve_models(&catalog(), &ProviderSettings::default(), &[]);
-        assert_eq!(reorder(&rows, 2, 1), ["opus", "haiku", "sonnet"]);
-        let settings = ProviderSettings {
-            model_order: reorder(&rows, 2, 1),
-            ..Default::default()
-        };
-        assert_eq!(
-            resolve_models(&catalog(), &settings, &[])
-                .iter()
-                .map(|row| row.id.as_str())
-                .collect::<Vec<_>>(),
-            ["opus", "haiku", "sonnet"]
+            ["haiku", "sonnet", "claude-sonnet-5"]
         );
     }
 

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -102,11 +102,7 @@ pub struct ProviderSettings {
     /// OpenCode ignores this field because it has no single-home override.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub home_path: Option<PathBuf>,
-    /// Codex only: account-specific `CODEX_HOME` (takes precedence over `home_path`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub shadow_home_path: Option<PathBuf>,
-    /// Native-provider CLI arguments appended on session start (Codex keeps
-    /// its separate shadow-home field in the corresponding card slot).
+    /// Native-provider CLI arguments appended on session start (ignored for Codex).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub launch_args: Option<String>,
     /// Model slugs added by hand in the Models section.
@@ -115,10 +111,6 @@ pub struct ProviderSettings {
     /// Model ids hidden from the composer's model picker.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub hidden_models: Vec<String>,
-    /// Explicit ordering (ids listed here come first, in this order; anything
-    /// else keeps its catalog order behind them).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub model_order: Vec<String>,
 }
 
 fn default_true() -> bool {
@@ -134,11 +126,9 @@ impl Default for ProviderSettings {
             env: Vec::new(),
             binary_path: None,
             home_path: None,
-            shadow_home_path: None,
             launch_args: None,
             custom_models: Vec::new(),
             hidden_models: Vec::new(),
-            model_order: Vec::new(),
         }
     }
 }
@@ -153,11 +143,9 @@ impl ProviderSettings {
     }
 
     /// The home directory this provider's children should run against
-    /// (`shadow_home_path` wins for Codex; `None` = inherit).
+    /// (`None` = inherit).
     pub fn effective_home(&self) -> Option<PathBuf> {
-        self.shadow_home_path
-            .clone()
-            .or_else(|| self.home_path.clone())
+        self.home_path.clone()
     }
 }
 
@@ -763,6 +751,16 @@ impl Settings {
         out
     }
 
+    /// Like [`Self::profiles_for_kind`], but only the profiles whose `enabled`
+    /// switch is on. This is what the new-session model/profile pickers iterate;
+    /// a disabled profile stays configurable in Settings but is not offered.
+    pub fn enabled_profiles_for_kind(&self, kind: ProviderKind) -> Vec<ResolvedProfile> {
+        self.profiles_for_kind(kind)
+            .into_iter()
+            .filter(|profile| profile.settings.enabled)
+            .collect()
+    }
+
     /// A profile's card title: its display-name override, else — for built-ins —
     /// the driver label, else the id. Used by the sidebar / picker / status row.
     pub fn profile_display_name(&self, id: &str) -> String {
@@ -900,13 +898,54 @@ mod tests {
     }
 
     #[test]
-    fn shadow_home_wins_over_home() {
+    fn effective_home_reads_home_path() {
         let settings = ProviderSettings {
             home_path: Some(PathBuf::from("/a")),
-            shadow_home_path: Some(PathBuf::from("/b")),
             ..ProviderSettings::default()
         };
-        assert_eq!(settings.effective_home(), Some(PathBuf::from("/b")));
+        assert_eq!(settings.effective_home(), Some(PathBuf::from("/a")));
+        assert_eq!(ProviderSettings::default().effective_home(), None);
+    }
+
+    #[test]
+    fn enabled_profiles_for_kind_drops_disabled_profiles() {
+        let mut settings = Settings::default();
+        // The built-in Claude profile is enabled; add one enabled and one
+        // disabled user profile of the same kind.
+        settings.profiles.insert(
+            "on".into(),
+            ProviderProfile {
+                kind: ProviderKind::ClaudeCode,
+                settings: ProviderSettings {
+                    enabled: true,
+                    ..ProviderSettings::default()
+                },
+            },
+        );
+        settings.profiles.insert(
+            "off".into(),
+            ProviderProfile {
+                kind: ProviderKind::ClaudeCode,
+                settings: ProviderSettings {
+                    enabled: false,
+                    ..ProviderSettings::default()
+                },
+            },
+        );
+        let ids: Vec<_> = settings
+            .enabled_profiles_for_kind(ProviderKind::ClaudeCode)
+            .into_iter()
+            .map(|profile| profile.id)
+            .collect();
+        assert_eq!(ids, ["claude", "on"]);
+        // Disabling the built-in removes it from the enabled set too.
+        settings.provider_mut(ProviderKind::ClaudeCode).enabled = false;
+        let ids: Vec<_> = settings
+            .enabled_profiles_for_kind(ProviderKind::ClaudeCode)
+            .into_iter()
+            .map(|profile| profile.id)
+            .collect();
+        assert_eq!(ids, ["on"]);
     }
 
     #[test]

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -808,9 +808,9 @@ pub struct AppState {
     /// Per-provider version-check results (Group C). Populated on launch (when
     /// the toggle is on) and by Settings → "Check now".
     pub provider_versions: HashMap<ProviderKind, ProviderVersionStatus>,
-    /// Per-provider install/auth probe results, driving the Settings → Providers
+    /// Per-profile install/auth probe results, driving the Settings → Providers
     /// card status dot + summary line. Absent until the first probe lands.
-    pub provider_snapshots: HashMap<ProviderKind, ProviderSnapshot>,
+    pub provider_snapshots: HashMap<String, ProviderSnapshot>,
     /// A restart-continuity marker taken at launch (see `tcode_services::relaunch`).
     /// Present only after an app-relaunch triggered by a permission grant; applied
     /// once by [`AppState::apply_pending_relaunch`] and then cleared.
@@ -1566,13 +1566,19 @@ impl AppState {
         self.provider_versions.get(&provider)
     }
 
-    /// Resolve the binary path for a provider: the settings override, else a
-    /// PATH lookup of the bare command name.
+    /// Resolve the binary path for a built-in provider profile.
     fn resolve_provider_binary(&self, provider: ProviderKind) -> Option<PathBuf> {
-        self.settings
-            .provider(provider)
+        self.resolve_profile_binary(Settings::builtin_profile_id(provider))
+    }
+
+    /// Resolve the binary path for a profile: its settings override, else a
+    /// PATH lookup of the protocol's bare command name.
+    fn resolve_profile_binary(&self, profile_id: &str) -> Option<PathBuf> {
+        let profile = self.settings.resolved_profile(profile_id)?;
+        profile
+            .settings
             .binary_path
-            .or_else(|| which_in_path(&default_program(provider)))
+            .or_else(|| which_in_path(&default_program(profile.kind)))
     }
 
     // -- per-provider configuration (Settings → Providers) ------------------
@@ -1705,9 +1711,9 @@ impl AppState {
     // A *profile* is a named configuration on top of a protocol `ProviderKind`.
     // The built-in native-provider cards are profiles too (with stable ids such
     // as "claude", "codex", "pi", and "opencode").
-    // The model catalog, version, and status probe stay keyed by kind and are
-    // shared across a kind's profiles; a profile overrides only its card config
-    // (env, binary, home, accent, custom/hidden models) and its own secrets.
+    // The model catalog and update-check version stay keyed by kind; status
+    // probes and card config (env, binary, home, accent, custom/hidden models)
+    // are profile-specific, as are secrets.
 
     /// Every selectable native profile, grouped by kind. ACP is handled
     /// separately through the installed-agent list.
@@ -1896,8 +1902,12 @@ impl AppState {
 
     // -- provider status snapshots (Settings → Providers card) --------------
 
+    pub fn profile_snapshot(&self, id: &str) -> Option<&ProviderSnapshot> {
+        self.provider_snapshots.get(id)
+    }
+
     pub fn provider_snapshot(&self, provider: ProviderKind) -> Option<&ProviderSnapshot> {
-        self.provider_snapshots.get(&provider)
+        self.profile_snapshot(Settings::builtin_profile_id(provider))
     }
 
     /// The most recent probe time across providers (the section's "Checked …").
@@ -1914,25 +1924,30 @@ impl AppState {
             || self.provider_versions.values().any(|s| s.checking)
     }
 
-    /// Probe every provider: is the CLI there, what version, and who is signed
+    /// Probe every provider profile: is the CLI there, what version, and who is signed
     /// in? Runs the same `--version` call the version check uses, plus the
     /// provider's own auth surface where one is unambiguous (`claude auth
     /// status --json`; Codex's `auth.json`). Multi-provider CLIs report an
     /// indeterminate auth state until their model/session requests run.
     pub fn refresh_provider_status(&mut self, cx: &mut Context<Self>) {
-        for provider in NATIVE_PROVIDER_KINDS {
-            let snapshot = self.provider_snapshots.entry(provider).or_default();
+        for profile in self.all_profiles() {
+            let profile_id = profile.id;
+            let provider = profile.kind;
+            let snapshot = self
+                .provider_snapshots
+                .entry(profile_id.clone())
+                .or_default();
             if snapshot.checking {
                 continue;
             }
             snapshot.checking = true;
-            let binary = self.resolve_provider_binary(provider);
-            let launch_env = self.launch_env(provider);
+            let binary = self.resolve_profile_binary(&profile_id);
+            let launch_env = self.launch_env_for_profile(&profile_id);
             cx.spawn(async move |this, cx| {
                 let snapshot = probe_provider(provider, binary, launch_env).await;
-                log::info!("probe {provider:?} -> {snapshot:?}");
+                log::info!("probe {provider:?} profile {profile_id} -> {snapshot:?}");
                 let _ = this.update(cx, |state, cx| {
-                    state.provider_snapshots.insert(provider, snapshot);
+                    state.provider_snapshots.insert(profile_id, snapshot);
                     cx.notify();
                 });
             })
@@ -8206,6 +8221,76 @@ mod tests {
                 ("PLAIN".to_string(), "visible".to_string()),
                 ("ANTHROPIC_API_KEY".to_string(), "sk-x".to_string()),
             ]
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn provider_snapshots_are_isolated_by_profile() {
+        let root = std::env::temp_dir().join(format!(
+            "tcode-profile-snapshot-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let store = SessionStore::open_at(root.clone()).unwrap();
+        let mut state = AppState::new(store);
+        state.provider_snapshots.insert(
+            "claude".into(),
+            ProviderSnapshot {
+                version: Some("1.0.0".into()),
+                ..ProviderSnapshot::default()
+            },
+        );
+        state.provider_snapshots.insert(
+            "kimi".into(),
+            ProviderSnapshot {
+                version: Some("2.0.0".into()),
+                ..ProviderSnapshot::default()
+            },
+        );
+
+        assert_eq!(
+            state
+                .profile_snapshot("kimi")
+                .and_then(|snapshot| snapshot.version.as_deref()),
+            Some("2.0.0")
+        );
+        assert_eq!(
+            state
+                .profile_snapshot("claude")
+                .and_then(|snapshot| snapshot.version.as_deref()),
+            Some("1.0.0")
+        );
+        assert_eq!(
+            state
+                .provider_snapshot(ProviderKind::ClaudeCode)
+                .and_then(|snapshot| snapshot.version.as_deref()),
+            Some("1.0.0")
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn profile_binary_override_wins_over_path_lookup() {
+        let root = std::env::temp_dir().join(format!(
+            "tcode-profile-binary-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let store = SessionStore::open_at(root.clone()).unwrap();
+        let mut state = AppState::new(store);
+        state.settings.profiles.insert(
+            "kimi".into(),
+            ProviderProfile {
+                kind: ProviderKind::ClaudeCode,
+                settings: ProviderSettings {
+                    binary_path: Some(PathBuf::from("/opt/kimi/claude")),
+                    ..ProviderSettings::default()
+                },
+            },
+        );
+
+        assert_eq!(
+            state.resolve_profile_binary("kimi"),
+            Some(PathBuf::from("/opt/kimi/claude"))
         );
         let _ = std::fs::remove_dir_all(root);
     }

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -1725,6 +1725,23 @@ impl AppState {
         out
     }
 
+    /// Every native profile enabled for new sessions (its card's switch on).
+    /// The new-session model/profile pickers iterate this; the Settings page
+    /// still lists every profile through [`Self::all_profiles`].
+    pub fn enabled_profiles(&self) -> Vec<ResolvedProfile> {
+        let mut out = self.settings.enabled_profiles_for_kind(ProviderKind::Codex);
+        out.extend(
+            self.settings
+                .enabled_profiles_for_kind(ProviderKind::ClaudeCode),
+        );
+        out.extend(self.settings.enabled_profiles_for_kind(ProviderKind::Pi));
+        out.extend(
+            self.settings
+                .enabled_profiles_for_kind(ProviderKind::OpenCode),
+        );
+        out
+    }
+
     /// The protocol kind a profile drives (built-in or user). Falls back to
     /// ClaudeCode for an unknown id (callers treat unknown ids as gone).
     pub fn profile_kind(&self, id: &str) -> ProviderKind {
@@ -2148,6 +2165,31 @@ impl AppState {
         picker_models(
             self.catalog_for_profile(id),
             &self.profile_settings(id),
+            &self.settings.favorite_models,
+        )
+    }
+
+    /// The model catalog backing a profile, owned (the provider dialog resolves
+    /// draft custom/hidden edits against it before Save; favorites stay live).
+    pub fn profile_catalog(&self, id: &str) -> Vec<ModelSpec> {
+        self.catalog_for_profile(id).to_vec()
+    }
+
+    /// Resolve a profile's Settings-card model list against a *draft* custom /
+    /// hidden set (what the provider dialog edits before Save). Favorites are
+    /// read live, matching the dialog's live favorite toggling.
+    pub fn draft_models_for_profile(
+        &self,
+        id: &str,
+        custom_models: &[String],
+        hidden_models: &[String],
+    ) -> Vec<ResolvedModel> {
+        let mut settings = self.profile_settings(id);
+        settings.custom_models = custom_models.to_vec();
+        settings.hidden_models = hidden_models.to_vec();
+        resolve_models(
+            self.catalog_for_profile(id),
+            &settings,
             &self.settings.favorite_models,
         )
     }
@@ -8148,7 +8190,7 @@ mod tests {
         claude.home_path = Some(PathBuf::from("/tmp/claude-home"));
         claude.launch_args = Some("--chrome --verbose".into());
         let codex = settings.provider_mut(ProviderKind::Codex);
-        codex.shadow_home_path = Some(PathBuf::from("/tmp/codex-shadow"));
+        codex.home_path = Some(PathBuf::from("/tmp/codex-shadow"));
 
         let launch_env = LaunchEnv {
             env: vec![("ANTHROPIC_BASE_URL".into(), "https://proxy.test".into())],
@@ -8168,7 +8210,7 @@ mod tests {
             ]
         );
 
-        // Codex takes its shadow home as CODEX_HOME, and has no launch args.
+        // Codex takes its home as CODEX_HOME, and has no launch args.
         let launch_env = LaunchEnv {
             env: Vec::new(),
             home: settings.provider(ProviderKind::Codex).effective_home(),

--- a/crates/services/src/settings.rs
+++ b/crates/services/src/settings.rs
@@ -168,11 +168,9 @@ mod tests {
                 ],
                 binary_path: Some(PathBuf::from("/opt/tools/codex")),
                 home_path: Some(PathBuf::from("/tmp/codex-home")),
-                shadow_home_path: Some(PathBuf::from("/tmp/codex-shadow")),
                 launch_args: None,
                 custom_models: vec!["gpt-6.7-codex".into()],
                 hidden_models: vec!["gpt-5".into()],
-                model_order: vec!["gpt-6".into(), "gpt-5".into()],
             },
         );
         providers.insert(

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -3560,15 +3560,15 @@ fn render_model_pane(
         PickerRail::Favorites,
         cx,
     ));
-    // One entry per native profile: every built-in plus any user-created
-    // profiles. Each is its own rail.
+    // One entry per *enabled* native profile: every built-in plus any
+    // user-created profiles whose switch is on. Each is its own rail.
     let profile_ids: Vec<String> = {
         let st = app_entity.read(cx);
         PICKER_PROVIDER_KINDS
             .into_iter()
             .flat_map(|kind| {
                 st.settings
-                    .profiles_for_kind(kind)
+                    .enabled_profiles_for_kind(kind)
                     .into_iter()
                     .map(|profile| profile.id)
             })

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -17,6 +17,7 @@ mod palette;
 mod plan_panel;
 mod preview_panel;
 pub mod provider_card;
+mod provider_dialog;
 mod provider_model_picker;
 pub mod provider_models;
 pub mod provider_status;

--- a/crates/ui/src/provider_card.rs
+++ b/crates/ui/src/provider_card.rs
@@ -464,14 +464,17 @@ impl ProviderCard {
     fn render_header(&self, cx: &mut Context<Self>) -> AnyElement {
         let state = self.app_state.read(cx);
         let provider = self.provider;
-        // Name + enabled come from this profile's card; the status/version/probe
-        // is shared across all profiles of the kind (same CLI).
+        // Name, enabled state, and probe result all belong to this profile;
+        // update-check versions remain shared by protocol kind.
         let name = state.profile_display_name(&self.profile_id);
         let enabled = state.profile_settings(&self.profile_id).enabled;
-        let summary =
-            crate::provider_status::summarize(provider, state.provider_snapshot(provider), enabled);
+        let summary = crate::provider_status::summarize(
+            provider,
+            state.profile_snapshot(&self.profile_id),
+            enabled,
+        );
         let version = state
-            .provider_snapshot(provider)
+            .profile_snapshot(&self.profile_id)
             .and_then(|s| s.version.clone())
             .or_else(|| {
                 state

--- a/crates/ui/src/provider_card.rs
+++ b/crates/ui/src/provider_card.rs
@@ -1,20 +1,19 @@
-//! One Settings → Providers card (T3's `ProviderInstanceCard`).
+//! One Settings → Providers list row.
 //!
-//! Collapsed: driver glyph + status dot, name, `v<version>`, an update icon when
-//! a newer CLI exists, the status summary line, then a chevron + enable switch.
-//! Expanded (T3's order): Display name → Accent color → Environment variables →
-//! driver fields → Models.
+//! A compact, non-expanding row: driver glyph + status dot, name, `v<version>`,
+//! an update icon when a newer CLI exists, the status summary line, a gear button
+//! and the enable switch. The row body and the gear both open the per-profile
+//! settings [`ProviderDialog`], a transactional modal form.
 
 use gpui::{
-    AnyElement, App, AppContext as _, ClipboardItem, Context, Entity, InteractiveElement as _,
-    IntoElement, ParentElement as _, Render, SharedString, StatefulInteractiveElement as _,
-    Styled as _, Subscription, Window, div, prelude::FluentBuilder as _, px, rgb,
+    AnyElement, AppContext as _, ClipboardItem, Context, Entity, InteractiveElement as _,
+    IntoElement, ParentElement as _, Render, StatefulInteractiveElement as _, Styled as _,
+    Subscription, Window, div, prelude::FluentBuilder as _, px, rgb,
 };
 use gpui_component::{
-    ActiveTheme as _, Disableable as _, Icon, IconName, Sizable as _, StyledExt as _,
+    ActiveTheme as _, Icon, IconName, Sizable as _, StyledExt as _, WindowExt as _,
     button::{Button, ButtonVariants as _},
     h_flex,
-    input::{Input, InputEvent, InputState},
     popover::Popover,
     switch::Switch,
     v_flex,
@@ -23,47 +22,23 @@ use gpui_component::{
 use agent::ProviderKind;
 use tcode_runtime::app::AppState;
 
-use crate::provider_models::{
-    ResolvedModel, model_capability_label, move_target, reorder, slug_error_message, validate_slug,
-};
+use crate::provider_dialog::ProviderDialog;
 use crate::provider_status::{EMAIL_SLOT, StatusDot, redact_email};
-use crate::settings::{ACCENT_PRESETS, EnvVar, ProviderSettings};
 
 /// Claude's official Clay brand color from Anthropic's media resources.
 pub const CLAUDE_BRAND_COLOR: u32 = 0xD97757;
 
-/// One environment-variable row's live inputs.
-struct EnvRowState {
-    name: Entity<InputState>,
-    value: Entity<InputState>,
-    sensitive: bool,
-    /// A sensitive row whose value is already stored in `secrets.json`. Its
-    /// value is never read back, so the input shows the "Stored secret"
-    /// placeholder until the user types a replacement.
-    stored: bool,
-}
-
 pub struct ProviderCard {
     app_state: Entity<AppState>,
-    /// The protocol this card's profile drives (glyph, home labels, third-field
-    /// semantics, shared model catalog / status / version are all keyed on it).
+    /// The protocol this card's profile drives (glyph, shared model catalog /
+    /// status / version are all keyed on it).
     provider: ProviderKind,
-    /// Which profile this card edits. A built-in native-provider id or a user
-    /// profile slug. All config/secret writes
-    /// are keyed on this; catalog/status/version stay keyed on `provider`.
+    /// Which profile this row represents: a built-in native-provider id or a
+    /// user profile slug. Status/config/secret lookups key on this.
     profile_id: String,
-    expanded: bool,
     /// Whether the account email in the summary line is revealed.
     email_revealed: bool,
-    display_name: Entity<InputState>,
-    binary: Entity<InputState>,
-    home: Entity<InputState>,
-    /// Codex: shadow home path. Other native providers: launch arguments.
-    third_field: Entity<InputState>,
-    custom_model: Entity<InputState>,
-    slug_error: Option<String>,
-    env_rows: Vec<EnvRowState>,
-    _subscriptions: Vec<Subscription>,
+    _subscription: Subscription,
 }
 
 impl ProviderCard {
@@ -71,396 +46,42 @@ impl ProviderCard {
         app_state: Entity<AppState>,
         provider: ProviderKind,
         profile_id: impl Into<String>,
-        expanded: bool,
-        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let profile_id = profile_id.into();
-        let settings = app_state.read(cx).profile_settings(&profile_id);
-        let text_input =
-            |placeholder: String, value: String, window: &mut Window, cx: &mut Context<Self>| {
-                cx.new(|cx| {
-                    let mut input = InputState::new(window, cx).placeholder(placeholder);
-                    input.set_value(value, window, cx);
-                    input
-                })
-            };
-
-        let display_name = text_input(
-            crate::settings::provider_label(provider).to_string(),
-            settings.display_name.clone().unwrap_or_default(),
-            window,
-            cx,
-        );
-        let binary = text_input(
-            default_binary_name(provider).to_string(),
-            path_string(&settings.binary_path),
-            window,
-            cx,
-        );
-        let home = text_input(
-            home_placeholder(provider).to_string(),
-            path_string(&settings.home_path),
-            window,
-            cx,
-        );
-        let third_field = text_input(
-            third_placeholder(provider).to_string(),
-            match provider {
-                ProviderKind::Codex => path_string(&settings.shadow_home_path),
-                ProviderKind::ClaudeCode
-                | ProviderKind::Pi
-                | ProviderKind::OpenCode
-                | ProviderKind::Acp => settings.launch_args.clone().unwrap_or_default(),
-            },
-            window,
-            cx,
-        );
-        let custom_model = text_input(
-            custom_model_placeholder(provider).to_string(),
-            String::new(),
-            window,
-            cx,
-        );
-
-        let mut subscriptions = vec![cx.observe(&app_state, |_, _, cx| cx.notify())];
-        for input in [&display_name, &binary, &home, &third_field] {
-            subscriptions.push(cx.subscribe(input, |this, _, event, cx| match event {
-                InputEvent::Change => this.commit_fields(cx),
-                // Re-running the CLI is deferred until the field is committed,
-                // so we don't spawn a probe on every keystroke.
-                InputEvent::Blur | InputEvent::PressEnter { .. } => {
-                    this.commit_fields(cx);
-                    let provider = this.provider;
-                    this.app_state
-                        .update(cx, |state, cx| state.reload_provider(provider, cx));
-                }
-                _ => {}
-            }));
-        }
-        subscriptions.push(
-            cx.subscribe_in(&custom_model, window, |this, _, event, window, cx| {
-                if let InputEvent::PressEnter { .. } = event {
-                    this.add_custom_model(window, cx);
-                }
-            }),
-        );
-
-        let mut card = Self {
+        let subscription = cx.observe(&app_state, |_, _, cx| cx.notify());
+        Self {
             app_state,
             provider,
-            profile_id,
-            expanded,
+            profile_id: profile_id.into(),
             email_revealed: false,
-            display_name,
-            binary,
-            home,
-            third_field,
-            custom_model,
-            slug_error: None,
-            env_rows: Vec::new(),
-            _subscriptions: subscriptions,
-        };
-        card.rebuild_env_rows(&settings, window, cx);
-        card
+            _subscription: subscription,
+        }
     }
 
-    // -- persistence --------------------------------------------------------
-
-    fn settings(&self, cx: &App) -> ProviderSettings {
-        self.app_state.read(cx).profile_settings(&self.profile_id)
-    }
-
-    fn update(&self, mutate: impl FnOnce(&mut ProviderSettings), cx: &mut Context<Self>) {
-        let profile_id = self.profile_id.clone();
-        self.app_state.update(cx, |state, cx| {
-            state.update_profile_settings(&profile_id, mutate, cx);
-        });
-    }
-
-    /// Whether this card edits a user-created profile (offer Delete + a distinct
-    /// name field) rather than a built-in one.
-    fn is_user_profile(&self) -> bool {
-        !tcode_core::settings::Settings::is_builtin_profile_id(&self.profile_id)
-    }
-
-    fn reload(&self, cx: &mut Context<Self>) {
+    /// Open the per-profile settings modal (the transactional editor).
+    fn open_dialog(&self, window: &mut Window, cx: &mut Context<Self>) {
+        let app_state = self.app_state.clone();
         let provider = self.provider;
-        self.app_state
-            .update(cx, |state, cx| state.reload_provider(provider, cx));
-    }
-
-    /// Write the four text fields back into settings (called on every keystroke).
-    fn commit_fields(&self, cx: &mut Context<Self>) {
-        let name = trimmed(&self.display_name, cx);
-        let binary = trimmed(&self.binary, cx);
-        let home = trimmed(&self.home, cx);
-        let third = trimmed(&self.third_field, cx);
-        let provider = self.provider;
-        self.update(
-            move |settings| {
-                settings.display_name = name;
-                settings.binary_path = binary.map(Into::into);
-                settings.home_path = (provider != ProviderKind::OpenCode)
-                    .then(|| home.map(Into::into))
-                    .flatten();
-                match provider {
-                    ProviderKind::Codex => settings.shadow_home_path = third.map(Into::into),
-                    ProviderKind::ClaudeCode | ProviderKind::Pi | ProviderKind::OpenCode => {
-                        settings.launch_args = third;
-                    }
-                    ProviderKind::Acp => {}
-                }
-            },
-            cx,
-        );
-    }
-
-    // -- environment variables ---------------------------------------------
-
-    /// Rebuild the env-row inputs from persisted settings (on construction and
-    /// after an add/remove).
-    fn rebuild_env_rows(
-        &mut self,
-        settings: &ProviderSettings,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        self.env_rows.clear();
-        let mut subscriptions = Vec::new();
-        for var in &settings.env {
-            let name = cx.new(|cx| {
-                let mut input = InputState::new(window, cx)
-                    .placeholder(tcode_i18n::tr!("providers.env.name_placeholder"));
-                input.set_value(var.name.clone(), window, cx);
-                input
-            });
-            // A stored secret is never returned to the app: its input starts
-            // empty behind the "Stored secret" placeholder.
-            let stored = var.sensitive
-                && self
-                    .app_state
-                    .read(cx)
-                    .launch_env_for_profile(&self.profile_id)
-                    .env
-                    .iter()
-                    .any(|(key, _)| key == &var.name);
-            let value = cx.new(|cx| {
-                let placeholder = if stored {
-                    tcode_i18n::tr!("providers.env.stored_secret")
-                } else {
-                    tcode_i18n::tr!("providers.env.value_placeholder")
-                };
-                let mut input = InputState::new(window, cx)
-                    .placeholder(placeholder)
-                    .masked(var.sensitive);
-                input.set_value(
-                    if var.sensitive {
-                        String::new()
-                    } else {
-                        var.value.clone()
-                    },
-                    window,
-                    cx,
-                );
-                input
-            });
-            for input in [&name, &value] {
-                subscriptions.push(cx.subscribe(input, |this, _, event, cx| match event {
-                    InputEvent::Change => this.commit_env(cx),
-                    InputEvent::Blur | InputEvent::PressEnter { .. } => {
-                        this.commit_env(cx);
-                        this.reload(cx);
-                    }
-                    _ => {}
-                }));
-            }
-            self.env_rows.push(EnvRowState {
-                name,
-                value,
-                sensitive: var.sensitive,
-                stored,
-            });
-        }
-        self._subscriptions.extend(subscriptions);
-    }
-
-    /// Persist the env rows: plaintext values inline, sensitive values into
-    /// `secrets.json` (leaving the settings value empty).
-    fn commit_env(&mut self, cx: &mut Context<Self>) {
-        let mut vars: Vec<EnvVar> = Vec::new();
-        let mut secrets: Vec<(String, Option<String>)> = Vec::new();
-        for row in &self.env_rows {
-            let name = row.name.read(cx).value().trim().to_string();
-            let value = row.value.read(cx).value().to_string();
-            if name.is_empty() {
-                // Keep the (empty) row in the UI, but never persist a nameless
-                // variable — it cannot be passed to a child anyway.
-                vars.push(EnvVar {
-                    name,
-                    value: String::new(),
-                    sensitive: row.sensitive,
-                });
-                continue;
-            }
-            if row.sensitive {
-                // An empty input means "leave the stored secret as it is"
-                // (nothing was typed to replace it).
-                if !value.is_empty() {
-                    secrets.push((name.clone(), Some(value)));
-                }
-                vars.push(EnvVar {
-                    name,
-                    value: String::new(),
-                    sensitive: true,
-                });
-            } else {
-                vars.push(EnvVar {
-                    name,
-                    value,
-                    sensitive: false,
-                });
-            }
-        }
-        let persisted: Vec<EnvVar> = vars
-            .iter()
-            .filter(|var| !var.name.is_empty())
-            .cloned()
-            .collect();
-        self.update(move |settings| settings.env = persisted, cx);
         let profile_id = self.profile_id.clone();
-        self.app_state.update(cx, |state, cx| {
-            for (name, value) in &secrets {
-                state.set_profile_secret(&profile_id, name, value.as_deref(), cx);
-            }
+        let title = self.app_state.read(cx).profile_display_name(&profile_id);
+        let dialog = cx.new(|cx| {
+            ProviderDialog::new(app_state.clone(), provider, profile_id.clone(), window, cx)
         });
-        // The rows whose secret we just wrote now render as "stored".
-        for row in self.env_rows.iter_mut() {
-            if row.sensitive && !row.value.read(cx).value().is_empty() {
-                row.stored = true;
-            }
-        }
-    }
-
-    fn add_env_row(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let mut settings = self.settings(cx);
-        // T3: new variables default to sensitive.
-        settings.env.push(EnvVar {
-            name: String::new(),
-            value: String::new(),
-            sensitive: true,
+        window.open_dialog(cx, move |dlg, window, cx| {
+            let content = dialog.clone();
+            dlg.title(title.clone())
+                .w(px(560.))
+                // Opaque panel over the library's translucent default.
+                .bg(cx.theme().popover)
+                .shadow_xl()
+                .content(move |content_el, _window, _cx| content_el.child(content.clone()))
+                .footer(crate::provider_dialog::render_footer(&dialog, window, cx))
         });
-        let env = settings.env.clone();
-        self.update(move |s| s.env = env, cx);
-        let settings = self.settings(cx);
-        self.rebuild_env_rows(&settings, window, cx);
-        cx.notify();
-    }
-
-    fn remove_env_row(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
-        let mut settings = self.settings(cx);
-        if index >= settings.env.len() {
-            return;
-        }
-        let removed = settings.env.remove(index);
-        let env = settings.env.clone();
-        self.update(move |s| s.env = env, cx);
-        if removed.sensitive && !removed.name.is_empty() {
-            let profile_id = self.profile_id.clone();
-            self.app_state.update(cx, |state, cx| {
-                state.set_profile_secret(&profile_id, &removed.name, None, cx);
-            });
-        }
-        let settings = self.settings(cx);
-        self.rebuild_env_rows(&settings, window, cx);
-        self.reload(cx);
-        cx.notify();
-    }
-
-    fn toggle_env_sensitive(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
-        let mut settings = self.settings(cx);
-        let Some(var) = settings.env.get_mut(index) else {
-            return;
-        };
-        let name = var.name.clone();
-        let becoming_sensitive = !var.sensitive;
-        var.sensitive = becoming_sensitive;
-        // A value that was plaintext moves into secrets.json (and vice versa the
-        // value is simply dropped: we cannot read a stored secret back out).
-        let plaintext = std::mem::take(&mut var.value);
-        let env = settings.env.clone();
-        self.update(move |s| s.env = env, cx);
-        if !name.is_empty() {
-            let profile_id = self.profile_id.clone();
-            let secret = becoming_sensitive
-                .then_some(plaintext)
-                .filter(|v| !v.is_empty());
-            self.app_state.update(cx, |state, cx| {
-                state.set_profile_secret(&profile_id, &name, secret.as_deref(), cx);
-            });
-        }
-        let settings = self.settings(cx);
-        self.rebuild_env_rows(&settings, window, cx);
-        self.reload(cx);
-        cx.notify();
-    }
-
-    // -- models -------------------------------------------------------------
-
-    fn add_custom_model(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let raw = self.custom_model.read(cx).value().to_string();
-        let settings = self.settings(cx);
-        let catalog = self.app_state.read(cx).models_for(self.provider).to_vec();
-        match validate_slug(&raw, &catalog, &settings) {
-            Ok(slug) => {
-                self.slug_error = None;
-                self.update(move |s| s.custom_models.push(slug), cx);
-                self.custom_model
-                    .update(cx, |state, cx| state.set_value("", window, cx));
-            }
-            Err(err) => self.slug_error = Some(slug_error_message(&err)),
-        }
-        cx.notify();
-    }
-
-    fn move_model(&self, rows: &[ResolvedModel], index: usize, up: bool, cx: &mut Context<Self>) {
-        let Some(target) = move_target(rows, index, up) else {
-            return;
-        };
-        let order = reorder(rows, index, target);
-        self.update(move |s| s.model_order = order, cx);
-    }
-
-    fn toggle_hidden(&self, id: &str, cx: &mut Context<Self>) {
-        let id = id.to_string();
-        self.update(
-            move |settings| {
-                if let Some(pos) = settings.hidden_models.iter().position(|m| m == &id) {
-                    settings.hidden_models.remove(pos);
-                } else {
-                    settings.hidden_models.push(id);
-                }
-            },
-            cx,
-        );
-    }
-
-    fn remove_custom_model(&self, id: &str, cx: &mut Context<Self>) {
-        let id = id.to_string();
-        self.update(
-            move |settings| {
-                settings.custom_models.retain(|m| m != &id);
-                settings.hidden_models.retain(|m| m != &id);
-                settings.model_order.retain(|m| m != &id);
-            },
-            cx,
-        );
     }
 
     // -- rendering ----------------------------------------------------------
 
-    /// The collapsed header: glyph + dot, name, version, update icon, summary,
-    /// chevron, enable switch.
+    /// The row: glyph + dot, name, version, update icon, summary, gear, switch.
     fn render_header(&self, cx: &mut Context<Self>) -> AnyElement {
         let state = self.app_state.read(cx);
         let provider = self.provider;
@@ -514,7 +135,7 @@ impl ProviderCard {
                     .bg(dot_color),
             );
 
-        let mut title = h_flex()
+        let title = h_flex()
             .gap_2()
             .items_center()
             .child(div().text_size(px(15.)).font_semibold().child(name.clone()))
@@ -527,17 +148,19 @@ impl ProviderCard {
                         .child(format!("v{}", version.trim_start_matches('v'))),
                 )
             });
-        if update_available {
-            title = title.child(self.render_update_popover(cx));
-        }
 
-        h_flex()
-            .w_full()
-            .min_h(px(44.))
-            .px_3()
-            .py_3()
+        // The row body (glyph + text) is the primary "configure" affordance;
+        // the update popover, gear and switch trail it as their own controls.
+        let body = h_flex()
+            .id(gpui::SharedString::from(format!(
+                "configure-{}",
+                self.profile_id
+            )))
+            .flex_1()
+            .min_w_0()
             .gap_3()
             .items_center()
+            .cursor_pointer()
             .child(div().flex_none().child(glyph))
             .child(
                 v_flex()
@@ -547,19 +170,34 @@ impl ProviderCard {
                     .child(title)
                     .child(self.render_summary_line(&summary, cx)),
             )
+            .tooltip({
+                let name = name.clone();
+                move |window, cx| {
+                    let label =
+                        tcode_i18n::tr!("providers.configure", name = name.clone()).into_owned();
+                    gpui_component::tooltip::Tooltip::new(label).build(window, cx)
+                }
+            })
+            .on_click(cx.listener(|this, _, window, cx| this.open_dialog(window, cx)));
+
+        h_flex()
+            .w_full()
+            .min_h(px(44.))
+            .px_3()
+            .py_3()
+            .gap_3()
+            .items_center()
+            .child(body)
+            .when(update_available, |this| {
+                this.child(self.render_update_popover(cx))
+            })
             .child(
-                Button::new("toggle-details")
+                Button::new("configure-profile")
                     .ghost()
                     .xsmall()
-                    .icon(IconName::ChevronDown)
-                    .tooltip(tcode_i18n::tr!(
-                        "providers.toggle_details",
-                        name = name.clone()
-                    ))
-                    .on_click(cx.listener(|this, _, _, cx| {
-                        this.expanded = !this.expanded;
-                        cx.notify();
-                    })),
+                    .icon(IconName::Settings)
+                    .tooltip(tcode_i18n::tr!("providers.configure", name = name.clone()))
+                    .on_click(cx.listener(|this, _, window, cx| this.open_dialog(window, cx))),
             )
             .child(
                 Switch::new("enable-provider")
@@ -567,8 +205,15 @@ impl ProviderCard {
                     .tooltip(tcode_i18n::tr!("providers.enable", name = name))
                     .on_click(cx.listener(move |this, checked: &bool, _, cx| {
                         let checked = *checked;
-                        this.update(move |settings| settings.enabled = checked, cx);
-                        this.reload(cx);
+                        this.app_state.update(cx, |state, cx| {
+                            let profile_id = this.profile_id.clone();
+                            state.update_profile_settings(
+                                &profile_id,
+                                move |settings| settings.enabled = checked,
+                                cx,
+                            );
+                            state.reload_provider(this.provider, cx);
+                        });
                     })),
             )
             .into_any_element()
@@ -660,7 +305,7 @@ impl ProviderCard {
         h_flex().w_full().min_w_0().child(line).into_any_element()
     }
 
-    /// The update-available icon + its popover (T3 §3).
+    /// The update-available icon + its popover.
     fn render_update_popover(&self, cx: &mut Context<Self>) -> AnyElement {
         let state = self.app_state.read(cx);
         let provider = self.provider;
@@ -771,485 +416,18 @@ impl ProviderCard {
             })
             .into_any_element()
     }
-
-    /// A labelled expanded-card block: label, control, muted help text.
-    fn field_block(
-        &self,
-        label: SharedString,
-        help: SharedString,
-        control: AnyElement,
-        cx: &Context<Self>,
-    ) -> AnyElement {
-        v_flex()
-            .w_full()
-            .px_4()
-            .py_3()
-            .gap_1p5()
-            .child(div().text_size(px(13.)).font_medium().child(label))
-            .child(control)
-            .child(
-                div()
-                    .text_size(px(13.))
-                    .text_color(cx.theme().muted_foreground)
-                    .child(help),
-            )
-            .into_any_element()
-    }
-
-    fn render_accent(&self, cx: &mut Context<Self>) -> AnyElement {
-        let current = self.settings(cx).accent_color;
-        let mut swatches = h_flex().gap_2().items_center();
-        for (index, preset) in ACCENT_PRESETS.iter().enumerate() {
-            let hex = (*preset).to_string();
-            let selected = current.as_deref() == Some(*preset);
-            let value = u32::from_str_radix(preset.trim_start_matches('#'), 16).unwrap_or(0);
-            swatches = swatches.child(
-                div()
-                    .id(("accent", index))
-                    .size(px(22.))
-                    .rounded_full()
-                    .cursor_pointer()
-                    .bg(rgb(value))
-                    .when(selected, |s| {
-                        s.border_2().border_color(cx.theme().foreground)
-                    })
-                    .tooltip({
-                        let hex = hex.clone();
-                        move |window, cx| {
-                            let label =
-                                tcode_i18n::tr!("providers.accent_select", color = hex.clone())
-                                    .into_owned();
-                            gpui_component::tooltip::Tooltip::new(label).build(window, cx)
-                        }
-                    })
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        let hex = hex.clone();
-                        this.update(move |settings| settings.accent_color = Some(hex), cx);
-                    })),
-            );
-        }
-        swatches = swatches.child(
-            Button::new("accent-clear")
-                .ghost()
-                .xsmall()
-                .icon(IconName::CircleX)
-                .tooltip(tcode_i18n::tr!("providers.accent_clear"))
-                .on_click(cx.listener(|this, _, _, cx| {
-                    this.update(|settings| settings.accent_color = None, cx);
-                })),
-        );
-        swatches.into_any_element()
-    }
-
-    fn render_env(&self, cx: &mut Context<Self>) -> AnyElement {
-        let muted = cx.theme().muted_foreground;
-        let mut block = v_flex().w_full().px_4().py_3().gap_2().child(
-            h_flex()
-                .w_full()
-                .items_center()
-                .justify_between()
-                .child(
-                    div()
-                        .text_size(px(13.))
-                        .font_medium()
-                        .child(tcode_i18n::tr!("providers.env.title")),
-                )
-                .child(
-                    Button::new("env-add")
-                        .outline()
-                        .xsmall()
-                        .icon(IconName::Plus)
-                        .label(tcode_i18n::tr!("providers.env.add"))
-                        .on_click(cx.listener(|this, _, window, cx| {
-                            this.add_env_row(window, cx);
-                        })),
-                ),
-        );
-
-        if self.env_rows.is_empty() {
-            block = block.child(
-                div()
-                    .text_size(px(13.))
-                    .text_color(muted)
-                    .child(tcode_i18n::tr!("providers.env.empty_help")),
-            );
-        } else {
-            for (index, row) in self.env_rows.iter().enumerate() {
-                block =
-                    block.child(
-                        h_flex()
-                            .w_full()
-                            .gap_2()
-                            .items_center()
-                            .child(div().flex_1().min_w_0().child(
-                                Input::new(&row.name).rounded(crate::material::radius_input()),
-                            ))
-                            .child(div().flex_1().min_w_0().child(
-                                Input::new(&row.value).rounded(crate::material::radius_input()),
-                            ))
-                            .child(
-                                Switch::new(("env-sensitive", index))
-                                    .checked(row.sensitive)
-                                    .tooltip(tcode_i18n::tr!("providers.env.sensitive"))
-                                    .on_click(cx.listener(move |this, _: &bool, window, cx| {
-                                        this.toggle_env_sensitive(index, window, cx);
-                                    })),
-                            )
-                            .child(
-                                Button::new(("env-remove", index))
-                                    .ghost()
-                                    .xsmall()
-                                    .icon(IconName::Delete)
-                                    .tooltip(tcode_i18n::tr!("providers.env.remove"))
-                                    .on_click(cx.listener(move |this, _, window, cx| {
-                                        this.remove_env_row(index, window, cx);
-                                    })),
-                            ),
-                    );
-            }
-        }
-        block
-            .child(
-                div()
-                    .text_size(px(13.))
-                    .text_color(muted)
-                    .child(tcode_i18n::tr!("providers.env.security_help")),
-            )
-            .into_any_element()
-    }
-
-    fn render_models(&self, cx: &mut Context<Self>) -> AnyElement {
-        let state = self.app_state.read(cx);
-        let rows = state.resolved_models_for_profile(&self.profile_id);
-        let muted = cx.theme().muted_foreground;
-
-        let mut block =
-            v_flex()
-                .w_full()
-                .px_4()
-                .py_3()
-                .gap_1()
-                .child(
-                    div()
-                        .text_size(px(13.))
-                        .font_medium()
-                        .child(tcode_i18n::tr!("providers.models.title")),
-                )
-                .child(div().pb_1().text_size(px(13.)).text_color(muted).child(
-                    if rows.len() == 1 {
-                        tcode_i18n::tr!("providers.models.count_one", count = 1).into_owned()
-                    } else {
-                        tcode_i18n::tr!("providers.models.count", count = rows.len()).into_owned()
-                    },
-                ));
-
-        for (index, row) in rows.iter().enumerate() {
-            block = block.child(self.render_model_row(&rows, index, row, cx));
-        }
-
-        // Custom-model input + validation copy.
-        block = block.child(
-            h_flex()
-                .w_full()
-                .pt_2()
-                .gap_2()
-                .items_center()
-                .child(
-                    div().flex_1().min_w_0().child(
-                        Input::new(&self.custom_model).rounded(crate::material::radius_input()),
-                    ),
-                )
-                .child(
-                    Button::new("add-custom-model")
-                        .outline()
-                        .small()
-                        .icon(IconName::Plus)
-                        .label(tcode_i18n::tr!("providers.models.add"))
-                        .on_click(
-                            cx.listener(|this, _, window, cx| this.add_custom_model(window, cx)),
-                        ),
-                ),
-        );
-        if let Some(error) = &self.slug_error {
-            block = block.child(
-                div()
-                    .text_size(px(13.))
-                    .text_color(cx.theme().danger_foreground)
-                    .child(error.clone()),
-            );
-        }
-        block.into_any_element()
-    }
-
-    fn render_model_row(
-        &self,
-        rows: &[ResolvedModel],
-        index: usize,
-        row: &ResolvedModel,
-        cx: &mut Context<Self>,
-    ) -> AnyElement {
-        let muted = cx.theme().muted_foreground;
-        let name = row.name.clone();
-        let hidden = row.hidden;
-        let capabilities = row
-            .capabilities
-            .iter()
-            .copied()
-            .map(model_capability_label)
-            .collect::<Vec<_>>()
-            .join(" · ");
-        let rows_up = rows.to_vec();
-        let rows_down = rows.to_vec();
-        let can_up = move_target(rows, index, true).is_some();
-        let can_down = move_target(rows, index, false).is_some();
-
-        let mut tags = h_flex().gap_1().items_center();
-        if row.custom {
-            tags = tags.child(tag(
-                tcode_i18n::tr!("providers.models.custom").into_owned(),
-                cx.theme().info.opacity(0.12),
-                cx.theme().info_foreground,
-            ));
-        }
-        if hidden {
-            tags = tags.child(tag(
-                tcode_i18n::tr!("providers.models.hidden").into_owned(),
-                cx.theme().warning.opacity(0.12),
-                cx.theme().warning_foreground,
-            ));
-        }
-
-        let fav_id = row.id.clone();
-        let is_fav = row.favorite;
-        let app_state = self.app_state.clone();
-        let hide_id = row.id.clone();
-        let remove_id = row.id.clone();
-        let custom = row.custom;
-
-        h_flex()
-            .w_full()
-            .py_1()
-            .gap_2()
-            .items_center()
-            .child(
-                h_flex()
-                    .flex_1()
-                    .min_w_0()
-                    .gap_1p5()
-                    .items_center()
-                    .child(
-                        div()
-                            .text_size(px(13.))
-                            .when(hidden, |d| d.text_color(muted))
-                            .child(name.clone()),
-                    )
-                    .when(!capabilities.is_empty(), |this| {
-                        this.child(
-                            div()
-                                .id(("model-info", index))
-                                .flex_none()
-                                .child(Icon::new(IconName::Info).xsmall().text_color(muted))
-                                .tooltip(move |window, cx| {
-                                    gpui_component::tooltip::Tooltip::new(capabilities.clone())
-                                        .build(window, cx)
-                                }),
-                        )
-                    })
-                    .child(tags),
-            )
-            .child(
-                Button::new(("model-fav", index))
-                    .ghost()
-                    .xsmall()
-                    .icon(if is_fav {
-                        IconName::StarFill
-                    } else {
-                        IconName::Star
-                    })
-                    .tooltip(if is_fav {
-                        tcode_i18n::tr!("providers.models.unfavorite")
-                    } else {
-                        tcode_i18n::tr!("providers.models.favorite")
-                    })
-                    .on_click(move |_, _, cx| {
-                        app_state.update(cx, |state, cx| state.toggle_favorite_model(&fav_id, cx));
-                    }),
-            )
-            .child(
-                Button::new(("model-up", index))
-                    .ghost()
-                    .xsmall()
-                    .icon(IconName::ArrowUp)
-                    .disabled(!can_up)
-                    .tooltip(tcode_i18n::tr!("providers.models.move_up"))
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        this.move_model(&rows_up, index, true, cx);
-                    })),
-            )
-            .child(
-                Button::new(("model-down", index))
-                    .ghost()
-                    .xsmall()
-                    .icon(IconName::ArrowDown)
-                    .disabled(!can_down)
-                    .tooltip(tcode_i18n::tr!("providers.models.move_down"))
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        this.move_model(&rows_down, index, false, cx);
-                    })),
-            )
-            .child(
-                Button::new(("model-hide", index))
-                    .ghost()
-                    .xsmall()
-                    .icon(if hidden {
-                        IconName::Eye
-                    } else {
-                        IconName::EyeOff
-                    })
-                    .tooltip(if hidden {
-                        tcode_i18n::tr!("providers.models.show")
-                    } else {
-                        tcode_i18n::tr!("providers.models.hide")
-                    })
-                    .on_click(cx.listener(move |this, _, _, cx| this.toggle_hidden(&hide_id, cx))),
-            )
-            .when(custom, |this| {
-                this.child(
-                    Button::new(("model-remove", index))
-                        .ghost()
-                        .xsmall()
-                        .icon(IconName::Delete)
-                        .tooltip(tcode_i18n::tr!("providers.models.remove"))
-                        .on_click(cx.listener(move |this, _, _, cx| {
-                            this.remove_custom_model(&remove_id, cx);
-                        })),
-                )
-            })
-            .into_any_element()
-    }
-
-    fn render_details(&self, cx: &mut Context<Self>) -> AnyElement {
-        let provider = self.provider;
-        v_flex()
-            .w_full()
-            .child(
-                self.field_block(
-                    tcode_i18n::tr!("providers.display_name")
-                        .into_owned()
-                        .into(),
-                    tcode_i18n::tr!("providers.display_name_help")
-                        .into_owned()
-                        .into(),
-                    Input::new(&self.display_name)
-                        .rounded(crate::material::radius_input())
-                        .into_any_element(),
-                    cx,
-                ),
-            )
-            .child(self.field_block(
-                tcode_i18n::tr!("providers.accent").into_owned().into(),
-                tcode_i18n::tr!("providers.accent_help").into_owned().into(),
-                self.render_accent(cx),
-                cx,
-            ))
-            .child(self.render_env(cx))
-            .child(
-                self.field_block(
-                    tcode_i18n::tr!("providers.binary_path").into_owned().into(),
-                    tcode_i18n::tr!(
-                        "providers.binary_path_help",
-                        name = crate::settings::provider_label(provider)
-                    )
-                    .into_owned()
-                    .into(),
-                    Input::new(&self.binary)
-                        .rounded(crate::material::radius_input())
-                        .into_any_element(),
-                    cx,
-                ),
-            )
-            .when(provider != ProviderKind::OpenCode, |this| {
-                this.child(
-                    self.field_block(
-                        home_label(provider).into(),
-                        home_help(provider).into(),
-                        Input::new(&self.home)
-                            .rounded(crate::material::radius_input())
-                            .into_any_element(),
-                        cx,
-                    ),
-                )
-            })
-            .child(
-                self.field_block(
-                    third_label(provider).into(),
-                    third_help(provider).into(),
-                    Input::new(&self.third_field)
-                        .rounded(crate::material::radius_input())
-                        .into_any_element(),
-                    cx,
-                ),
-            )
-            .child(self.render_models(cx))
-            .when(self.is_user_profile(), |this| {
-                this.child(self.render_delete(cx))
-            })
-            .into_any_element()
-    }
-
-    /// A destructive "Delete profile" action, only rendered for user-created
-    /// profiles (built-in provider cards can't be deleted).
-    fn render_delete(&self, cx: &mut Context<Self>) -> AnyElement {
-        let profile_id = self.profile_id.clone();
-        v_flex()
-            .w_full()
-            .px_4()
-            .py_3()
-            .child(
-                Button::new("delete-profile")
-                    .danger()
-                    .small()
-                    .icon(IconName::Delete)
-                    .label(tcode_i18n::tr!("providers.delete_profile").into_owned())
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        let profile_id = profile_id.clone();
-                        this.app_state
-                            .update(cx, |state, cx| state.delete_profile(&profile_id, cx));
-                    })),
-            )
-            .into_any_element()
-    }
 }
 
 impl Render for ProviderCard {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        // A row inside the providers group — the group owns the fill and border;
-        // the expanded editor nests under the row, set off by an inset hairline.
-        v_flex()
-            .w_full()
-            .child(self.render_header(cx))
-            .when(self.expanded, |this| {
-                this.child(
-                    v_flex()
-                        .w_full()
-                        .child(
-                            div()
-                                .pl_4()
-                                .child(div().w_full().h(px(1.)).bg(cx.theme().border)),
-                        )
-                        .child(self.render_details(cx)),
-                )
-            })
+        // A row inside the providers group — the group owns the fill and border.
+        v_flex().w_full().child(self.render_header(cx))
     }
 }
 
 // ---------------------------------------------------------------------------
-// Copy + helpers
+// Shared glyph
 // ---------------------------------------------------------------------------
-
-fn tag(label: String, background: gpui::Hsla, foreground: gpui::Hsla) -> AnyElement {
-    crate::material::semantic_chip(label, background, foreground).into_any_element()
-}
 
 /// The provider's glyph (the same asset the composer's picker rail uses).
 pub fn provider_glyph(provider: ProviderKind) -> Icon {
@@ -1262,101 +440,4 @@ pub fn provider_glyph(provider: ProviderKind) -> Icon {
         ProviderKind::OpenCode => Icon::empty().path("icons/opencode.svg"),
         ProviderKind::Acp => Icon::empty(),
     }
-}
-
-fn default_binary_name(provider: ProviderKind) -> &'static str {
-    match provider {
-        ProviderKind::Codex => "codex",
-        ProviderKind::ClaudeCode => "claude",
-        ProviderKind::Pi => "pi",
-        ProviderKind::OpenCode => "opencode",
-        // ACP agents are not configured through this card (they have their own
-        // marketplace cards); these arms only keep the matches total.
-        ProviderKind::Acp => "",
-    }
-}
-
-fn home_placeholder(provider: ProviderKind) -> &'static str {
-    match provider {
-        ProviderKind::Codex => "~/.codex",
-        ProviderKind::ClaudeCode => "~",
-        ProviderKind::Pi => "~/.pi/agent",
-        ProviderKind::OpenCode => "",
-        ProviderKind::Acp => "",
-    }
-}
-
-fn home_label(provider: ProviderKind) -> String {
-    match provider {
-        ProviderKind::Codex => tcode_i18n::tr!("providers.codex_home").into_owned(),
-        ProviderKind::ClaudeCode => tcode_i18n::tr!("providers.claude_home").into_owned(),
-        ProviderKind::Pi => tcode_i18n::tr!("providers.pi_home").into_owned(),
-        ProviderKind::OpenCode | ProviderKind::Acp => {
-            tcode_i18n::tr!("providers.home").into_owned()
-        }
-    }
-}
-
-fn home_help(provider: ProviderKind) -> String {
-    match provider {
-        ProviderKind::Codex => tcode_i18n::tr!("providers.codex_home_help").into_owned(),
-        ProviderKind::ClaudeCode => tcode_i18n::tr!("providers.claude_home_help").into_owned(),
-        ProviderKind::Pi => tcode_i18n::tr!("providers.pi_home_help").into_owned(),
-        ProviderKind::OpenCode | ProviderKind::Acp => {
-            tcode_i18n::tr!("providers.home_help").into_owned()
-        }
-    }
-}
-
-fn third_placeholder(provider: ProviderKind) -> &'static str {
-    match provider {
-        ProviderKind::Codex => "~/.codex-t3/personal",
-        ProviderKind::ClaudeCode => "e.g. --chrome",
-        ProviderKind::Pi => "e.g. --provider openai-codex",
-        ProviderKind::OpenCode => "e.g. --print-logs",
-        ProviderKind::Acp => "",
-    }
-}
-
-fn third_label(provider: ProviderKind) -> String {
-    match provider {
-        ProviderKind::Codex => tcode_i18n::tr!("providers.shadow_home").into_owned(),
-        ProviderKind::ClaudeCode
-        | ProviderKind::Pi
-        | ProviderKind::OpenCode
-        | ProviderKind::Acp => tcode_i18n::tr!("providers.launch_args").into_owned(),
-    }
-}
-
-fn third_help(provider: ProviderKind) -> String {
-    match provider {
-        ProviderKind::Codex => tcode_i18n::tr!("providers.shadow_home_help").into_owned(),
-        ProviderKind::ClaudeCode
-        | ProviderKind::Pi
-        | ProviderKind::OpenCode
-        | ProviderKind::Acp => tcode_i18n::tr!("providers.launch_args_help").into_owned(),
-    }
-}
-
-fn custom_model_placeholder(provider: ProviderKind) -> &'static str {
-    match provider {
-        ProviderKind::Codex => "gpt-6.7-codex-ultra-preview",
-        ProviderKind::ClaudeCode => "claude-sonnet-5",
-        ProviderKind::Pi => "openai-codex/gpt-5.5",
-        ProviderKind::OpenCode => "openai/gpt-5.1-codex",
-        ProviderKind::Acp => "",
-    }
-}
-
-fn path_string(path: &Option<std::path::PathBuf>) -> String {
-    path.as_ref()
-        .map(|p| p.display().to_string())
-        .unwrap_or_default()
-}
-
-/// An input's trimmed value, or `None` when it is empty (T3: an empty field
-/// removes the override).
-fn trimmed(input: &Entity<InputState>, cx: &App) -> Option<String> {
-    let value = input.read(cx).value().trim().to_string();
-    (!value.is_empty()).then_some(value)
 }

--- a/crates/ui/src/provider_dialog.rs
+++ b/crates/ui/src/provider_dialog.rs
@@ -1,0 +1,1007 @@
+//! The per-profile provider settings dialog (Settings → Providers → gear).
+//!
+//! A transactional editor: it seeds a draft from the profile's current
+//! [`ProviderSettings`] plus its effective launch env (for secret placeholders),
+//! edits that draft in isolation, and persists only on Save. Cancel discards
+//! everything, including pending secrets. Favorite toggling is the one live
+//! exception — favorites are a global, not a `ProviderSettings` field.
+
+use std::collections::HashSet;
+
+use gpui::{
+    AnyElement, App, AppContext as _, Context, Entity, InteractiveElement as _, IntoElement,
+    ParentElement as _, Render, SharedString, StatefulInteractiveElement as _, Styled as _,
+    Subscription, Window, div, prelude::FluentBuilder as _, px, rgb,
+};
+use gpui_component::{
+    ActiveTheme as _, Icon, IconName, Sizable as _, StyledExt as _, WindowExt as _,
+    button::{Button, ButtonVariant, ButtonVariants as _},
+    dialog::DialogButtonProps,
+    h_flex,
+    input::{Input, InputEvent, InputState},
+    switch::Switch,
+    v_flex,
+};
+
+use agent::ProviderKind;
+use tcode_runtime::app::AppState;
+
+use crate::provider_models::{
+    ResolvedModel, model_capability_label, slug_error_message, validate_slug,
+};
+use crate::settings::{ACCENT_PRESETS, EnvVar, provider_label};
+
+/// One environment-variable row's live inputs and its draft flags.
+struct EnvRow {
+    name: Entity<InputState>,
+    value: Entity<InputState>,
+    sensitive: bool,
+    /// A sensitive row whose value is already stored in `secrets.json`. Its
+    /// value input starts empty behind the "Stored secret" placeholder.
+    stored: bool,
+}
+
+/// A serializable snapshot of an env row, used to rebuild the inputs after an
+/// add / remove / sensitivity toggle without losing the other rows' edits.
+struct EnvSeed {
+    name: String,
+    value: String,
+    sensitive: bool,
+    stored: bool,
+}
+
+pub struct ProviderDialog {
+    app_state: Entity<AppState>,
+    provider: ProviderKind,
+    profile_id: String,
+    display_name: Entity<InputState>,
+    binary: Entity<InputState>,
+    home: Entity<InputState>,
+    launch_args: Entity<InputState>,
+    custom_model: Entity<InputState>,
+    slug_error: Option<String>,
+    /// Draft accent (`#rrggbb`); applied on Save.
+    accent: Option<String>,
+    env_rows: Vec<EnvRow>,
+    /// Names that held a persisted secret when the dialog opened. On Save, any
+    /// that is no longer a sensitive row is cleared from `secrets.json`.
+    original_secret_names: Vec<String>,
+    custom_models: Vec<String>,
+    hidden_models: Vec<String>,
+    _subscriptions: Vec<Subscription>,
+}
+
+impl ProviderDialog {
+    pub fn new(
+        app_state: Entity<AppState>,
+        provider: ProviderKind,
+        profile_id: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let settings = app_state.read(cx).profile_settings(&profile_id);
+        // Which of this profile's names resolve to a value at launch: a sensitive
+        // row present here has its secret saved (see `launch_env_for_profile`).
+        let stored: HashSet<String> = app_state
+            .read(cx)
+            .launch_env_for_profile(&profile_id)
+            .env
+            .iter()
+            .map(|(name, _)| name.clone())
+            .collect();
+
+        let text_input =
+            |placeholder: String, value: String, window: &mut Window, cx: &mut Context<Self>| {
+                cx.new(|cx| {
+                    let mut input = InputState::new(window, cx).placeholder(placeholder);
+                    input.set_value(value, window, cx);
+                    input
+                })
+            };
+
+        let display_name = text_input(
+            provider_label(provider).to_string(),
+            settings.display_name.clone().unwrap_or_default(),
+            window,
+            cx,
+        );
+        let binary = text_input(
+            default_binary_name(provider).to_string(),
+            path_string(&settings.binary_path),
+            window,
+            cx,
+        );
+        let home = text_input(
+            home_placeholder(provider).to_string(),
+            path_string(&settings.home_path),
+            window,
+            cx,
+        );
+        let launch_args = text_input(
+            launch_args_placeholder(provider).to_string(),
+            settings.launch_args.clone().unwrap_or_default(),
+            window,
+            cx,
+        );
+        let custom_model = text_input(
+            custom_model_placeholder(provider).to_string(),
+            String::new(),
+            window,
+            cx,
+        );
+
+        let mut subscriptions = vec![cx.observe(&app_state, |_, _, cx| cx.notify())];
+        subscriptions.push(
+            cx.subscribe_in(&custom_model, window, |this, _, event, window, cx| {
+                if let InputEvent::PressEnter { .. } = event {
+                    this.add_custom_model(window, cx);
+                }
+            }),
+        );
+
+        let original_secret_names: Vec<String> = settings
+            .env
+            .iter()
+            .filter(|var| var.sensitive && stored.contains(&var.name))
+            .map(|var| var.name.clone())
+            .collect();
+
+        let seeds: Vec<EnvSeed> = settings
+            .env
+            .iter()
+            .map(|var| EnvSeed {
+                name: var.name.clone(),
+                value: if var.sensitive {
+                    String::new()
+                } else {
+                    var.value.clone()
+                },
+                sensitive: var.sensitive,
+                stored: var.sensitive && stored.contains(&var.name),
+            })
+            .collect();
+
+        let mut dialog = Self {
+            app_state,
+            provider,
+            profile_id,
+            display_name,
+            binary,
+            home,
+            launch_args,
+            custom_model,
+            slug_error: None,
+            accent: settings.accent_color.clone(),
+            env_rows: Vec::new(),
+            original_secret_names,
+            custom_models: settings.custom_models.clone(),
+            hidden_models: settings.hidden_models.clone(),
+            _subscriptions: subscriptions,
+        };
+        dialog.rebuild_env_rows(&seeds, window, cx);
+        dialog
+    }
+
+    /// Whether this dialog edits a user-created profile (offer Delete) rather
+    /// than a built-in one.
+    fn is_user_profile(&self) -> bool {
+        !tcode_core::settings::Settings::is_builtin_profile_id(&self.profile_id)
+    }
+
+    // -- persistence (Save) -------------------------------------------------
+
+    /// Persist the whole draft: card settings, then secret writes/clears, then a
+    /// single provider reload. `enabled` is owned by the row switch and left as
+    /// it is. Called only from Save.
+    fn apply(&mut self, cx: &mut Context<Self>) {
+        let seeds = self.snapshot_env(cx);
+        let mut env: Vec<EnvVar> = Vec::new();
+        let mut secret_writes: Vec<(String, String)> = Vec::new();
+        let mut final_sensitive: HashSet<String> = HashSet::new();
+        for seed in &seeds {
+            let name = seed.name.trim().to_string();
+            if name.is_empty() {
+                // A nameless variable can't be passed to a child; drop it.
+                continue;
+            }
+            if seed.sensitive {
+                // An empty input means "keep the stored secret as it is".
+                if !seed.value.is_empty() {
+                    secret_writes.push((name.clone(), seed.value.clone()));
+                }
+                env.push(EnvVar {
+                    name: name.clone(),
+                    value: String::new(),
+                    sensitive: true,
+                });
+                final_sensitive.insert(name);
+            } else {
+                env.push(EnvVar {
+                    name,
+                    value: seed.value.clone(),
+                    sensitive: false,
+                });
+            }
+        }
+        // Secrets whose row was removed, renamed, or turned plaintext are cleared.
+        let clears: Vec<String> = self
+            .original_secret_names
+            .iter()
+            .filter(|name| !final_sensitive.contains(*name))
+            .cloned()
+            .collect();
+
+        let display_name = trimmed(&self.display_name, cx);
+        let binary = trimmed(&self.binary, cx);
+        let home = trimmed(&self.home, cx);
+        let launch = trimmed(&self.launch_args, cx);
+        let accent = self.accent.clone();
+        let custom = self.custom_models.clone();
+        let hidden = self.hidden_models.clone();
+        let provider = self.provider;
+        let profile_id = self.profile_id.clone();
+
+        self.app_state.update(cx, |state, cx| {
+            state.update_profile_settings(
+                &profile_id,
+                move |settings| {
+                    settings.display_name = display_name;
+                    settings.accent_color = accent;
+                    settings.env = env;
+                    settings.binary_path = binary.map(Into::into);
+                    // OpenCode has no single-home override.
+                    settings.home_path = (provider != ProviderKind::OpenCode)
+                        .then(|| home.map(Into::into))
+                        .flatten();
+                    // Codex ignores launch arguments (no field is rendered).
+                    settings.launch_args = match provider {
+                        ProviderKind::Codex => None,
+                        _ => launch,
+                    };
+                    settings.custom_models = custom;
+                    settings.hidden_models = hidden;
+                },
+                cx,
+            );
+            for (name, value) in &secret_writes {
+                state.set_profile_secret(&profile_id, name, Some(value), cx);
+            }
+            for name in &clears {
+                state.set_profile_secret(&profile_id, name, None, cx);
+            }
+            state.reload_provider(provider, cx);
+        });
+    }
+
+    // -- environment variables ---------------------------------------------
+
+    /// Read the live env inputs back into seeds (preserves other rows' edits
+    /// across a rebuild).
+    fn snapshot_env(&self, cx: &App) -> Vec<EnvSeed> {
+        self.env_rows
+            .iter()
+            .map(|row| EnvSeed {
+                name: row.name.read(cx).value().to_string(),
+                value: row.value.read(cx).value().to_string(),
+                sensitive: row.sensitive,
+                stored: row.stored,
+            })
+            .collect()
+    }
+
+    fn rebuild_env_rows(&mut self, seeds: &[EnvSeed], window: &mut Window, cx: &mut Context<Self>) {
+        self.env_rows.clear();
+        for seed in seeds {
+            let name = cx.new(|cx| {
+                let mut input = InputState::new(window, cx)
+                    .placeholder(tcode_i18n::tr!("providers.env.name_placeholder"));
+                input.set_value(seed.name.clone(), window, cx);
+                input
+            });
+            let show_stored = seed.sensitive && seed.stored && seed.value.is_empty();
+            let value = cx.new(|cx| {
+                let placeholder = if show_stored {
+                    tcode_i18n::tr!("providers.env.stored_secret")
+                } else {
+                    tcode_i18n::tr!("providers.env.value_placeholder")
+                };
+                let mut input = InputState::new(window, cx)
+                    .placeholder(placeholder)
+                    .masked(seed.sensitive);
+                input.set_value(seed.value.clone(), window, cx);
+                input
+            });
+            self.env_rows.push(EnvRow {
+                name,
+                value,
+                sensitive: seed.sensitive,
+                stored: seed.stored,
+            });
+        }
+    }
+
+    fn add_env_row(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let mut seeds = self.snapshot_env(cx);
+        // New variables default to sensitive.
+        seeds.push(EnvSeed {
+            name: String::new(),
+            value: String::new(),
+            sensitive: true,
+            stored: false,
+        });
+        self.rebuild_env_rows(&seeds, window, cx);
+        cx.notify();
+    }
+
+    fn remove_env_row(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
+        let mut seeds = self.snapshot_env(cx);
+        if index >= seeds.len() {
+            return;
+        }
+        seeds.remove(index);
+        self.rebuild_env_rows(&seeds, window, cx);
+        cx.notify();
+    }
+
+    fn toggle_env_sensitive(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
+        let mut seeds = self.snapshot_env(cx);
+        let Some(seed) = seeds.get_mut(index) else {
+            return;
+        };
+        seed.sensitive = !seed.sensitive;
+        // Its state changed, so it is no longer the untouched stored secret; the
+        // masked value (plaintext ↔ secret) rides along in the draft until Save.
+        seed.stored = false;
+        self.rebuild_env_rows(&seeds, window, cx);
+        cx.notify();
+    }
+
+    // -- models -------------------------------------------------------------
+
+    fn add_custom_model(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let raw = self.custom_model.read(cx).value().to_string();
+        let catalog = self.app_state.read(cx).profile_catalog(&self.profile_id);
+        let mut draft = self.app_state.read(cx).profile_settings(&self.profile_id);
+        draft.custom_models = self.custom_models.clone();
+        match validate_slug(&raw, &catalog, &draft) {
+            Ok(slug) => {
+                self.slug_error = None;
+                self.custom_models.push(slug);
+                self.custom_model
+                    .update(cx, |state, cx| state.set_value("", window, cx));
+            }
+            Err(err) => self.slug_error = Some(slug_error_message(&err)),
+        }
+        cx.notify();
+    }
+
+    fn toggle_hidden(&mut self, id: &str, cx: &mut Context<Self>) {
+        if let Some(pos) = self.hidden_models.iter().position(|m| m == id) {
+            self.hidden_models.remove(pos);
+        } else {
+            self.hidden_models.push(id.to_string());
+        }
+        cx.notify();
+    }
+
+    fn remove_custom_model(&mut self, id: &str, cx: &mut Context<Self>) {
+        self.custom_models.retain(|m| m != id);
+        self.hidden_models.retain(|m| m != id);
+        cx.notify();
+    }
+
+    // -- rendering ----------------------------------------------------------
+
+    /// A labelled section: an 11px caption over its field blocks.
+    fn section(
+        &self,
+        label: SharedString,
+        children: Vec<AnyElement>,
+        cx: &Context<Self>,
+    ) -> AnyElement {
+        v_flex()
+            .w_full()
+            .gap_3()
+            .child(
+                div()
+                    .text_size(px(11.))
+                    .font_medium()
+                    .text_color(cx.theme().muted_foreground)
+                    .child(label),
+            )
+            .children(children)
+            .into_any_element()
+    }
+
+    /// A labelled field block: label, control, optional muted help text.
+    fn field_block(
+        &self,
+        label: SharedString,
+        help: SharedString,
+        control: AnyElement,
+        cx: &Context<Self>,
+    ) -> AnyElement {
+        v_flex()
+            .w_full()
+            .gap_1p5()
+            .child(div().text_size(px(13.)).font_medium().child(label))
+            .child(control)
+            .when(!help.is_empty(), |this| {
+                this.child(
+                    div()
+                        .text_size(px(13.))
+                        .text_color(cx.theme().muted_foreground)
+                        .child(help),
+                )
+            })
+            .into_any_element()
+    }
+
+    fn render_identity(&self, cx: &mut Context<Self>) -> AnyElement {
+        self.section(
+            tcode_i18n::tr!("providers.dialog.identity")
+                .into_owned()
+                .into(),
+            vec![
+                self.field_block(
+                    tcode_i18n::tr!("providers.display_name")
+                        .into_owned()
+                        .into(),
+                    tcode_i18n::tr!("providers.display_name_help")
+                        .into_owned()
+                        .into(),
+                    Input::new(&self.display_name)
+                        .rounded(crate::material::radius_input())
+                        .into_any_element(),
+                    cx,
+                ),
+                self.field_block(
+                    tcode_i18n::tr!("providers.accent").into_owned().into(),
+                    tcode_i18n::tr!("providers.accent_help").into_owned().into(),
+                    self.render_accent(cx),
+                    cx,
+                ),
+            ],
+            cx,
+        )
+    }
+
+    fn render_accent(&self, cx: &mut Context<Self>) -> AnyElement {
+        let current = self.accent.clone();
+        let mut swatches = h_flex().gap_2().items_center();
+        for (index, preset) in ACCENT_PRESETS.iter().enumerate() {
+            let hex = (*preset).to_string();
+            let selected = current.as_deref() == Some(*preset);
+            let value = u32::from_str_radix(preset.trim_start_matches('#'), 16).unwrap_or(0);
+            swatches = swatches.child(
+                div()
+                    .id(("accent", index))
+                    .size(px(22.))
+                    .rounded_full()
+                    .cursor_pointer()
+                    .bg(rgb(value))
+                    .when(selected, |s| {
+                        s.border_2().border_color(cx.theme().foreground)
+                    })
+                    .tooltip({
+                        let hex = hex.clone();
+                        move |window, cx| {
+                            let label =
+                                tcode_i18n::tr!("providers.accent_select", color = hex.clone())
+                                    .into_owned();
+                            gpui_component::tooltip::Tooltip::new(label).build(window, cx)
+                        }
+                    })
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.accent = Some(hex.clone());
+                        cx.notify();
+                    })),
+            );
+        }
+        swatches = swatches.child(
+            Button::new("accent-clear")
+                .ghost()
+                .xsmall()
+                .icon(IconName::CircleX)
+                .tooltip(tcode_i18n::tr!("providers.accent_clear"))
+                .on_click(cx.listener(|this, _, _, cx| {
+                    this.accent = None;
+                    cx.notify();
+                })),
+        );
+        swatches.into_any_element()
+    }
+
+    fn render_connection(&self, cx: &mut Context<Self>) -> AnyElement {
+        let provider = self.provider;
+        let mut blocks = vec![
+            self.field_block(
+                tcode_i18n::tr!("providers.binary_path").into_owned().into(),
+                tcode_i18n::tr!(
+                    "providers.binary_path_help",
+                    name = provider_label(provider)
+                )
+                .into_owned()
+                .into(),
+                Input::new(&self.binary)
+                    .rounded(crate::material::radius_input())
+                    .into_any_element(),
+                cx,
+            ),
+        ];
+        if provider != ProviderKind::OpenCode {
+            blocks.push(
+                self.field_block(
+                    home_label(provider).into(),
+                    home_help(provider).into(),
+                    Input::new(&self.home)
+                        .rounded(crate::material::radius_input())
+                        .into_any_element(),
+                    cx,
+                ),
+            );
+        }
+        blocks.push(self.render_env(cx));
+        if provider != ProviderKind::Codex {
+            blocks.push(
+                self.field_block(
+                    tcode_i18n::tr!("providers.launch_args").into_owned().into(),
+                    tcode_i18n::tr!("providers.launch_args_help")
+                        .into_owned()
+                        .into(),
+                    Input::new(&self.launch_args)
+                        .rounded(crate::material::radius_input())
+                        .into_any_element(),
+                    cx,
+                ),
+            );
+        }
+        self.section(
+            tcode_i18n::tr!("providers.dialog.connection")
+                .into_owned()
+                .into(),
+            blocks,
+            cx,
+        )
+    }
+
+    fn render_env(&self, cx: &mut Context<Self>) -> AnyElement {
+        let muted = cx.theme().muted_foreground;
+        let mut block = v_flex().w_full().gap_2().child(
+            h_flex()
+                .w_full()
+                .items_center()
+                .justify_between()
+                .child(
+                    div()
+                        .text_size(px(13.))
+                        .font_medium()
+                        .child(tcode_i18n::tr!("providers.env.title")),
+                )
+                .child(
+                    Button::new("env-add")
+                        .outline()
+                        .xsmall()
+                        .icon(IconName::Plus)
+                        .label(tcode_i18n::tr!("providers.env.add"))
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.add_env_row(window, cx);
+                        })),
+                ),
+        );
+
+        if self.env_rows.is_empty() {
+            block = block.child(
+                div()
+                    .text_size(px(13.))
+                    .text_color(muted)
+                    .child(tcode_i18n::tr!("providers.env.empty_help")),
+            );
+        } else {
+            for (index, row) in self.env_rows.iter().enumerate() {
+                block =
+                    block.child(
+                        h_flex()
+                            .w_full()
+                            .gap_2()
+                            .items_center()
+                            .child(div().flex_1().min_w_0().child(
+                                Input::new(&row.name).rounded(crate::material::radius_input()),
+                            ))
+                            .child(div().flex_1().min_w_0().child(
+                                Input::new(&row.value).rounded(crate::material::radius_input()),
+                            ))
+                            .child(
+                                Switch::new(("env-sensitive", index))
+                                    .checked(row.sensitive)
+                                    .tooltip(tcode_i18n::tr!("providers.env.sensitive"))
+                                    .on_click(cx.listener(move |this, _: &bool, window, cx| {
+                                        this.toggle_env_sensitive(index, window, cx);
+                                    })),
+                            )
+                            .child(
+                                Button::new(("env-remove", index))
+                                    .ghost()
+                                    .xsmall()
+                                    .icon(IconName::Delete)
+                                    .tooltip(tcode_i18n::tr!("providers.env.remove"))
+                                    .on_click(cx.listener(move |this, _, window, cx| {
+                                        this.remove_env_row(index, window, cx);
+                                    })),
+                            ),
+                    );
+            }
+        }
+        block
+            .child(
+                div()
+                    .text_size(px(13.))
+                    .text_color(muted)
+                    .child(tcode_i18n::tr!("providers.env.security_help")),
+            )
+            .into_any_element()
+    }
+
+    fn render_models(&self, cx: &mut Context<Self>) -> AnyElement {
+        let rows = self.app_state.read(cx).draft_models_for_profile(
+            &self.profile_id,
+            &self.custom_models,
+            &self.hidden_models,
+        );
+        let muted = cx.theme().muted_foreground;
+
+        let mut block = v_flex().w_full().gap_1().child(
+            div()
+                .pb_1()
+                .text_size(px(13.))
+                .text_color(muted)
+                .child(if rows.len() == 1 {
+                    tcode_i18n::tr!("providers.models.count_one", count = 1).into_owned()
+                } else {
+                    tcode_i18n::tr!("providers.models.count", count = rows.len()).into_owned()
+                }),
+        );
+
+        for (index, row) in rows.iter().enumerate() {
+            block = block.child(self.render_model_row(index, row, cx));
+        }
+
+        // Custom-model input + validation copy.
+        block = block.child(
+            h_flex()
+                .w_full()
+                .pt_2()
+                .gap_2()
+                .items_center()
+                .child(
+                    div().flex_1().min_w_0().child(
+                        Input::new(&self.custom_model).rounded(crate::material::radius_input()),
+                    ),
+                )
+                .child(
+                    Button::new("add-custom-model")
+                        .outline()
+                        .small()
+                        .icon(IconName::Plus)
+                        .label(tcode_i18n::tr!("providers.models.add"))
+                        .on_click(
+                            cx.listener(|this, _, window, cx| this.add_custom_model(window, cx)),
+                        ),
+                ),
+        );
+        if let Some(error) = &self.slug_error {
+            block = block.child(
+                div()
+                    .text_size(px(13.))
+                    .text_color(cx.theme().danger_foreground)
+                    .child(error.clone()),
+            );
+        }
+        self.section(
+            tcode_i18n::tr!("providers.models.title")
+                .into_owned()
+                .into(),
+            vec![block.into_any_element()],
+            cx,
+        )
+    }
+
+    fn render_model_row(
+        &self,
+        index: usize,
+        row: &ResolvedModel,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let muted = cx.theme().muted_foreground;
+        let name = row.name.clone();
+        let hidden = row.hidden;
+        let capabilities = row
+            .capabilities
+            .iter()
+            .copied()
+            .map(model_capability_label)
+            .collect::<Vec<_>>()
+            .join(" · ");
+
+        let mut tags = h_flex().gap_1().items_center();
+        if row.custom {
+            tags = tags.child(tag(
+                tcode_i18n::tr!("providers.models.custom").into_owned(),
+                cx.theme().info.opacity(0.12),
+                cx.theme().info_foreground,
+            ));
+        }
+        if hidden {
+            tags = tags.child(tag(
+                tcode_i18n::tr!("providers.models.hidden").into_owned(),
+                cx.theme().warning.opacity(0.12),
+                cx.theme().warning_foreground,
+            ));
+        }
+
+        let fav_id = row.id.clone();
+        let is_fav = row.favorite;
+        let app_state = self.app_state.clone();
+        let hide_id = row.id.clone();
+        let remove_id = row.id.clone();
+        let custom = row.custom;
+
+        h_flex()
+            .w_full()
+            .py_1()
+            .gap_2()
+            .items_center()
+            .child(
+                h_flex()
+                    .flex_1()
+                    .min_w_0()
+                    .gap_1p5()
+                    .items_center()
+                    .child(
+                        div()
+                            .text_size(px(13.))
+                            .when(hidden, |d| d.text_color(muted))
+                            .child(name.clone()),
+                    )
+                    .when(!capabilities.is_empty(), |this| {
+                        this.child(
+                            div()
+                                .id(("model-info", index))
+                                .flex_none()
+                                .child(Icon::new(IconName::Info).xsmall().text_color(muted))
+                                .tooltip(move |window, cx| {
+                                    gpui_component::tooltip::Tooltip::new(capabilities.clone())
+                                        .build(window, cx)
+                                }),
+                        )
+                    })
+                    .child(tags),
+            )
+            .child(
+                // Favorites are a global, not part of the draft — this writes live.
+                Button::new(("model-fav", index))
+                    .ghost()
+                    .xsmall()
+                    .icon(if is_fav {
+                        IconName::StarFill
+                    } else {
+                        IconName::Star
+                    })
+                    .tooltip(if is_fav {
+                        tcode_i18n::tr!("providers.models.unfavorite")
+                    } else {
+                        tcode_i18n::tr!("providers.models.favorite")
+                    })
+                    .on_click(move |_, _, cx| {
+                        app_state.update(cx, |state, cx| state.toggle_favorite_model(&fav_id, cx));
+                    }),
+            )
+            .child(
+                Button::new(("model-hide", index))
+                    .ghost()
+                    .xsmall()
+                    .icon(if hidden {
+                        IconName::Eye
+                    } else {
+                        IconName::EyeOff
+                    })
+                    .tooltip(if hidden {
+                        tcode_i18n::tr!("providers.models.show")
+                    } else {
+                        tcode_i18n::tr!("providers.models.hide")
+                    })
+                    .on_click(cx.listener(move |this, _, _, cx| this.toggle_hidden(&hide_id, cx))),
+            )
+            .when(custom, |this| {
+                this.child(
+                    Button::new(("model-remove", index))
+                        .ghost()
+                        .xsmall()
+                        .icon(IconName::Delete)
+                        .tooltip(tcode_i18n::tr!("providers.models.remove"))
+                        .on_click(cx.listener(move |this, _, _, cx| {
+                            this.remove_custom_model(&remove_id, cx);
+                        })),
+                )
+            })
+            .into_any_element()
+    }
+}
+
+impl Render for ProviderDialog {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        // The dialog's content_builder path has no built-in scroll, so cap and
+        // scroll the form body ourselves.
+        div()
+            .id("provider-dialog-body")
+            .w_full()
+            .max_h(px(520.))
+            .overflow_y_scroll()
+            .child(
+                v_flex()
+                    .w_full()
+                    .gap(px(20.))
+                    .child(self.render_identity(cx))
+                    .child(self.render_connection(cx))
+                    .child(self.render_models(cx)),
+            )
+    }
+}
+
+/// The dialog footer: Delete (user profiles only, left) + Cancel / Save (right).
+pub fn render_footer(
+    dialog: &Entity<ProviderDialog>,
+    _window: &mut Window,
+    cx: &mut App,
+) -> AnyElement {
+    let (is_user, profile_id, app_state) = {
+        let d = dialog.read(cx);
+        (
+            d.is_user_profile(),
+            d.profile_id.clone(),
+            d.app_state.clone(),
+        )
+    };
+    let save_dialog = dialog.clone();
+
+    let mut left = div().flex_1();
+    if is_user {
+        let delete_id = profile_id.clone();
+        let delete_state = app_state.clone();
+        left = left.child(
+            Button::new("delete-profile")
+                .danger()
+                .icon(IconName::Delete)
+                .label(tcode_i18n::tr!("providers.delete_profile").into_owned())
+                .on_click(move |_, window, cx| {
+                    let delete_id = delete_id.clone();
+                    let delete_state = delete_state.clone();
+                    window.open_alert_dialog(cx, move |alert, _, _| {
+                        let delete_id = delete_id.clone();
+                        let delete_state = delete_state.clone();
+                        alert
+                            .title(tcode_i18n::tr!("providers.delete_confirm_title"))
+                            .description(tcode_i18n::tr!("providers.delete_confirm_body"))
+                            .button_props(
+                                DialogButtonProps::default()
+                                    .ok_variant(ButtonVariant::Danger)
+                                    .ok_text(tcode_i18n::tr!("providers.delete_profile"))
+                                    .cancel_text(tcode_i18n::tr!("settings.cancel"))
+                                    .show_cancel(true),
+                            )
+                            .on_ok(move |_, window, cx| {
+                                delete_state
+                                    .update(cx, |state, cx| state.delete_profile(&delete_id, cx));
+                                // Close the confirm and the underlying settings dialog.
+                                window.close_all_dialogs(cx);
+                                true
+                            })
+                    });
+                }),
+        );
+    }
+
+    h_flex()
+        .w_full()
+        .items_center()
+        .gap_2()
+        .child(left)
+        .child(
+            Button::new("provider-cancel")
+                .ghost()
+                .label(tcode_i18n::tr!("settings.cancel").into_owned())
+                .on_click(|_, window, cx| window.close_dialog(cx)),
+        )
+        .child(
+            Button::new("provider-save")
+                .primary()
+                .label(tcode_i18n::tr!("settings.save").into_owned())
+                .on_click(move |_, window, cx| {
+                    save_dialog.update(cx, |d, cx| d.apply(cx));
+                    window.close_dialog(cx);
+                }),
+        )
+        .into_any_element()
+}
+
+// ---------------------------------------------------------------------------
+// Copy + helpers
+// ---------------------------------------------------------------------------
+
+fn tag(label: String, background: gpui::Hsla, foreground: gpui::Hsla) -> AnyElement {
+    crate::material::semantic_chip(label, background, foreground).into_any_element()
+}
+
+fn default_binary_name(provider: ProviderKind) -> &'static str {
+    match provider {
+        ProviderKind::Codex => "codex",
+        ProviderKind::ClaudeCode => "claude",
+        ProviderKind::Pi => "pi",
+        ProviderKind::OpenCode => "opencode",
+        ProviderKind::Acp => "",
+    }
+}
+
+fn home_placeholder(provider: ProviderKind) -> &'static str {
+    match provider {
+        ProviderKind::Codex => "~/.codex",
+        ProviderKind::ClaudeCode => "~",
+        ProviderKind::Pi => "~/.pi/agent",
+        ProviderKind::OpenCode => "",
+        ProviderKind::Acp => "",
+    }
+}
+
+fn home_label(provider: ProviderKind) -> String {
+    match provider {
+        ProviderKind::Codex => tcode_i18n::tr!("providers.codex_home").into_owned(),
+        ProviderKind::ClaudeCode => tcode_i18n::tr!("providers.claude_home").into_owned(),
+        ProviderKind::Pi => tcode_i18n::tr!("providers.pi_home").into_owned(),
+        ProviderKind::OpenCode | ProviderKind::Acp => {
+            tcode_i18n::tr!("providers.home").into_owned()
+        }
+    }
+}
+
+fn home_help(provider: ProviderKind) -> String {
+    match provider {
+        ProviderKind::Codex => tcode_i18n::tr!("providers.codex_home_help").into_owned(),
+        ProviderKind::ClaudeCode => tcode_i18n::tr!("providers.claude_home_help").into_owned(),
+        ProviderKind::Pi => tcode_i18n::tr!("providers.pi_home_help").into_owned(),
+        ProviderKind::OpenCode | ProviderKind::Acp => {
+            tcode_i18n::tr!("providers.home_help").into_owned()
+        }
+    }
+}
+
+fn launch_args_placeholder(provider: ProviderKind) -> &'static str {
+    match provider {
+        ProviderKind::ClaudeCode => "e.g. --chrome",
+        ProviderKind::Pi => "e.g. --provider openai-codex",
+        ProviderKind::OpenCode => "e.g. --print-logs",
+        ProviderKind::Codex | ProviderKind::Acp => "",
+    }
+}
+
+fn custom_model_placeholder(provider: ProviderKind) -> &'static str {
+    match provider {
+        ProviderKind::Codex => "gpt-6.7-codex-ultra-preview",
+        ProviderKind::ClaudeCode => "claude-sonnet-5",
+        ProviderKind::Pi => "openai-codex/gpt-5.5",
+        ProviderKind::OpenCode => "openai/gpt-5.1-codex",
+        ProviderKind::Acp => "",
+    }
+}
+
+fn path_string(path: &Option<std::path::PathBuf>) -> String {
+    path.as_ref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default()
+}
+
+/// An input's trimmed value, or `None` when it is empty (an empty field removes
+/// the override).
+fn trimmed(input: &Entity<InputState>, cx: &App) -> Option<String> {
+    let value = input.read(cx).value().trim().to_string();
+    (!value.is_empty()).then_some(value)
+}

--- a/crates/ui/src/provider_model_picker.rs
+++ b/crates/ui/src/provider_model_picker.rs
@@ -127,7 +127,9 @@ impl ProviderModelPicker {
     fn options(&self, cx: &App) -> Vec<ModelOption> {
         let state = self.app_state.read(cx);
         let mut options = Vec::new();
-        for profile in state.all_profiles() {
+        // Only enabled profiles are offered for new selections; a disabled
+        // profile stays configurable in Settings but never reaches the picker.
+        for profile in state.enabled_profiles() {
             let catalog = state.models_for(profile.kind);
             let profile_id =
                 (!Settings::is_builtin_profile_id(&profile.id)).then_some(profile.id.clone());
@@ -185,6 +187,7 @@ impl ProviderModelPicker {
                         (kind, "", None)
                     });
                 let display = self.display_name(provider, model, profile_id, cx);
+                let glyph = tinted_glyph(self.app_state.read(cx), provider, profile_id);
                 // Ghost, not outline: a quiet resting trigger (glyph + value +
                 // muted chevron) that only tints on hover, matching the
                 // composer's model picker. The "Add" variant stays an outlined
@@ -195,7 +198,7 @@ impl ProviderModelPicker {
                         .items_center()
                         .gap_2()
                         .text_size(px(13.))
-                        .child(provider_glyph(provider).small())
+                        .child(glyph.small())
                         .child(div().flex_1().min_w_0().child(display))
                         .child(
                             Icon::new(IconName::ChevronDown)
@@ -223,12 +226,13 @@ impl Render for ProviderModelPicker {
                     let picker = picker.read(cx);
                     (
                         picker.options(cx),
-                        picker.app_state.read(cx).all_profiles(),
+                        picker.app_state.read(cx).enabled_profiles(),
                         picker.selected_profile.clone(),
                         picker.selected.clone(),
                         picker.excluded.clone(),
                     )
                 };
+                let app_state = picker.read(cx).app_state.clone();
                 // A deleted profile falls back to the first tab (built-ins
                 // always exist, so the list is never empty).
                 let current_profile = if profiles.iter().any(|p| p.id == selected_profile) {
@@ -280,7 +284,14 @@ impl Render for ProviderModelPicker {
                                 .rounded(crate::material::radius_button())
                                 .cursor_pointer()
                                 .hover(|style| style.bg(cx.theme().accent))
-                                .child(provider_glyph(option.provider).small())
+                                .child(
+                                    tinted_glyph(
+                                        app_state.read(cx),
+                                        option.provider,
+                                        option.profile_id.as_deref(),
+                                    )
+                                    .small(),
+                                )
                                 .child(
                                     v_flex()
                                         .flex_1()
@@ -349,7 +360,9 @@ impl Render for ProviderModelPicker {
                             .cursor_pointer()
                             .when(is_selected, |tab| tab.bg(cx.theme().accent).font_medium())
                             .hover(|tab| tab.bg(cx.theme().accent))
-                            .child(provider_glyph(kind).xsmall())
+                            .child(
+                                tinted_glyph(app_state.read(cx), kind, Some(&profile.id)).xsmall(),
+                            )
                             .child(div().text_size(px(13.)).child(label))
                             .on_click(move |_, _, cx| {
                                 picker.update(cx, |picker, cx| {
@@ -373,6 +386,20 @@ impl Render for ProviderModelPicker {
                             .child(div().size_full().child(rows)),
                     )
             })
+    }
+}
+
+/// The provider glyph tinted with the profile's own accent (falling back to the
+/// kind's built-in card accent), matching the composer's picker rail.
+fn tinted_glyph(state: &AppState, provider: ProviderKind, profile_id: Option<&str>) -> Icon {
+    let glyph = provider_glyph(provider);
+    let accent = match profile_id {
+        Some(id) => state.profile_accent(id),
+        None => state.provider_accent(provider),
+    };
+    match accent {
+        Some(accent) => glyph.text_color(accent),
+        None => glyph,
     }
 }
 

--- a/crates/ui/src/provider_models.rs
+++ b/crates/ui/src/provider_models.rs
@@ -1,8 +1,8 @@
 //! Provider model presentation with core-owned semantics and localized copy.
 
 pub use tcode_core::provider_models::{
-    MAX_SLUG_LEN, ModelCapability, ResolvedModel, SlugError, move_target, picker_models, reorder,
-    resolve_models, validate_slug,
+    MAX_SLUG_LEN, ModelCapability, ResolvedModel, SlugError, picker_models, resolve_models,
+    validate_slug,
 };
 
 pub fn model_capability_label(capability: ModelCapability) -> String {

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -189,7 +189,7 @@ impl SettingsPage {
                     this.commit_home_url(cx);
                 }
             }));
-        page.build_provider_cards(window, cx);
+        page.build_provider_cards(cx);
         page.sync_acp_cards(window, cx);
         page
     }
@@ -202,20 +202,16 @@ impl SettingsPage {
     }
 
     /// (Re)build the provider cards from current settings — also used after
-    /// "Restore defaults", which invalidates every card's inputs.
-    fn build_provider_cards(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        // Screenshot-only: `--debug-provider-expanded <profile-id>` opens one
-        // card's details (clicking the chevron cannot be driven headlessly).
-        let expanded = self.app_state.read(cx).debug_provider_expanded.clone();
+    /// "Restore defaults", which invalidates the cards' cached settings.
+    fn build_provider_cards(&mut self, cx: &mut Context<Self>) {
         let profiles = self.app_state.read(cx).all_profiles();
         self.provider_cards = profiles
             .into_iter()
             .map(|profile| {
                 let app_state = self.app_state.clone();
-                let open = expanded.as_deref() == Some(profile.id.as_str());
                 let kind = profile.kind;
                 let id = profile.id.clone();
-                let card = cx.new(|cx| ProviderCard::new(app_state, kind, id, open, window, cx));
+                let card = cx.new(|cx| ProviderCard::new(app_state, kind, id, cx));
                 (profile.id, card)
             })
             .collect();
@@ -503,8 +499,8 @@ impl SettingsPage {
                 )
                 .on_ok(move |_, window, cx| {
                     app_state.update(cx, |state, cx| state.reset_settings(cx));
-                    // Every provider card's inputs now hold stale overrides.
-                    page.update(cx, |page, cx| page.build_provider_cards(window, cx));
+                    // The profile set may have changed; rebuild the rows.
+                    page.update(cx, |page, cx| page.build_provider_cards(cx));
                     page.update(cx, |page, cx| {
                         let app_state = page.app_state.clone();
                         page.orchestrate_panel =
@@ -652,7 +648,7 @@ impl SettingsPage {
             .map(|(id, _)| id.clone())
             .collect();
         if current_ids != card_ids {
-            self.build_provider_cards(window, cx);
+            self.build_provider_cards(cx);
         }
         let state = self.app_state.read(cx);
         let checked_at = state.providers_checked_at();
@@ -706,8 +702,8 @@ impl SettingsPage {
                 })),
         );
 
-        // Native providers form one grouped list; each card renders as a row
-        // (its expanded editor nests under the row via an inset hairline).
+        // Native providers form one grouped list; each card is a compact row
+        // whose gear / body click opens the per-profile settings dialog.
         let provider_rows: Vec<AnyElement> = self
             .provider_cards
             .iter()

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -144,6 +144,7 @@ settings:
   restore_title: "Restore default settings?"
   restore_description: "Reset language, theme, thread-title model, diff, provider, and orchestrate settings to their defaults. Your projects and conversations will not be changed."
   cancel: "Cancel"
+  save: "Save"
   general_section: "GENERAL"
   appearance_section: "APPEARANCE"
   conversation_section: "CONVERSATION"
@@ -315,10 +316,16 @@ providers:
   updating: "Updating"
   update_manual: "or, update manually using"
   copy_command: "Copy command"
-  # Expanded card fields (T3 §4)
+  # Per-profile settings dialog (opened from a provider row's gear).
+  configure: "Configure %{name}"
+  dialog:
+    identity: "IDENTITY"
+    connection: "CONNECTION"
   display_name: "Display name"
   display_name_help: "Optional label shown in the provider list."
   delete_profile: "Delete profile"
+  delete_confirm_title: "Delete this profile?"
+  delete_confirm_body: "Its settings and stored secrets are removed. Sessions still using it fall back to the built-in provider."
   third_party:
     section: "Connect a provider"
     claude_title: "Claude Code"
@@ -358,8 +365,6 @@ providers:
   pi_home_help: "Custom pi agent directory. Keeps sessions, auth, models, prompts, and extensions separate."
   home: "Provider home path"
   home_help: "Custom home or data directory used by this provider instance."
-  shadow_home: "Shadow home path"
-  shadow_home_help: "Account-specific Codex home. Keeps auth.json separate while sharing state from CODEX_HOME."
   launch_args: "Launch arguments"
   launch_args_help: "Additional CLI arguments passed on session start."
   models:
@@ -371,8 +376,6 @@ providers:
     hidden: "hidden"
     favorite: "Add to favorites"
     unfavorite: "Remove from favorites"
-    move_up: "Move up"
-    move_down: "Move down"
     hide: "Hide from picker"
     show: "Show in picker"
     remove: "Remove custom model"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -144,6 +144,7 @@ settings:
   restore_title: "恢复默认设置？"
   restore_description: "将语言、主题、对话命名模型、diff、提供商和 Orchestrate 设置恢复为默认值。项目和对话不会受到影响。"
   cancel: "取消"
+  save: "保存"
   general_section: "通用"
   appearance_section: "外观"
   conversation_section: "对话"
@@ -311,9 +312,16 @@ providers:
   updating: "更新中"
   update_manual: "或者手动更新："
   copy_command: "复制命令"
+  # 单个配置的设置对话框（点击提供方行的齿轮图标打开）。
+  configure: "配置 %{name}"
+  dialog:
+    identity: "标识"
+    connection: "连接"
   display_name: "显示名称"
   display_name_help: "在提供方列表中显示的可选标签。"
   delete_profile: "删除配置"
+  delete_confirm_title: "确定删除此配置？"
+  delete_confirm_body: "其设置和已保存的密钥将被移除。仍在使用它的会话会回退到内置提供方。"
   third_party:
     section: "接入模型服务商"
     claude_title: "Claude Code"
@@ -353,8 +361,6 @@ providers:
   pi_home_help: "自定义 pi 智能体目录，可隔离会话、认证、模型、提示词与扩展。"
   home: "提供方主目录路径"
   home_help: "该提供方实例使用的自定义主目录或数据目录。"
-  shadow_home: "影子主目录路径"
-  shadow_home_help: "账号专用的 Codex 主目录。在共享 CODEX_HOME 状态的同时隔离 auth.json。"
   launch_args: "启动参数"
   launch_args_help: "会话启动时额外传入的 CLI 参数。"
   models:
@@ -366,8 +372,6 @@ providers:
     hidden: "已隐藏"
     favorite: "加入收藏"
     unfavorite: "取消收藏"
-    move_up: "上移"
-    move_down: "下移"
     hide: "从选择器中隐藏"
     show: "在选择器中显示"
     remove: "移除自定义模型"


### PR DESCRIPTION
## What

Two related changes to Settings → Providers:

**1. Per-profile status probes** (`7d5bd16b`)
Status snapshots were keyed by `ProviderKind` and probed with the built-in card's binary/env, so a third-party Claude profile (e.g. a Kimi endpoint) showed the official Claude account's auth. Snapshots are now keyed by profile id and probed with each profile's own binary override and launch env (isolated HOME + secrets), so a third-party profile reports its own API-key auth.

**2. Provider settings move to a transactional dialog; fields pruned** (`72b92135`)
- Provider rows no longer expand inline; the gear (or row click) opens a dialog seeded from the profile's settings. Draft-only until **Save** (one settings write + secret writes + one reload); **Cancel** discards everything, including pending secrets. Previously every keystroke wrote settings.json.
- Pruned t3-inherited fields: `shadow_home_path` folds into `home_path` (Codex label remains CODEX_HOME), `model_order` and its reorder arrows are gone (favorites-first ordering stays). Old JSON keys are ignored on load.
- Kind-irrelevant fields no longer render: OpenCode home (runtime ignores it), Codex launch args (runtime ignores them).
- The **enabled** switch now actually gates new-session surfaces: disabled profiles are filtered from the composer rail and model pickers via `enabled_profiles_for_kind`, while staying visible (and probed) in Settings. Existing sessions are untouched.
- The standalone model picker picks up the profile accent tint it was missing.

## Notes
- `--debug-provider-expanded` (screenshot tooling) is inert now that rows don't expand; plumbing left in place.
- i18n: removed `providers.shadow_home(_help)`, `providers.models.move_up/move_down`; added `settings.save`, `providers.configure`, `providers.dialog.identity/connection`, `providers.delete_confirm_title/body` (en + zh-CN in sync).

## Testing
- `cargo test --workspace` green; new tests: snapshot isolation per profile, profile binary override precedence, enabled-profile filtering, effective_home, resolver without model_order.
- `cargo clippy --workspace --all-targets` 0 warnings; `cargo fmt --check` clean; `rg "shadow_home|model_order|move_up|move_down"` 0 hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)