### PR TITLE
fix(agent): make AgentEvent::Warning a struct variant so it serializes

### DIFF
--- a/crates/agent/examples/read_only_probe.rs
+++ b/crates/agent/examples/read_only_probe.rs
@@ -223,7 +223,7 @@ fn print_event(label: &str, event: &AgentEvent) {
         AgentEvent::TurnCompleted { status, .. } => {
             eprintln!("probe: {label} TurnCompleted status={status:?}")
         }
-        AgentEvent::Warning(message) => eprintln!("probe: {label} Warning {message:?}"),
+        AgentEvent::Warning { message } => eprintln!("probe: {label} Warning {message:?}"),
         AgentEvent::Error { fatal, message } => {
             eprintln!("probe: {label} Error fatal={fatal} {message:?}")
         }

--- a/crates/agent/examples/steer_probe.rs
+++ b/crates/agent/examples/steer_probe.rs
@@ -148,7 +148,7 @@ fn main() {
                         assistant.push('\n');
                     }
                 }
-                AgentEvent::Warning(message) => {
+                AgentEvent::Warning { message } => {
                     eprintln!("steer_probe: WARNING: {message}");
                 }
                 AgentEvent::Error { message, .. } => {

--- a/crates/agent/src/acp.rs
+++ b/crates/agent/src/acp.rs
@@ -755,10 +755,10 @@ async fn handshake(
             agent.id
         );
         let _ = events
-            .send(AgentEvent::Warning(format!(
+            .send(AgentEvent::Warning { message: format!(
                 "{} does not support HTTP MCP servers; tcode MCP tools are unavailable in this session",
                 agent.name
-            )))
+            ) })
             .await;
     }
 
@@ -770,46 +770,47 @@ async fn handshake(
         .map(str::to_string)
         .filter(|_| caps.load_session);
 
-    let (session_id, mut modes, config_options) = match resumed {
-        Some(session_id) => {
-            // `session/load` replays the whole conversation as `session/update`
-            // notifications. Our JSONL log is the authoritative history and the
-            // UI has already folded it, so the replay is swallowed (see
-            // `State::replaying`); we only want the session live again.
-            state.lock().unwrap().replaying = true;
-            let session_id = acp::SessionId::new(session_id);
-            let loaded = connection
-                .send_request(
-                    acp::LoadSessionRequest::new(session_id.clone(), opts.cwd.clone())
-                        .mcp_servers(mcp_servers.clone()),
-                )
-                .block_task()
-                .await;
-            state.lock().unwrap().replaying = false;
-            match loaded {
-                Ok(loaded) => (session_id, loaded.modes, loaded.config_options),
-                Err(err) => {
-                    log::warn!(
-                        "acp[{}]: session/load failed ({}); starting a fresh session",
-                        agent.id,
-                        describe(&err)
-                    );
-                    let _ = events
-                        .send(AgentEvent::Warning(format!(
+    let (session_id, mut modes, config_options) =
+        match resumed {
+            Some(session_id) => {
+                // `session/load` replays the whole conversation as `session/update`
+                // notifications. Our JSONL log is the authoritative history and the
+                // UI has already folded it, so the replay is swallowed (see
+                // `State::replaying`); we only want the session live again.
+                state.lock().unwrap().replaying = true;
+                let session_id = acp::SessionId::new(session_id);
+                let loaded = connection
+                    .send_request(
+                        acp::LoadSessionRequest::new(session_id.clone(), opts.cwd.clone())
+                            .mcp_servers(mcp_servers.clone()),
+                    )
+                    .block_task()
+                    .await;
+                state.lock().unwrap().replaying = false;
+                match loaded {
+                    Ok(loaded) => (session_id, loaded.modes, loaded.config_options),
+                    Err(err) => {
+                        log::warn!(
+                            "acp[{}]: session/load failed ({}); starting a fresh session",
+                            agent.id,
+                            describe(&err)
+                        );
+                        let _ = events
+                        .send(AgentEvent::Warning { message: format!(
                             "{} could not resume the previous conversation; starting a new one",
                             agent.name
-                        )))
+                        ) })
                         .await;
-                    let new = new_session(connection, agent, opts, &mcp_servers, &init).await?;
-                    (new.session_id, new.modes, new.config_options)
+                        let new = new_session(connection, agent, opts, &mcp_servers, &init).await?;
+                        (new.session_id, new.modes, new.config_options)
+                    }
                 }
             }
-        }
-        None => {
-            let new = new_session(connection, agent, opts, &mcp_servers, &init).await?;
-            (new.session_id, new.modes, new.config_options)
-        }
-    };
+            None => {
+                let new = new_session(connection, agent, opts, &mcp_servers, &init).await?;
+                (new.session_id, new.modes, new.config_options)
+            }
+        };
 
     if opts.approval_mode == ApprovalMode::ReadOnly
         && let Some(plan_mode) = modes.as_ref().and_then(acp_plan_mode)
@@ -832,11 +833,13 @@ async fn handshake(
                 // current mode, which is the same least-privilege fallback used
                 // for Supervised sessions.
                 let _ = events
-                    .send(AgentEvent::Warning(format!(
-                        "{} could not enter its read-only plan mode: {}",
-                        agent.name,
-                        describe(&err)
-                    )))
+                    .send(AgentEvent::Warning {
+                        message: format!(
+                            "{} could not enter its read-only plan mode: {}",
+                            agent.name,
+                            describe(&err)
+                        ),
+                    })
                     .await;
             }
         }
@@ -1054,11 +1057,11 @@ async fn handle_command(
         SessionCommand::Steer { .. } => {
             log::warn!("acp: steering is not part of the protocol; ignoring");
             let _ = events
-                .send(AgentEvent::Warning(
-                    "This agent cannot be steered (ACP has no steering method); \
+                .send(AgentEvent::Warning {
+                    message: "This agent cannot be steered (ACP has no steering method); \
                      send the message after the turn finishes."
                         .into(),
-                ))
+                })
                 .await;
         }
         SessionCommand::SendTurn {
@@ -1071,10 +1074,11 @@ async fn handle_command(
                 // ACP has no steering: one `session/prompt` per turn. The app
                 // queues turns, so this should not happen.
                 let _ = events
-                    .send(AgentEvent::Warning(
+                    .send(AgentEvent::Warning {
+                        message:
                         "a turn is already running; ACP agents cannot take a second prompt mid-turn"
                             .into(),
-                    ))
+                     })
                     .await;
                 return;
             }
@@ -1153,10 +1157,11 @@ async fn handle_command(
                 Some(outcome) => outcome,
                 None => {
                     let _ = events
-                        .send(AgentEvent::Warning(
+                        .send(AgentEvent::Warning {
+                            message:
                             "the agent offered no matching permission option; cancelling instead"
                                 .into(),
-                        ))
+                         })
                         .await;
                     acp::RequestPermissionOutcome::Cancelled
                 }
@@ -1188,10 +1193,9 @@ async fn handle_command(
                 }
                 Err(err) => {
                     let _ = events
-                        .send(AgentEvent::Warning(format!(
-                            "could not apply `{id}`: {}",
-                            describe(&err)
-                        )))
+                        .send(AgentEvent::Warning {
+                            message: format!("could not apply `{id}`: {}", describe(&err)),
+                        })
                         .await;
                 }
             }
@@ -1202,10 +1206,11 @@ async fn handle_command(
         }
         SessionCommand::SetApprovalMode(_) => {
             let _ = events
-                .send(AgentEvent::Warning(
-                    "ACP agents own their permission policy; use the agent's own mode selector"
-                        .into(),
-                ))
+                .send(AgentEvent::Warning {
+                    message:
+                        "ACP agents own their permission policy; use the agent's own mode selector"
+                            .into(),
+                })
                 .await;
         }
         SessionCommand::SetInteractionMode(_) => {

--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -704,9 +704,9 @@ async fn handle_command(
             let msg = mapper.set_permission_mode_request(mode);
             if write_line(stdin, &msg).await.is_err() {
                 let _ = event_tx
-                    .send(AgentEvent::Warning(format!(
-                        "claude: failed to switch permission mode to {mode:?}"
-                    )))
+                    .send(AgentEvent::Warning {
+                        message: format!("claude: failed to switch permission mode to {mode:?}"),
+                    })
                     .await;
             } else {
                 mapper.applied_permission_mode = flag.to_string();

--- a/crates/agent/src/codex.rs
+++ b/crates/agent/src/codex.rs
@@ -1115,9 +1115,9 @@ impl Actor {
             }
             SessionCommand::Interrupt => {
                 let Some(turn_id) = self.active_turn.clone() else {
-                    self.emit(AgentEvent::Warning(
-                        "cannot interrupt: no active Codex turn".into(),
-                    ))
+                    self.emit(AgentEvent::Warning {
+                        message: "cannot interrupt: no active Codex turn".into(),
+                    })
                     .await;
                     return Ok(());
                 };
@@ -1133,9 +1133,9 @@ impl Actor {
                 decision,
             } => {
                 let Some(json_rpc_id) = self.approvals.remove(&request_id) else {
-                    self.emit(AgentEvent::Warning(format!(
-                        "unknown Codex approval request id: {request_id}"
-                    )))
+                    self.emit(AgentEvent::Warning {
+                        message: format!("unknown Codex approval request id: {request_id}"),
+                    })
                     .await;
                     return Ok(());
                 };
@@ -1171,9 +1171,9 @@ impl Actor {
                 answers,
             } => {
                 let Some(json_rpc_id) = self.user_inputs.remove(&request_id) else {
-                    self.emit(AgentEvent::Warning(format!(
-                        "unknown Codex user-input request id: {request_id}"
-                    )))
+                    self.emit(AgentEvent::Warning {
+                        message: format!("unknown Codex user-input request id: {request_id}"),
+                    })
                     .await;
                     return Ok(());
                 };
@@ -1201,9 +1201,11 @@ impl Actor {
                 // request. Signal the UI to fall back to a resume-restart (the
                 // fresh thread/resume carries the new mode), mirroring the
                 // model-switch path.
-                self.emit(AgentEvent::Warning(format!(
-                    "codex: applying approval mode {mode:?} requires a session restart"
-                )))
+                self.emit(AgentEvent::Warning {
+                    message: format!(
+                        "codex: applying approval mode {mode:?} requires a session restart"
+                    ),
+                })
                 .await;
                 Ok(())
             }
@@ -1227,9 +1229,9 @@ impl Actor {
                 // which is exactly the race we want to lose loudly rather than
                 // silently start a second turn.
                 let Some(turn_id) = self.active_turn.clone() else {
-                    self.emit(AgentEvent::Warning(
-                        "cannot steer: no active Codex turn".into(),
-                    ))
+                    self.emit(AgentEvent::Warning {
+                        message: "cannot steer: no active Codex turn".into(),
+                    })
                     .await;
                     return Ok(());
                 };
@@ -1381,9 +1383,9 @@ impl Actor {
                     &mut self.stdin,
                     &json!({ "id": id, "error": { "code": -32601, "message": format!("unsupported server request: {method}") } }),
                 );
-                self.emit(AgentEvent::Warning(format!(
-                    "unsupported Codex server request: {method}"
-                )))
+                self.emit(AgentEvent::Warning {
+                    message: format!("unsupported Codex server request: {method}"),
+                })
                 .await;
                 return;
             }
@@ -1454,9 +1456,9 @@ impl Actor {
                         .await;
                     }
                     Err(err) => {
-                        self.emit(AgentEvent::Warning(format!(
-                            "Codex supplied an invalid turn diff: {err}"
-                        )))
+                        self.emit(AgentEvent::Warning {
+                            message: format!("Codex supplied an invalid turn diff: {err}"),
+                        })
                         .await;
                     }
                 }
@@ -1603,13 +1605,16 @@ impl Actor {
             }
             "warning" | "configWarning" | "deprecationNotice" => {
                 if let Some(message) = params.get("message").and_then(Value::as_str) {
-                    self.emit(AgentEvent::Warning(message.into())).await;
+                    self.emit(AgentEvent::Warning {
+                        message: message.into(),
+                    })
+                    .await;
                 }
             }
             "thread/closed" => {
-                self.emit(AgentEvent::Warning(
-                    "Codex thread was closed by the server".into(),
-                ))
+                self.emit(AgentEvent::Warning {
+                    message: "Codex thread was closed by the server".into(),
+                })
                 .await;
             }
             _ => log::trace!("ignored Codex notification {method}: {params}"),

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -770,7 +770,9 @@ pub enum AgentEvent {
         item_id: String,
         markdown: String,
     },
-    Warning(String),
+    Warning {
+        message: String,
+    },
     /// A runtime-synthesized fatal provider startup failure persisted for replay.
     #[rustfmt::skip]
     ProviderStartFailed { error: String },
@@ -1480,6 +1482,21 @@ mod turn_diff_tests {
     fn empty_diff_is_an_exact_empty_snapshot_but_malformed_diff_is_rejected() {
         assert!(file_changes_from_unified_diff("\n").unwrap().is_empty());
         assert!(file_changes_from_unified_diff("--- a/file\n+++ b/file\n").is_err());
+    }
+
+    #[test]
+    fn warning_event_round_trips() {
+        let event = AgentEvent::Warning {
+            message: "boom".into(),
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "warning");
+        assert_eq!(json["message"], "boom");
+        let decoded: AgentEvent = serde_json::from_value(json).unwrap();
+        assert!(matches!(
+            decoded,
+            AgentEvent::Warning { message } if message == "boom"
+        ));
     }
 
     #[test]

--- a/crates/agent/src/opencode.rs
+++ b/crates/agent/src/opencode.rs
@@ -191,10 +191,11 @@ async fn run_actor(
         .await;
     if opts.launch_env.home.is_some() {
         actor
-            .emit(AgentEvent::Warning(
+            .emit(AgentEvent::Warning {
+                message:
                 "OpenCode has no supported single-directory home override; custom environment variables still apply"
                     .into(),
-            ))
+             })
             .await;
     }
     if ready.send(Ok(())).await.is_err() {
@@ -273,9 +274,9 @@ impl OpenCodeActor {
             match self.fetch_diff() {
                 Ok(event) => self.emit(event).await,
                 Err(err) => {
-                    self.emit(AgentEvent::Warning(format!(
-                        "failed to fetch OpenCode session diff: {err}"
-                    )))
+                    self.emit(AgentEvent::Warning {
+                        message: format!("failed to fetch OpenCode session diff: {err}"),
+                    })
                     .await
                 }
             }
@@ -368,10 +369,11 @@ impl OpenCodeActor {
             }
             SessionCommand::SetApprovalMode(mode) => {
                 if mode != self.approval_mode {
-                    self.emit(AgentEvent::Warning(
-                        "OpenCode permission changes require restarting the per-session server"
-                            .into(),
-                    ))
+                    self.emit(AgentEvent::Warning {
+                        message:
+                            "OpenCode permission changes require restarting the per-session server"
+                                .into(),
+                    })
                     .await;
                 }
                 Ok(())
@@ -387,23 +389,25 @@ impl OpenCodeActor {
                 Ok(())
             }
             SessionCommand::Steer { .. } => {
-                self.emit(AgentEvent::Warning(
-                    "OpenCode's server API does not support steering an active turn".into(),
-                ))
+                self.emit(AgentEvent::Warning {
+                    message: "OpenCode's server API does not support steering an active turn"
+                        .into(),
+                })
                 .await;
                 Ok(())
             }
             SessionCommand::RespondUserInput { .. } => {
-                self.emit(AgentEvent::Warning(
-                    "OpenCode structured questions are not yet bridged by this adapter".into(),
-                ))
+                self.emit(AgentEvent::Warning {
+                    message: "OpenCode structured questions are not yet bridged by this adapter"
+                        .into(),
+                })
                 .await;
                 Ok(())
             }
             SessionCommand::Rewind { .. } => {
-                self.emit(AgentEvent::Warning(
-                    "OpenCode rewind is not exposed by tcode's native adapter".into(),
-                ))
+                self.emit(AgentEvent::Warning {
+                    message: "OpenCode rewind is not exposed by tcode's native adapter".into(),
+                })
                 .await;
                 Ok(())
             }
@@ -508,17 +512,19 @@ impl OpenCodeMapper {
         match kind {
             "session.status" => match properties.pointer("/status/type").and_then(Value::as_str) {
                 Some("busy") => mapped.events.extend(self.start_turn()),
-                Some("retry") => mapped.events.push(AgentEvent::Warning(format!(
-                    "OpenCode retry {}: {}",
-                    properties
-                        .pointer("/status/attempt")
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0),
-                    properties
-                        .pointer("/status/message")
-                        .and_then(Value::as_str)
-                        .unwrap_or("provider error")
-                ))),
+                Some("retry") => mapped.events.push(AgentEvent::Warning {
+                    message: format!(
+                        "OpenCode retry {}: {}",
+                        properties
+                            .pointer("/status/attempt")
+                            .and_then(Value::as_u64)
+                            .unwrap_or(0),
+                        properties
+                            .pointer("/status/message")
+                            .and_then(Value::as_str)
+                            .unwrap_or("provider error")
+                    ),
+                }),
                 Some("idle") => mapped.events.extend(self.complete_turn()),
                 _ => {}
             },

--- a/crates/agent/src/pi.rs
+++ b/crates/agent/src/pi.rs
@@ -314,10 +314,11 @@ async fn run_actor(
     }
     if opts.interaction_mode == InteractionMode::Plan {
         actor
-            .emit(AgentEvent::Warning(
+            .emit(AgentEvent::Warning {
+                message:
                 "pi RPC has no native Plan interaction mode; this session is running in Build mode"
                     .into(),
-            ))
+             })
             .await;
     }
     if opts.mcp_server.is_some()
@@ -325,10 +326,11 @@ async fn run_actor(
         || opts.computer_use_server.is_some()
     {
         actor
-            .emit(AgentEvent::Warning(
+            .emit(AgentEvent::Warning {
+                message:
                 "pi RPC does not expose native MCP registration; configured tcode MCP servers were not attached"
                     .into(),
-            ))
+             })
             .await;
     }
     if ready.send(Ok(())).await.is_err() {
@@ -483,9 +485,9 @@ impl PiActor {
         let message: Value = match serde_json::from_str(line) {
             Ok(message) => message,
             Err(err) => {
-                self.emit(AgentEvent::Warning(format!(
-                    "ignored invalid pi RPC record: {err}"
-                )))
+                self.emit(AgentEvent::Warning {
+                    message: format!("ignored invalid pi RPC record: {err}"),
+                })
                 .await;
                 return;
             }
@@ -535,16 +537,16 @@ impl PiActor {
                 &mut self.stdin,
                 &json!({"type":"extension_ui_response","id":id,"cancelled":true}),
             );
-            self.emit(AgentEvent::Warning(format!(
-                "pi extension requested unsupported UI method `{method}`"
-            )))
+            self.emit(AgentEvent::Warning {
+                message: format!("pi extension requested unsupported UI method `{method}`"),
+            })
             .await;
             return;
         }
         let Some(id) = message.get("id").and_then(Value::as_str) else {
-            self.emit(AgentEvent::Warning(
-                "pi extension confirmation omitted its id".into(),
-            ))
+            self.emit(AgentEvent::Warning {
+                message: "pi extension confirmation omitted its id".into(),
+            })
             .await;
             return;
         };
@@ -661,33 +663,33 @@ impl PiActor {
             }
             SessionCommand::SetApprovalMode(mode) => {
                 if mode != self.approval_mode {
-                    self.emit(AgentEvent::Warning(
-                        "pi permission changes require restarting the session".into(),
-                    ))
+                    self.emit(AgentEvent::Warning {
+                        message: "pi permission changes require restarting the session".into(),
+                    })
                     .await;
                 }
                 Ok(())
             }
             SessionCommand::SetInteractionMode(mode) => {
                 if mode == InteractionMode::Plan {
-                    self.emit(AgentEvent::Warning(
-                        "pi RPC has no native Plan interaction mode".into(),
-                    ))
+                    self.emit(AgentEvent::Warning {
+                        message: "pi RPC has no native Plan interaction mode".into(),
+                    })
                     .await;
                 }
                 Ok(())
             }
             SessionCommand::RespondUserInput { .. } => {
-                self.emit(AgentEvent::Warning(
-                    "pi RPC does not expose structured user-input requests".into(),
-                ))
+                self.emit(AgentEvent::Warning {
+                    message: "pi RPC does not expose structured user-input requests".into(),
+                })
                 .await;
                 Ok(())
             }
             SessionCommand::Rewind { .. } => {
-                self.emit(AgentEvent::Warning(
-                    "pi rewind is not exposed by tcode's native adapter".into(),
-                ))
+                self.emit(AgentEvent::Warning {
+                    message: "pi rewind is not exposed by tcode's native adapter".into(),
+                })
                 .await;
                 Ok(())
             }
@@ -792,36 +794,42 @@ impl PiMapper {
                 },
                 true,
             ),
-            "compaction_start" => vec![AgentEvent::Warning(format!(
-                "pi is compacting context ({})",
-                message
-                    .get("reason")
-                    .and_then(Value::as_str)
-                    .unwrap_or("unknown reason")
-            ))],
+            "compaction_start" => vec![AgentEvent::Warning {
+                message: format!(
+                    "pi is compacting context ({})",
+                    message
+                        .get("reason")
+                        .and_then(Value::as_str)
+                        .unwrap_or("unknown reason")
+                ),
+            }],
             "compaction_end" => {
                 if message.get("result").is_some_and(|value| !value.is_null()) {
                     vec![AgentEvent::ContextCompacted]
                 } else {
-                    vec![AgentEvent::Warning(format!(
-                        "pi context compaction did not complete: {}",
-                        message
-                            .get("errorMessage")
-                            .and_then(Value::as_str)
-                            .unwrap_or("aborted")
-                    ))]
+                    vec![AgentEvent::Warning {
+                        message: format!(
+                            "pi context compaction did not complete: {}",
+                            message
+                                .get("errorMessage")
+                                .and_then(Value::as_str)
+                                .unwrap_or("aborted")
+                        ),
+                    }]
                 }
             }
-            "auto_retry_start" => vec![AgentEvent::Warning(format!(
-                "pi retry {}/{} in {} ms: {}",
-                number(message.get("attempt")).unwrap_or(0),
-                number(message.get("maxAttempts")).unwrap_or(0),
-                number(message.get("delayMs")).unwrap_or(0),
-                message
-                    .get("errorMessage")
-                    .and_then(Value::as_str)
-                    .unwrap_or("transient provider error")
-            ))],
+            "auto_retry_start" => vec![AgentEvent::Warning {
+                message: format!(
+                    "pi retry {}/{} in {} ms: {}",
+                    number(message.get("attempt")).unwrap_or(0),
+                    number(message.get("maxAttempts")).unwrap_or(0),
+                    number(message.get("delayMs")).unwrap_or(0),
+                    message
+                        .get("errorMessage")
+                        .and_then(Value::as_str)
+                        .unwrap_or("transient provider error")
+                ),
+            }],
             "auto_retry_end"
                 if !message
                     .get("success")
@@ -829,25 +837,29 @@ impl PiMapper {
                     .unwrap_or(false) =>
             {
                 self.failed = true;
-                vec![AgentEvent::Warning(format!(
-                    "pi retry failed: {}",
-                    message
-                        .get("finalError")
-                        .and_then(Value::as_str)
-                        .unwrap_or("provider error")
-                ))]
+                vec![AgentEvent::Warning {
+                    message: format!(
+                        "pi retry failed: {}",
+                        message
+                            .get("finalError")
+                            .and_then(Value::as_str)
+                            .unwrap_or("provider error")
+                    ),
+                }]
             }
-            "extension_error" => vec![AgentEvent::Warning(format!(
-                "pi extension error in {}: {}",
-                message
-                    .get("event")
-                    .and_then(Value::as_str)
-                    .unwrap_or("unknown event"),
-                message
-                    .get("error")
-                    .and_then(Value::as_str)
-                    .unwrap_or("unknown error")
-            ))],
+            "extension_error" => vec![AgentEvent::Warning {
+                message: format!(
+                    "pi extension error in {}: {}",
+                    message
+                        .get("event")
+                        .and_then(Value::as_str)
+                        .unwrap_or("unknown event"),
+                    message
+                        .get("error")
+                        .and_then(Value::as_str)
+                        .unwrap_or("unknown error")
+                ),
+            }],
             _ => Vec::new(),
         }
     }

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -512,7 +512,7 @@ impl Timeline {
                 }
             }
             AgentEvent::TokenUsage(usage) => self.usage = Some(*usage),
-            AgentEvent::Warning(message) => log::warn!("provider warning: {message}"),
+            AgentEvent::Warning { message } => log::warn!("provider warning: {message}"),
             AgentEvent::ProviderStartFailed { error } => {
                 let turn = self.ensure_turn(ts);
                 let id = self.synthetic_id("error");

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -5976,7 +5976,7 @@ impl AppState {
                     message.clone(),
                 )));
             }
-            AgentEvent::Warning(message) => {
+            AgentEvent::Warning { message } => {
                 // Provider warnings (config problems, deprecations, failed
                 // mode switches) explain later misbehavior: a log line alone
                 // hides them from the person who needs to act on them.


### PR DESCRIPTION
## Problem

`AgentEvent` is internally tagged (`#[serde(tag = "type")]`, `crates/agent/src/lib.rs`), and `Warning(String)` was the only variant wrapping a bare primitive. Serde cannot inject the `"type"` tag into a plain string, so `Store::append_event` failed at runtime with:

```
cannot serialize tagged newtype variant AgentEvent::Warning containing a string
```

The live timeline still rendered warnings (folding happens regardless of persistence), which is why the app appeared unaffected — but every Warning event was silently dropped from the JSONL log and lost on session resume.

## Fix

`Warning(String)` → `Warning { message: String }`, matching the sibling `Error { message, fatal }` shape; serializes as `{"type":"warning","message":"…"}`. All construction/match sites updated (compiler-enforced). Adds a serde round-trip test.

No on-disk compatibility concern: the old shape never serialized successfully, so no legacy data exists.

Other newtype variants (`TokenUsage(TokenUsage)`, `ItemStarted(ThreadItem)`, …) wrap structs, which serialize as maps and accept the tag — they are unaffected, as are the other `#[serde(tag = "kind")]` enums in the file.

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets --locked -- -D warnings` ✅
- `cargo test --workspace --locked` ✅ (one pre-existing, environment-only failure in `term` PTY test locally; fails identically on unchanged `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)