### PR TITLE
fix(ui): repair the image attachment pipeline end to end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8546,6 +8546,7 @@ dependencies = [
  "gpui-component",
  "gpui-component-assets",
  "gpui-wry",
+ "image",
  "lb-wry",
  "log",
  "objc2-app-kit 0.3.2",

--- a/crates/agent/examples/image_probe.rs
+++ b/crates/agent/examples/image_probe.rs
@@ -105,6 +105,7 @@ fn main() {
     let attachment = Attachment {
         media_type: mime_from_path(&image_path),
         data_base64: base64_encode(&bytes),
+        source_path: None,
     };
     eprintln!(
         "image_probe: provider={provider:?} image={} ({} bytes, {}) prompt={prompt:?}",

--- a/crates/agent/src/acp.rs
+++ b/crates/agent/src/acp.rs
@@ -3267,6 +3267,7 @@ mod tests {
             &[Attachment {
                 media_type: "image/png".into(),
                 data_base64: "AAAA".into(),
+                source_path: None,
             }],
         );
         let value = serde_json::to_value(&blocks).unwrap();

--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -3245,10 +3245,12 @@ mod tests {
             Attachment {
                 media_type: "image/png".into(),
                 data_base64: "AAAA".into(),
+                source_path: None,
             },
             Attachment {
                 media_type: "image/jpeg".into(),
                 data_base64: "BBBB".into(),
+                source_path: None,
             },
         ];
         let msg = user_message("what color is this?", &attachments);

--- a/crates/agent/src/codex.rs
+++ b/crates/agent/src/codex.rs
@@ -2314,6 +2314,7 @@ mod tests {
         let attachments = vec![Attachment {
             media_type: "image/png".into(),
             data_base64: "AAAA".into(),
+            source_path: None,
         }];
         let params = actor.build_turn_params("what color?", None, &attachments);
         let input = params["input"].as_array().unwrap();

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -433,6 +433,12 @@ pub struct Attachment {
     pub media_type: String,
     /// Standard-base64 of the raw bytes (no `data:...;base64,` prefix).
     pub data_base64: String,
+    /// Local path of the persisted copy backing this attachment, when one
+    /// exists. Never sent to providers (their payloads are built field by
+    /// field); the runtime threads it into the recorded user-message event so
+    /// the timeline can render the image without re-encoding the base64.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_path: Option<String>,
 }
 
 /// A provider-native command or skill surfaced to the composer's `/` and `$`
@@ -708,6 +714,10 @@ pub enum AgentEvent {
     SteerRequested {
         request_id: String,
         text: String,
+        /// Local paths of the image attachments steered with the text (see
+        /// [`ItemContent::UserMessage::attachments`]).
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        attachments: Vec<String>,
     },
     /// Emitted only after the provider has consumed the correlated steer into
     /// its model context (or provided the strongest available consumption
@@ -881,6 +891,11 @@ pub enum ItemContent {
         /// which therefore render as a plain bubble exactly as before.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         context_len: Option<usize>,
+        /// Local paths of the image attachments sent with this message, so the
+        /// timeline (live and replayed) can render them. Empty on text-only
+        /// messages and on logs written before this field existed.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        attachments: Vec<String>,
     },
     AssistantMessage {
         text: String,

--- a/crates/agent/src/subagent_tail.rs
+++ b/crates/agent/src/subagent_tail.rs
@@ -126,6 +126,7 @@ impl TranscriptMapper {
                     ItemContent::UserMessage {
                         text: text.into(),
                         context_len: None,
+                        attachments: Vec::new(),
                     },
                 )));
                 continue;

--- a/crates/core/src/attachments.rs
+++ b/crates/core/src/attachments.rs
@@ -20,7 +20,10 @@ pub fn validate_attachment(
     size: u64,
     current_count: usize,
 ) -> Result<(), AttachError> {
-    if !mime.starts_with("image/") {
+    if !matches!(
+        mime,
+        "image/png" | "image/jpeg" | "image/gif" | "image/webp" | "image/tiff" | "image/bmp"
+    ) {
         return Err(AttachError::UnsupportedType {
             name: name.to_string(),
         });
@@ -58,6 +61,21 @@ mod tests {
                 name: "notes.txt".into()
             })
         );
+    }
+
+    #[test]
+    fn rejects_unsupported_image_type() {
+        assert_eq!(
+            validate_attachment("drawing.svg", "image/svg+xml", 10, 0),
+            Err(AttachError::UnsupportedType {
+                name: "drawing.svg".into()
+            })
+        );
+    }
+
+    #[test]
+    fn accepts_tiff_for_transcoding() {
+        assert!(validate_attachment("scan.tiff", "image/tiff", 1_000, 0).is_ok());
     }
 
     #[test]

--- a/crates/core/src/relay.rs
+++ b/crates/core/src/relay.rs
@@ -358,6 +358,7 @@ mod tests {
             ItemContent::UserMessage {
                 text: text.into(),
                 context_len: None,
+                attachments: Vec::new(),
             },
         )
     }

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -207,6 +207,9 @@ pub enum EntryContent {
         /// collapsed disclosure row and keeps the bubble to `text[context_len..]`.
         /// `None` for ordinary messages and for logs predating the annotation.
         context_len: Option<usize>,
+        /// Local paths of the image attachments sent with this message (empty
+        /// for text-only messages and for logs predating the field).
+        attachments: Vec<String>,
     },
     Assistant {
         text: String,
@@ -479,9 +482,11 @@ impl Timeline {
                     }
                 }
             }
-            AgentEvent::SteerRequested { request_id, text } => {
-                self.request_steer(ts, request_id, text)
-            }
+            AgentEvent::SteerRequested {
+                request_id,
+                text,
+                attachments,
+            } => self.request_steer(ts, request_id, text, attachments),
             AgentEvent::SteerAccepted { request_id } => self.accept_steer(request_id),
             AgentEvent::Delta {
                 item_id,
@@ -779,7 +784,13 @@ impl Timeline {
         }
     }
 
-    fn request_steer(&mut self, ts: Option<u64>, request_id: &str, text: &str) {
+    fn request_steer(
+        &mut self,
+        ts: Option<u64>,
+        request_id: &str,
+        text: &str,
+        attachments: &[String],
+    ) {
         if self.entries.iter().any(|entry| entry.id == request_id) {
             return;
         }
@@ -790,6 +801,7 @@ impl Timeline {
                 text: text.to_owned(),
                 steering: Some(SteeringStatus::Pending),
                 context_len: None,
+                attachments: attachments.to_vec(),
             },
             ts,
             turn,
@@ -827,10 +839,15 @@ impl Timeline {
 
     fn content_from_item(content: &ItemContent) -> EntryContent {
         match content {
-            ItemContent::UserMessage { text, context_len } => EntryContent::User {
+            ItemContent::UserMessage {
+                text,
+                context_len,
+                attachments,
+            } => EntryContent::User {
                 text: text.clone(),
                 steering: None,
                 context_len: *context_len,
+                attachments: attachments.clone(),
             },
             ItemContent::AssistantMessage { text } => {
                 EntryContent::Assistant { text: text.clone() }
@@ -1006,12 +1023,16 @@ fn merge_content(existing: EntryContent, incoming: EntryContent) -> EntryContent
         (
             EntryContent::User { steering, .. },
             EntryContent::User {
-                text, context_len, ..
+                text,
+                context_len,
+                attachments,
+                ..
             },
         ) => EntryContent::User {
             text,
             steering,
             context_len,
+            attachments,
         },
         (EntryContent::Assistant { text: old }, EntryContent::Assistant { text: new }) => {
             EntryContent::Assistant {
@@ -1095,6 +1116,7 @@ mod tests {
             content: ItemContent::UserMessage {
                 text: text.into(),
                 context_len: None,
+                attachments: Vec::new(),
             },
         })
     }
@@ -1467,6 +1489,7 @@ mod tests {
         let request = AgentEvent::SteerRequested {
             request_id: "steer-a".into(),
             text: "change direction".into(),
+            attachments: Vec::new(),
         };
         let encoded = serde_json::to_string(&request).unwrap();
         let decoded: AgentEvent = serde_json::from_str(&encoded).unwrap();
@@ -1551,6 +1574,7 @@ mod tests {
             AgentEvent::SteerRequested {
                 request_id: "S".into(),
                 text: "change direction".into(),
+                attachments: Vec::new(),
             },
             assistant_item("A"),
             assistant_item("B"),
@@ -2108,6 +2132,7 @@ mod tests {
             content: ItemContent::UserMessage {
                 text: "ping".into(),
                 context_len: None,
+                attachments: Vec::new(),
             },
         };
         let completed = ThreadItem {
@@ -2248,6 +2273,7 @@ mod tests {
             content: ItemContent::UserMessage {
                 text: text.into(),
                 context_len,
+                attachments: Vec::new(),
             },
         })
     }

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -231,19 +231,41 @@ enum QueuedMessageKind {
 }
 
 impl QueuedMessage {
-    /// The text actually sent to the provider (Ultrathink prefix applied).
+    /// The text actually sent to the provider (image-only placeholder and
+    /// Ultrathink prefix applied). The recorded user message keeps `text`
+    /// verbatim, so an image-only bubble renders as just its thumbnails.
     fn wire_text(&self) -> String {
         let text = if let Some(transcript) = &self.relay_transcript {
             assemble_relay_prompt(transcript, &self.text)
         } else {
             self.text.clone()
         };
+        let text = wire_text_with_placeholder(text, &self.attachments);
         if self.ultrathink {
             format!("Ultrathink:\n{text}")
         } else {
             text
         }
     }
+}
+
+/// Providers require non-empty turn text: an image-only message goes on the
+/// wire with T3's synthetic placeholder while the transcript records the
+/// user's (empty) text plus the attachments.
+fn wire_text_with_placeholder(text: String, attachments: &[Attachment]) -> String {
+    if text.trim().is_empty() && !attachments.is_empty() {
+        tcode_core::attachments::image_only_message().to_string()
+    } else {
+        text
+    }
+}
+
+/// The local persisted paths behind `attachments`, for the recorded event.
+fn attachment_paths(attachments: &[Attachment]) -> Vec<String> {
+    attachments
+        .iter()
+        .filter_map(|attachment| attachment.source_path.clone())
+        .collect()
 }
 
 impl From<&str> for QueuedMessage {
@@ -1277,7 +1299,7 @@ impl AppState {
                     .or_else(|| self.background.get(&thread_id))
                     .is_some_and(|child| child.turn_in_flight && child.supports_steering());
                 if can_steer {
-                    let request_id = self.record_steer_request(&thread_id, &message, cx);
+                    let request_id = self.record_steer_request(&thread_id, &message, &[], cx);
                     let sent = self
                         .active
                         .as_mut()
@@ -4439,7 +4461,13 @@ impl AppState {
             );
             return;
         };
-        self.record_user_message(session_id, &message.text, message.context_len, cx);
+        self.record_user_message(
+            session_id,
+            &message.text,
+            message.context_len,
+            &message.attachments,
+            cx,
+        );
         if is_active {
             self.maybe_generate_title(&message.text, &message.attachments, cx);
         }
@@ -4639,7 +4667,7 @@ impl AppState {
         if can_steer {
             // A steered callback is already part of this turn, so persist it just
             // like a user-triggered steer before handing it to the provider.
-            let request_id = self.record_steer_request(parent_id, &text, cx);
+            let request_id = self.record_steer_request(parent_id, &text, &[], cx);
             let sent = self
                 .active
                 .as_mut()
@@ -4707,6 +4735,7 @@ impl AppState {
         session_id: &str,
         text: &str,
         context_len: Option<usize>,
+        attachments: &[Attachment],
         cx: &mut Context<Self>,
     ) {
         let user_event = AgentEvent::ItemCompleted(ThreadItem {
@@ -4715,6 +4744,7 @@ impl AppState {
             content: ItemContent::UserMessage {
                 text: text.to_owned(),
                 context_len,
+                attachments: attachment_paths(attachments),
             },
         });
         self.record_event(session_id, &user_event, cx);
@@ -4726,6 +4756,7 @@ impl AppState {
         &mut self,
         session_id: &str,
         text: &str,
+        attachments: &[Attachment],
         cx: &mut Context<Self>,
     ) -> String {
         let request_id = format!("local-steer-{}", uuid::Uuid::new_v4());
@@ -4734,6 +4765,7 @@ impl AppState {
             &AgentEvent::SteerRequested {
                 request_id: request_id.clone(),
                 text: text.to_owned(),
+                attachments: attachment_paths(attachments),
             },
             cx,
         );
@@ -4769,15 +4801,16 @@ impl AppState {
             }
             SendRouting::Steer => {
                 let session_id = active.meta.id.clone();
+                let wire_text = wire_text_with_placeholder(text.clone(), &attachments);
                 let wire_text = if active.pending_ultrathink {
-                    format!("Ultrathink:\n{text}")
+                    format!("Ultrathink:\n{wire_text}")
                 } else {
-                    text.clone()
+                    wire_text
                 };
                 // The steered message joins the running turn, so it belongs in
                 // the transcript exactly like any other user message. (A merely
                 // *queued* message does not — see `dispatch_next_queued`.)
-                let request_id = self.record_steer_request(&session_id, &text, cx);
+                let request_id = self.record_steer_request(&session_id, &text, &attachments, cx);
 
                 let Some(active) = self.active.as_mut() else {
                     return;
@@ -7452,7 +7485,10 @@ mod tests {
                 .iter()
                 .find_map(|stored| match &stored.event {
                     AgentEvent::ItemCompleted(ThreadItem {
-                        content: ItemContent::UserMessage { text, context_len },
+                        content:
+                            ItemContent::UserMessage {
+                                text, context_len, ..
+                            },
                         ..
                     }) => Some((text.clone(), *context_len)),
                     _ => None,
@@ -8996,6 +9032,7 @@ mod tests {
                     content: ItemContent::UserMessage {
                         text: "start".into(),
                         context_len: None,
+                        attachments: Vec::new(),
                     },
                 }),
             );
@@ -9537,6 +9574,40 @@ mod tests {
             receiver.try_recv(),
             Ok(SessionCommand::SendTurn { text, .. }) if text == "shallow"
         ));
+    }
+
+    /// An image-only send keeps its empty text in the transcript (the bubble
+    /// renders just the thumbnails) while the wire carries T3's placeholder.
+    #[test]
+    fn image_only_message_gets_placeholder_on_the_wire_only() {
+        let (commands, receiver) = async_channel::unbounded();
+        let mut active = live_session(ProviderKind::Codex, commands);
+        let attachment = Attachment {
+            media_type: "image/png".into(),
+            data_base64: "AAAA".into(),
+            source_path: Some("/tmp/a.png".into()),
+        };
+        active.push_queued(String::new(), vec![attachment.clone()]);
+
+        assert_eq!(active.dispatch_next_pending(), Ok(true));
+        let delivery_id = match receiver.try_recv() {
+            Ok(SessionCommand::SendTurn {
+                delivery_id,
+                text,
+                attachments,
+                ..
+            }) => {
+                assert_eq!(text, tcode_core::attachments::image_only_message());
+                assert_eq!(attachments, vec![attachment]);
+                delivery_id
+            }
+            other => panic!("expected SendTurn, got {other:?}"),
+        };
+        // The accepted (recorded) message keeps the user's empty text and the
+        // local path for the timeline.
+        let recorded = active.accept_turn_delivery(delivery_id).unwrap();
+        assert_eq!(recorded.text, "");
+        assert_eq!(attachment_paths(&recorded.attachments), vec!["/tmp/a.png"]);
     }
 
     #[test]

--- a/crates/services/src/import/claude.rs
+++ b/crates/services/src/import/claude.rs
@@ -55,6 +55,7 @@ pub(super) fn convert(path: &Path, external_id: &str) -> Result<Option<Converted
                                     content: ItemContent::UserMessage {
                                         text,
                                         context_len: None,
+                                        attachments: Vec::new(),
                                     },
                                 },
                             });

--- a/crates/services/src/import/codex.rs
+++ b/crates/services/src/import/codex.rs
@@ -82,6 +82,7 @@ pub(super) fn convert(path: &Path, external_id: &str) -> Result<Option<Converted
                                 ItemContent::UserMessage {
                                     text,
                                     context_len: None,
+                                    attachments: Vec::new(),
                                 }
                             } else if role == Some("assistant") {
                                 ItemContent::AssistantMessage { text }

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -14,6 +14,7 @@ computer-use-mcp = { path = "../computer-use-mcp" }
 gpui = { git = "https://github.com/zed-industries/zed" }
 gpui-component = { git = "https://github.com/longbridge/gpui-component", rev = "031555662e99a1b5a549990b47f246d475b8288a" }
 gpui-component-assets = { git = "https://github.com/longbridge/gpui-component", rev = "031555662e99a1b5a549990b47f246d475b8288a" }
+image = { version = "0.25.10", default-features = false, features = ["png", "jpeg", "gif", "webp", "bmp", "tiff"] }
 async-channel = "2"
 base64 = "0.22"
 chrono = "0.4"
@@ -31,7 +32,7 @@ raw-window-handle = { version = "0.6", features = ["std"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 block2 = "0.6.2"
-objc2-app-kit = { version = "0.3.2", features = ["NSGraphicsContext", "NSImage", "NSImageRep", "objc2-core-graphics"] }
+objc2-app-kit = { version = "0.3.2", features = ["NSGraphicsContext", "NSImage", "NSImageRep", "NSPasteboard", "objc2-core-graphics"] }
 objc2-core-foundation = { version = "0.3.2", features = ["CFData", "CFString"] }
 objc2-core-graphics = { version = "0.3.2", features = ["CGImage"] }
 objc2-foundation = { version = "0.3.2", features = ["NSError"] }

--- a/crates/ui/src/attachments.rs
+++ b/crates/ui/src/attachments.rs
@@ -1,6 +1,41 @@
 //! Attachment presentation with core-owned validation semantics and localized errors.
 
+use std::path::PathBuf;
+
+use gpui::{App, ParentElement as _, Styled as _, Window, div, img, px};
+use gpui_component::{ActiveTheme as _, WindowExt as _};
 use tcode_core::attachments::AttachError;
+
+/// Open an image as a window-level lightbox. The dialog lives on the Root
+/// layer, so its backdrop covers the whole window and it inherits
+/// backdrop-click / Escape / `x` dismissal. Shared by the composer's pending
+/// strip and the chat timeline's sent-message thumbnails.
+pub(crate) fn open_image_lightbox(path: PathBuf, title: String, window: &mut Window, cx: &mut App) {
+    window.open_dialog(cx, move |builder, window, cx| {
+        let viewport = window.viewport_size();
+        let width = (viewport.width - px(160.)).clamp(px(320.), px(760.));
+        let max_h = viewport.height * 0.65;
+        let path = path.clone();
+        builder
+            .w(width)
+            .rounded(crate::material::radius_overlay())
+            .bg(cx.theme().popover)
+            .border_1()
+            .border_color(cx.theme().border)
+            .shadow_xl()
+            .title(title.clone())
+            .content(move |content_el, _, _| {
+                content_el.child(
+                    div().w_full().flex().items_center().justify_center().child(
+                        img(path.clone())
+                            .max_w_full()
+                            .max_h(max_h)
+                            .rounded(crate::material::radius_card()),
+                    ),
+                )
+            })
+    });
+}
 
 pub(crate) fn attach_error_message(error: &AttachError) -> String {
     match error {

--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -10,9 +10,9 @@ use std::path::{Path, PathBuf};
 use agent::{ChangeCompleteness, FileChange, ItemStatus, RewindMode};
 use gpui::{
     Anchor, AnyElement, App, AppContext as _, ClipboardItem, Context, Entity, FollowMode,
-    InteractiveElement as _, IntoElement, ListAlignment, ListState, ParentElement as _, Render,
-    Role, SharedString, StatefulInteractiveElement as _, Styled as _, Subscription, Task, Window,
-    div, list, prelude::FluentBuilder as _, px,
+    InteractiveElement as _, IntoElement, ListAlignment, ListState, ObjectFit, ParentElement as _,
+    Render, Role, SharedString, StatefulInteractiveElement as _, Styled as _, StyledImage as _,
+    Subscription, Task, Window, div, img, list, prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
     ActiveTheme as _, Disableable as _, Icon, IconName, Selectable as _, Sizable as _,
@@ -512,7 +512,9 @@ fn hash_entry_shape(content: &EntryContent, hash: &mut DefaultHasher) {
             text,
             steering,
             context_len,
+            attachments,
         } => {
+            attachments.len().hash(hash);
             text.len().hash(hash);
             steering.hash(hash);
             context_len.hash(hash);
@@ -873,6 +875,7 @@ impl ChatView {
                         text,
                         steering,
                         context_len,
+                        attachments,
                     } = &entry.content
                     else {
                         unreachable!();
@@ -893,6 +896,7 @@ impl ChatView {
                             &entry.id,
                             text,
                             *context_len,
+                            attachments,
                             *steering,
                             pinned.0 == Some(entry.id.as_str()),
                             window,
@@ -986,6 +990,7 @@ impl ChatView {
                 text,
                 steering,
                 context_len,
+                attachments,
             } = &entry.content
             else {
                 unreachable!();
@@ -995,6 +1000,7 @@ impl ChatView {
                 &entry.id,
                 text,
                 *context_len,
+                attachments,
                 *steering,
                 pinned.0 == Some(entry.id.as_str()),
                 window,
@@ -1151,12 +1157,14 @@ impl ChatView {
     /// the timeline; it is revealed for `pinned` (the last user message) so the
     /// action is reachable without hovering.
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     fn render_user(
         &self,
         turn: usize,
         entry_id: &str,
         text: &str,
         context_len: Option<usize>,
+        attachments: &[String],
         steering: Option<SteeringStatus>,
         pinned: bool,
         window: &mut Window,
@@ -1182,16 +1190,62 @@ impl ChatView {
         });
 
         let group_key = SharedString::from(format!("user-{entry_id}"));
-        let mut actions = h_flex()
-            .gap_1()
-            .items_center()
-            .justify_end()
-            .child(self.render_copy_button(&format!("user:{entry_id}"), Arc::from(visible), cx));
+        let mut actions = h_flex().gap_1().items_center().justify_end();
+        if !visible.trim().is_empty() {
+            actions = actions.child(self.render_copy_button(
+                &format!("user:{entry_id}"),
+                Arc::from(visible),
+                cx,
+            ));
+        }
         if steering.is_none()
             && let Some(rewind) = self.render_native_rewind_button(turn, cx)
         {
             actions = actions.child(rewind);
         }
+
+        // Sent image attachments render as a right-aligned thumbnail row above
+        // the text bubble; each opens the shared window-level lightbox. Missing
+        // files (a pruned attachments dir) simply render an empty tile.
+        let thumbnails = (!attachments.is_empty()).then(|| {
+            h_flex().gap_2().justify_end().flex_wrap().children(
+                attachments
+                    .iter()
+                    .enumerate()
+                    .map(|(image_index, path)| {
+                        let path = PathBuf::from(path);
+                        let title = path
+                            .file_name()
+                            .map(|name| name.to_string_lossy().into_owned())
+                            .unwrap_or_else(|| "image".to_string());
+                        let click_path = path.clone();
+                        div()
+                            .id(SharedString::from(format!(
+                                "user-image-{entry_id}-{image_index}"
+                            )))
+                            .size(px(120.))
+                            .rounded_xl()
+                            .overflow_hidden()
+                            .bg(cx.theme().muted)
+                            .cursor_pointer()
+                            .child(
+                                img(path)
+                                    .size(px(120.))
+                                    .rounded_xl()
+                                    .object_fit(ObjectFit::Cover),
+                            )
+                            .on_click(cx.listener(move |_, _, window, cx| {
+                                crate::attachments::open_image_lightbox(
+                                    click_path.clone(),
+                                    title.clone(),
+                                    window,
+                                    cx,
+                                );
+                            }))
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        });
 
         let content = self.md_states.get(entry_id).map_or_else(
             || div().child(visible.to_string()).into_any_element(),
@@ -1221,30 +1275,33 @@ impl ChatView {
                         }),
                 )
             })
-            .child({
-                let pending = steering == Some(SteeringStatus::Pending);
-                div()
-                    // Ceil past sub-pixel snapping plus 1px slack — an exact
-                    // fractional fit can still wrap the final glyph. The extra
-                    // 2px always reserves the pending state's border (sizes are
-                    // border-box), so the width holds steady across steering
-                    // states and the last glyph never wraps while pending.
-                    .w((text_width + px(32.)).ceil() + px(3.))
-                    .flex_none()
-                    .max_w_3_4()
-                    .px_4()
-                    .py_3()
-                    .rounded_xl()
-                    .bg(cx.theme().muted)
-                    .when(pending, |bubble| {
-                        bubble
-                            .border_1()
-                            .border_dashed()
-                            .border_color(cx.theme().border)
-                    })
-                    .text_color(cx.theme().foreground)
-                    .text_size(px(15.))
-                    .child(content)
+            .children(thumbnails)
+            .when(!visible.trim().is_empty(), |column| {
+                column.child({
+                    let pending = steering == Some(SteeringStatus::Pending);
+                    div()
+                        // Ceil past sub-pixel snapping plus 1px slack — an exact
+                        // fractional fit can still wrap the final glyph. The extra
+                        // 2px always reserves the pending state's border (sizes are
+                        // border-box), so the width holds steady across steering
+                        // states and the last glyph never wraps while pending.
+                        .w((text_width + px(32.)).ceil() + px(3.))
+                        .flex_none()
+                        .max_w_3_4()
+                        .px_4()
+                        .py_3()
+                        .rounded_xl()
+                        .bg(cx.theme().muted)
+                        .when(pending, |bubble| {
+                            bubble
+                                .border_1()
+                                .border_dashed()
+                                .border_color(cx.theme().border)
+                        })
+                        .text_color(cx.theme().foreground)
+                        .text_size(px(15.))
+                        .child(content)
+                })
             })
             .child(self.reserve_action_row(actions, group_key, pinned));
 
@@ -3333,6 +3390,7 @@ This begins after the hard break."#;
                         text: "render a long document".into(),
                         steering: None,
                         context_len: None,
+                        attachments: Vec::new(),
                     },
                 ),
                 entry(
@@ -3495,6 +3553,7 @@ This begins after the hard break."#;
                     text: "go".into(),
                     steering: None,
                     context_len: None,
+                    attachments: Vec::new(),
                 },
             ),
             entry(
@@ -3531,6 +3590,7 @@ This begins after the hard break."#;
                     text: "next".into(),
                     steering: None,
                     context_len: None,
+                    attachments: Vec::new(),
                 },
             ),
             1,
@@ -3611,6 +3671,7 @@ This begins after the hard break."#;
                     text: "go".into(),
                     steering: None,
                     context_len: None,
+                    attachments: Vec::new(),
                 },
             ),
             command("cmd-1"),
@@ -3682,6 +3743,7 @@ This begins after the hard break."#;
                     text: id.into(),
                     steering: Some(SteeringStatus::Pending),
                     context_len: None,
+                    attachments: Vec::new(),
                 },
             )
         };
@@ -3730,6 +3792,7 @@ This begins after the hard break."#;
                 text: "redirect".into(),
                 steering: Some(SteeringStatus::Pending),
                 context_len: None,
+                attachments: Vec::new(),
             },
         );
         let assistant = entry(

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -41,7 +41,7 @@ use crate::context_meter;
 use crate::palette::fuzzy_score;
 use crate::provider_card::{CLAUDE_BRAND_COLOR, provider_glyph};
 use crate::workspace_walk::filter_entries;
-use tcode_core::attachments::{image_only_message, validate_attachment};
+use tcode_core::attachments::validate_attachment;
 use tcode_core::session::append_review_comments_to_prompt;
 use tcode_runtime::app::{AppState, TerminalContext, WorkspaceMode};
 use tcode_runtime::ui_facade::PathEntry;
@@ -422,12 +422,9 @@ fn provider_display_name(provider: ProviderKind) -> &'static str {
 fn image_extension(mime: &str, name: &str) -> String {
     let from_mime = match mime {
         "image/png" => "png",
-        "image/jpeg" | "image/jpg" => "jpg",
+        "image/jpeg" => "jpg",
         "image/webp" => "webp",
         "image/gif" => "gif",
-        "image/svg+xml" => "svg",
-        "image/bmp" => "bmp",
-        "image/tiff" | "image/tif" => "tiff",
         _ => "",
     };
     if !from_mime.is_empty() {
@@ -438,6 +435,20 @@ fn image_extension(mime: &str, name: &str) -> String {
         .and_then(|e| e.to_str())
         .map(|e| e.to_ascii_lowercase())
         .unwrap_or_else(|| "png".to_string())
+}
+
+fn is_wire_ready_image(mime: &str) -> bool {
+    matches!(
+        mime,
+        "image/png" | "image/jpeg" | "image/gif" | "image/webp"
+    )
+}
+
+fn transcode_image_to_png(bytes: &[u8]) -> image::ImageResult<Vec<u8>> {
+    let image = image::load_from_memory(bytes)?;
+    let mut png = std::io::Cursor::new(Vec::new());
+    image.write_to(&mut png, image::ImageFormat::Png)?;
+    Ok(png.into_inner())
 }
 
 /// Best-effort MIME type from a file extension (for drag/drop of image files).
@@ -516,8 +527,6 @@ pub struct Composer {
     pending_images: Vec<PendingImage>,
     /// The session id `pending_images` belongs to (reset the strip on switch).
     images_session: Option<String>,
-    /// Index of the image shown in the expanded-preview overlay, if any.
-    image_preview: Option<usize>,
     /// Whether the one-shot screenshot debug seed has been applied.
     debug_applied: bool,
     _subscriptions: Vec<Subscription>,
@@ -620,7 +629,6 @@ impl Composer {
             workspace_loading: false,
             pending_images: Vec::new(),
             images_session: None,
-            image_preview: None,
             debug_applied: false,
             _subscriptions: subscriptions,
         }
@@ -771,14 +779,12 @@ impl Composer {
         let prompt_text = orchestrate_text.as_deref().unwrap_or(&text);
         let text = append_terminal_contexts_to_prompt(prompt_text, &terminal_contexts);
         let text = append_review_comments_to_prompt(&text, &review_comments);
-        // Image-only messages get T3's exact synthetic text. Attachments are
-        // persisted on disk (see `add_image_*`); read + base64-encode each one
-        // so the provider receives real image content blocks (Group A).
-        let sent_text = if text.is_empty() && has_images {
-            image_only_message().to_string()
-        } else {
-            text
-        };
+        // Attachments are persisted on disk (see `add_image_*`); read +
+        // base64-encode each one so the provider receives real image content
+        // blocks. An image-only message keeps its empty text here — the runtime
+        // substitutes T3's synthetic placeholder on the wire only, so the
+        // transcript bubble renders as just the thumbnails.
+        let sent_text = text;
         let attachments = self.collect_attachments();
         if let Some((from, to)) = self.app_state.read(cx).relay_confirmation() {
             let composer = cx.entity();
@@ -846,7 +852,6 @@ impl Composer {
         self.text_cache.clear_current();
         input.update(cx, |state, cx| state.set_value("", window, cx));
         self.pending_images.clear();
-        self.image_preview = None;
         self.app_state.update(cx, |state, cx| {
             if let Some(active) = state.active.as_mut() {
                 active.terminal_workspace.contexts.clear();
@@ -1111,7 +1116,6 @@ impl Composer {
         if id != self.images_session {
             self.images_session = id;
             self.pending_images.clear();
-            self.image_preview = None;
         }
     }
 
@@ -1131,6 +1135,17 @@ impl Composer {
             window.push_notification(Notification::error(attach_error_message(&err)), cx);
             return;
         }
+        let (mime, bytes) = if is_wire_ready_image(&mime) {
+            (mime, bytes)
+        } else {
+            let Ok(bytes) = transcode_image_to_png(&bytes) else {
+                let err =
+                    tcode_core::attachments::AttachError::UnsupportedType { name: name.clone() };
+                window.push_notification(Notification::error(attach_error_message(&err)), cx);
+                return;
+            };
+            ("image/png".to_string(), bytes)
+        };
         let ext = image_extension(&mime, &name);
         match self.app_state.read(cx).save_attachment(&bytes, &ext) {
             Ok(path) => {
@@ -1166,25 +1181,30 @@ impl Composer {
 
     /// Pull an image off the clipboard (⌘V with image content), if present.
     fn paste_clipboard_image(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let Some(item) = cx.read_from_clipboard() else {
-            return;
-        };
-        for entry in &item.entries {
-            match entry {
-                ClipboardEntry::Image(image) => {
-                    let mime = image.format().mime_type().to_string();
-                    let bytes = image.bytes().to_vec();
-                    self.add_image_bytes("pasted-image".to_string(), mime, bytes, window, cx);
-                }
-                ClipboardEntry::ExternalPaths(paths) => {
-                    for path in paths.paths() {
-                        if mime_from_path(path).starts_with("image/") {
-                            self.add_image_path(path.clone(), window, cx);
+        let image_count_before = self.pending_images.len();
+        if let Some(item) = cx.read_from_clipboard() {
+            for entry in &item.entries {
+                match entry {
+                    ClipboardEntry::Image(image) => {
+                        let mime = image.format().mime_type().to_string();
+                        let bytes = image.bytes().to_vec();
+                        self.add_image_bytes("pasted-image".to_string(), mime, bytes, window, cx);
+                    }
+                    ClipboardEntry::ExternalPaths(paths) => {
+                        for path in paths.paths() {
+                            if mime_from_path(path).starts_with("image/") {
+                                self.add_image_path(path.clone(), window, cx);
+                            }
                         }
                     }
+                    ClipboardEntry::String(_) => {}
                 }
-                ClipboardEntry::String(_) => {}
             }
+        }
+        if self.pending_images.len() == image_count_before
+            && let Some((mime, bytes)) = crate::pasteboard::read_pasteboard_image()
+        {
+            self.add_image_bytes("pasted-image".to_string(), mime, bytes, window, cx);
         }
     }
 
@@ -1199,6 +1219,7 @@ impl Composer {
                 Some(Attachment {
                     media_type: mime_from_path(&image.path),
                     data_base64: base64::engine::general_purpose::STANDARD.encode(&bytes),
+                    source_path: Some(image.path.to_string_lossy().into_owned()),
                 })
             })
             .collect()
@@ -1208,9 +1229,6 @@ impl Composer {
         if index < self.pending_images.len() {
             let removed = self.pending_images.remove(index);
             let _ = tcode_runtime::ui_facade::remove_user_file(&removed.path);
-            if self.image_preview == Some(index) {
-                self.image_preview = None;
-            }
             cx.notify();
         }
     }
@@ -1870,9 +1888,8 @@ impl Composer {
                             .size(px(64.))
                             .rounded(crate::material::radius_card()),
                     )
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        this.image_preview = Some(index);
-                        cx.notify();
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        this.open_image_preview(index, window, cx);
                     }))
                     .child(
                         div()
@@ -1903,47 +1920,13 @@ impl Composer {
         Some(row.into_any_element())
     }
 
-    /// The expanded image preview overlay (click backdrop / `x` to close).
-    fn render_image_preview(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
-        let index = self.image_preview?;
-        let image = self.pending_images.get(index)?;
-        let path = image.path.clone();
-        let name = image.name.clone();
-        Some(
-            div()
-                .id("image-preview")
-                .absolute()
-                .inset_0()
-                .flex()
-                .items_center()
-                .justify_center()
-                .bg(gpui::black().opacity(0.7))
-                .cursor_pointer()
-                .on_click(cx.listener(|this, _, _, cx| {
-                    this.image_preview = None;
-                    cx.notify();
-                }))
-                .child(
-                    v_flex()
-                        .items_center()
-                        .gap_2()
-                        .child(
-                            div()
-                                .max_w(px(420.))
-                                .max_h(px(420.))
-                                .rounded(crate::material::radius_card())
-                                .overflow_hidden()
-                                .child(img(path).max_w(px(420.)).max_h(px(420.))),
-                        )
-                        .child(
-                            div()
-                                .text_size(px(13.))
-                                .text_color(gpui::white())
-                                .child(name),
-                        ),
-                )
-                .into_any_element(),
-        )
+    /// Open the clicked thumbnail as a window-level lightbox (see
+    /// [`crate::attachments::open_image_lightbox`]).
+    fn open_image_preview(&self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(image) = self.pending_images.get(index) else {
+            return;
+        };
+        crate::attachments::open_image_lightbox(image.path.clone(), image.name.clone(), window, cx);
     }
 
     // -- send / stop --------------------------------------------------------
@@ -3488,7 +3471,6 @@ impl Render for Composer {
                     .child(card)
                     .children(self.render_checkout_row(cx)),
             )
-            .children(self.render_image_preview(cx))
     }
 }
 
@@ -4565,6 +4547,20 @@ fn file_change_kind_label(kind: FileChangeKind) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bmp_and_tiff_transcode_to_decodable_png() {
+        let source = image::DynamicImage::new_rgba8(2, 2);
+        for format in [image::ImageFormat::Bmp, image::ImageFormat::Tiff] {
+            let mut encoded = std::io::Cursor::new(Vec::new());
+            source.write_to(&mut encoded, format).unwrap();
+
+            let png = transcode_image_to_png(&encoded.into_inner()).unwrap();
+            assert_eq!(image::guess_format(&png).unwrap(), image::ImageFormat::Png);
+            let decoded = image::load_from_memory(&png).unwrap();
+            assert_eq!((decoded.width(), decoded.height()), (2, 2));
+        }
+    }
 
     fn thread(id: &str) -> ComposerDestination {
         ComposerDestination::Thread(id.to_string())

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -14,6 +14,7 @@ pub mod markdown;
 pub mod material;
 mod orchestrate_settings;
 mod palette;
+mod pasteboard;
 mod plan_panel;
 mod preview_panel;
 pub mod provider_card;

--- a/crates/ui/src/pasteboard.rs
+++ b/crates/ui/src/pasteboard.rs
@@ -1,0 +1,22 @@
+#[cfg(target_os = "macos")]
+pub(crate) fn read_pasteboard_image() -> Option<(String, Vec<u8>)> {
+    use objc2_app_kit::NSPasteboard;
+    use objc2_foundation::ns_string;
+
+    let pasteboard = NSPasteboard::generalPasteboard();
+    for (pasteboard_type, mime) in [
+        (ns_string!("public.png"), "image/png"),
+        (ns_string!("public.jpeg"), "image/jpeg"),
+        (ns_string!("public.tiff"), "image/tiff"),
+    ] {
+        if let Some(data) = pasteboard.dataForType(pasteboard_type) {
+            return Some((mime.to_string(), data.to_vec()));
+        }
+    }
+    None
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn read_pasteboard_image() -> Option<(String, Vec<u8>)> {
+    None
+}


### PR DESCRIPTION
## Summary

Fixes the four user-visible defects in image input/sending:

1. **Preview overlay was not window-level** — the expanded image preview was an `absolute().inset_0()` child of the composer column, so its backdrop only covered the composer strip. Replaced with a Root-layer dialog lightbox (`window.open_dialog`, same mechanism as the project's other modals): whole-window dim backdrop, Esc / backdrop-click / `x` dismissal. Shared by the composer thumbnail strip and chat bubbles (`crates/ui/src/attachments.rs::open_image_lightbox`).

2. **Sent images vanished from the transcript** — `ItemContent::UserMessage`, `EntryContent::User`, and `SteerRequested` now carry the attachments' persisted paths (`serde(default)` keeps old logs readable). The user bubble renders a right-aligned thumbnail row (click → lightbox) and replayed sessions restore it. Image-only messages keep their empty text in the transcript: T3's synthetic placeholder is applied **on the wire only** (`QueuedMessage::wire_text` / steer path), so the bubble shows just the images instead of an English placeholder blob.

3. **Unsupported media types reached providers** — providers accept only png/jpeg/gif/webp, but validation admitted any `image/*` (TIFF pasteboards, BMP drops, SVG). `validate_attachment` is now an explicit policy: wire-ready types pass; tiff/bmp are accepted and transcoded to PNG at attach time (`image` crate, direct dependency pinned to the version already in the lockfile); everything else is rejected with the existing localized error.

4. **Paste attached nothing when the clipboard also held text** — gpui's macOS pasteboard read returns file paths, then a plain string, then images, so "Copy Image" from a browser (URL string + bitmap) never yielded an image entry. When the gpui read produces no image, the composer now probes `NSPasteboard` image types directly (png/jpeg/tiff, cfg-gated to macOS with a no-op stub elsewhere) and attaches the data through the same transcode path.

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked` — clean on this branch rebased onto `b98fe881` (the only failures observed were pre-existing flaky `term` PTY tests under parallel load on a busy host; untouched by this diff and green standalone).
- New unit tests: image-only wire placeholder vs recorded text (runtime), SVG rejection + TIFF acceptance (core), BMP/TIFF→PNG transcode round-trip (ui).
- Live end-to-end on a real session: TIFF dragged in transcodes to a `.png` on disk; an image-only send records `text: ""` + attachment path in the session JSONL while the provider receives the placeholder and correctly describes the image; the bubble shows only thumbnails; restart + replay restores them; the lightbox dims the whole window and closes on Esc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)