### PR TITLE
fix(app): quit guard counts background-task sessions as working

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -53,7 +53,7 @@ fn finish_quit_prompt(app_state: &Entity<AppState>, epoch: u64, cx: &mut App) ->
 }
 
 fn handle_quit(_: &Quit, app_state: &Entity<AppState>, cx: &mut App) {
-    let count = app_state.read(cx).turns_in_flight_count();
+    let count = app_state.read(cx).working_sessions_count();
     if count == 0 {
         cx.quit();
         return;

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -3698,6 +3698,40 @@ impl AppState {
             .count()
     }
 
+    /// Number of active or parked sessions that still own live work: a turn in
+    /// flight, an unacknowledged delivery, queued messages, or provider
+    /// background tasks. Quitting stops all of it, so the quit guard must gate
+    /// on this rather than on turns alone.
+    pub fn working_sessions_count(&self) -> usize {
+        fn works(
+            turn_in_flight: bool,
+            delivery: bool,
+            queued: bool,
+            background_tasks: usize,
+        ) -> bool {
+            turn_in_flight || delivery || queued || background_tasks > 0
+        }
+        usize::from(self.active.as_ref().is_some_and(|s| {
+            works(
+                s.turn_in_flight,
+                s.delivery_in_flight.is_some(),
+                !s.queue.is_empty(),
+                s.background_task_count,
+            )
+        })) + self
+            .background
+            .values()
+            .filter(|s| {
+                works(
+                    s.turn_in_flight,
+                    s.delivery_in_flight.is_some(),
+                    !s.queue.is_empty(),
+                    s.background_task_count,
+                )
+            })
+            .count()
+    }
+
     /// Record that a thread has been visited now (clears its unread dot).
     fn mark_visited(&mut self, session_id: &str) {
         self.settings
@@ -9099,6 +9133,55 @@ mod tests {
 
         assert!(matches!(receiver.try_recv(), Ok(SessionCommand::Shutdown)));
         assert!(state.active.is_none());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// The quit guard gates on working sessions: a session whose turn has
+    /// completed but which still owns provider background tasks must count as
+    /// working, or quitting silently kills those tasks.
+    #[test]
+    fn background_tasks_alone_count_as_working() {
+        let root = std::env::temp_dir().join(format!("tcode-app-test-{}", uuid::Uuid::new_v4()));
+        let store = SessionStore::open_at(root.clone()).unwrap();
+        let mut state = AppState::new(store);
+        let (commands, _receiver) = async_channel::unbounded();
+        state.active = Some(ActiveSession {
+            meta: SessionMeta::new(ProviderKind::Codex, PathBuf::from("/tmp/project"), None),
+            timeline: Timeline::default(),
+            git_branch: None,
+            branches: Vec::new(),
+            draft: false,
+            pending_relay: None,
+            runtime: Runtime::Live(commands),
+            live_model: None,
+            live_approval_mode: None,
+            live_option_selections: Vec::new(),
+            pending_ultrathink: false,
+            pending_context_len: None,
+            plan_implemented: false,
+            draft_workspace: WorkspaceMode::LocalCheckout,
+            preparing_worktree: false,
+            queue: Vec::new(),
+            next_queue_id: 0,
+            delivery_in_flight: None,
+            turn_in_flight: false,
+            background_task_count: 2,
+            provider_commands: Vec::new(),
+            provider_options: Vec::new(),
+            diff_open: false,
+            diff_expanded: false,
+            diff_selected_turn: None,
+            right_tab: RightTab::default(),
+            auto_open_suppressed: false,
+            terminal_workspace: TerminalWorkspace::default(),
+            _pump: None,
+        });
+
+        assert_eq!(state.turns_in_flight_count(), 0);
+        assert_eq!(state.working_sessions_count(), 1);
+
+        state.active.as_mut().unwrap().background_task_count = 0;
+        assert_eq!(state.working_sessions_count(), 0);
         let _ = std::fs::remove_dir_all(root);
     }
 


### PR DESCRIPTION
The quit confirmation ("仍有 N 个会话正在工作") gated on `turns_in_flight_count()` only. Since af99dd01 a session's turn completes immediately while provider background tasks keep running — so quitting with only background tasks pending showed no warning and silently killed them, violating the original quit-warning contract.

New `working_sessions_count()` counts sessions with a turn in flight, an unacknowledged delivery, queued messages, or live background tasks (the same work notion parking uses since #100); `handle_quit` gates on it. The existing dialog copy already says "sessions are still working", so no locale changes needed — the count now simply tells the truth.

Regression test: a session with completed turn + 2 background tasks counts as working (and turns_in_flight stays 0); dropping the tasks returns the count to 0.

Gates: fmt / clippy (runtime+app) / runtime tests (67) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)