### PR TITLE
fix(ui): diff panel scroll freeze + click-to-navigate changed files

### DIFF
--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -131,6 +131,15 @@ pub enum RightTab {
     Preview,
 }
 
+/// One-shot request from a changed-file row to focus that file in a turn diff.
+/// The diff panel consumes it only after the matching rendered cache is ready.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffFocusRequest {
+    pub session: String,
+    pub turn: usize,
+    pub path: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct RightPanelState {
     open: bool,
@@ -827,6 +836,8 @@ pub struct AppState {
     review_comment_drafts: HashMap<String, Vec<ReviewComment>>,
     /// Invalidates working-tree/branch previews on panel open and turn finish.
     pub diff_refresh_generation: u64,
+    /// Pending changed-file row navigation, consumed by the diff panel once.
+    pending_diff_focus: Option<DiffFocusRequest>,
     /// Per-provider version-check results (Group C). Populated on launch (when
     /// the toggle is on) and by Settings → "Check now".
     pub provider_versions: HashMap<ProviderKind, ProviderVersionStatus>,
@@ -947,6 +958,7 @@ impl AppState {
             debug_open_commit_dialog: false,
             review_comment_drafts: HashMap::new(),
             diff_refresh_generation: 0,
+            pending_diff_focus: None,
             debug_palette: None,
             debug_settings_section: None,
             debug_acp_search: None,
@@ -2839,6 +2851,7 @@ impl AppState {
             // tabs while already open) shows diffs; a second click closes.
             if active.diff_open && active.right_tab == RightTab::Diff {
                 active.diff_open = false;
+                self.pending_diff_focus = None;
                 if active.timeline.turn_running {
                     active.auto_open_suppressed = true;
                 }
@@ -2853,6 +2866,7 @@ impl AppState {
 
     /// Open the diff panel and select `turn` (a "View diff" card button).
     pub fn open_diff_for_turn(&mut self, turn: usize, cx: &mut Context<Self>) {
+        self.pending_diff_focus = None;
         if let Some(active) = self.active.as_mut() {
             active.diff_open = true;
             active.right_tab = RightTab::Diff;
@@ -2862,9 +2876,50 @@ impl AppState {
         }
     }
 
+    /// Open a turn diff and focus one file after its async render cache lands.
+    pub fn open_diff_for_file(&mut self, turn: usize, path: String, cx: &mut Context<Self>) {
+        let Some(active) = self.active.as_mut() else {
+            return;
+        };
+        let session = active.meta.id.clone();
+        active.diff_open = true;
+        active.right_tab = RightTab::Diff;
+        active.diff_selected_turn = Some(turn);
+        self.set_diff_focus(session, turn, path);
+        self.diff_refresh_generation = self.diff_refresh_generation.wrapping_add(1);
+        cx.notify();
+    }
+
+    pub fn pending_diff_focus(&self) -> Option<&DiffFocusRequest> {
+        self.pending_diff_focus.as_ref()
+    }
+
+    fn set_diff_focus(&mut self, session: String, turn: usize, path: String) {
+        self.pending_diff_focus = Some(DiffFocusRequest {
+            session,
+            turn,
+            path,
+        });
+    }
+
+    /// Consume a request only for the cache it was created for.
+    pub fn take_diff_focus(&mut self, session: &str, turn: usize) -> Option<DiffFocusRequest> {
+        let matches = self
+            .pending_diff_focus
+            .as_ref()
+            .is_some_and(|request| request.session == session && request.turn == turn);
+        matches.then(|| self.pending_diff_focus.take()).flatten()
+    }
+
+    /// Cancel pending file navigation when the user chooses another scope.
+    pub fn discard_diff_focus(&mut self) {
+        self.pending_diff_focus = None;
+    }
+
     /// Open the diff panel on the latest turn with changes (used by
     /// `--open-diff` and as a general "just show me the diffs" entry point).
     pub fn open_diff_panel(&mut self, cx: &mut Context<Self>) {
+        self.pending_diff_focus = None;
         if let Some(active) = self.active.as_mut() {
             active.diff_open = true;
             active.right_tab = RightTab::Diff;
@@ -3190,6 +3245,7 @@ impl AppState {
     }
 
     pub fn close_diff_panel(&mut self, cx: &mut Context<Self>) {
+        self.pending_diff_focus = None;
         if let Some(active) = self.active.as_mut() {
             active.diff_open = false;
             // Closing during a turn suppresses auto-open for the rest of it.
@@ -4155,6 +4211,7 @@ impl AppState {
         if self.active_session_id() == Some(session_id) {
             return;
         }
+        self.pending_diff_focus = None;
         let Some(meta) = self.sessions.iter().find(|m| m.id == session_id).cloned() else {
             return;
         };
@@ -6385,6 +6442,7 @@ impl AppState {
     /// field docs); an idle one is shut down as before. Every "switch away" path
     /// goes through here; only destructive paths use `shutdown_active` directly.
     fn park_active(&mut self) {
+        self.pending_diff_focus = None;
         self.persist_terminal_preferences();
         let Some(mut active) = self.active.take() else {
             return;
@@ -7161,6 +7219,34 @@ fn truncate_title(text: &str) -> String {
 mod tests {
     use super::*;
     use gpui::AppContext as _;
+
+    #[test]
+    fn diff_file_focus_request_is_consumed_once_and_discarded_on_scope_change() {
+        let root =
+            std::env::temp_dir().join(format!("tcode-diff-focus-test-{}", uuid::Uuid::new_v4()));
+        let store = SessionStore::open_at(root.clone()).unwrap();
+        let mut state = AppState::new(store);
+
+        state.set_diff_focus("session-a".into(), 3, "src/second.rs".into());
+        assert_eq!(state.take_diff_focus("session-a", 2), None);
+        assert!(state.pending_diff_focus().is_some());
+        assert_eq!(
+            state.take_diff_focus("session-a", 3),
+            Some(DiffFocusRequest {
+                session: "session-a".into(),
+                turn: 3,
+                path: "src/second.rs".into(),
+            })
+        );
+        assert_eq!(state.take_diff_focus("session-a", 3), None);
+
+        state.set_diff_focus("session-a".into(), 3, "src/second.rs".into());
+        // The diff panel invokes this when its local scope selector changes.
+        state.discard_diff_focus();
+        assert!(state.pending_diff_focus().is_none());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
 
     #[test]
     fn generated_titles_are_cleaned_and_bounded() {

--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -2147,28 +2147,42 @@ impl ChatView {
                     );
                 }
                 for file in files {
+                    let path = file.path.clone();
+                    let row_label = format!("{}: {}", tcode_i18n::tr!("chat.view_diff"), file.path);
                     body = body.child(
-                        h_flex()
-                            .w_full()
-                            .pl(px(if dir.is_empty() { 8. } else { 28. }))
-                            .pr_2()
-                            .py_1()
-                            .gap_1p5()
-                            .items_center()
-                            .text_size(px(13.))
-                            .rounded(px(6.))
-                            .hover(|s| s.bg(cx.theme().list_hover))
-                            .child(Icon::new(IconName::File).xsmall().text_color(muted))
-                            .child(
-                                div()
-                                    .flex_1()
-                                    .min_w_0()
-                                    .overflow_hidden()
-                                    .text_ellipsis()
-                                    .font_family(cx.theme().mono_font_family.clone())
-                                    .child(file.name),
-                            )
-                            .child(diff_counts(file.added, file.deleted, cx)),
+                        crate::material::accessible_clickable(
+                            h_flex(),
+                            SharedString::from(format!("changed-file-{index}-{}", file.path)),
+                            Role::Button,
+                            row_label,
+                            cx,
+                        )
+                        .w_full()
+                        .pl(px(if dir.is_empty() { 8. } else { 28. }))
+                        .pr_2()
+                        .py_1()
+                        .gap_1p5()
+                        .items_center()
+                        .text_size(px(13.))
+                        .rounded(px(6.))
+                        .cursor_pointer()
+                        .hover(|s| s.bg(cx.theme().list_hover))
+                        .on_click(cx.listener(move |this, _, _, cx| {
+                            this.app_state.update(cx, |state, cx| {
+                                state.open_diff_for_file(index, path.clone(), cx)
+                            });
+                        }))
+                        .child(Icon::new(IconName::File).xsmall().text_color(muted))
+                        .child(
+                            div()
+                                .flex_1()
+                                .min_w_0()
+                                .overflow_hidden()
+                                .text_ellipsis()
+                                .font_family(cx.theme().mono_font_family.clone())
+                                .child(file.name),
+                        )
+                        .child(diff_counts(file.added, file.deleted, cx)),
                     );
                 }
             }
@@ -3183,6 +3197,7 @@ fn diff_stats(diff: Option<&str>) -> (u32, u32) {
 }
 
 struct FileRow {
+    path: String,
     name: String,
     added: u32,
     deleted: u32,
@@ -3201,6 +3216,7 @@ fn group_by_dir(changes: &[FileChange], cwd: &Path) -> Vec<(String, Vec<FileRow>
         };
         let (added, deleted) = diff_stats(change.diff.as_deref());
         let row = FileRow {
+            path: display,
             name,
             added,
             deleted,

--- a/crates/ui/src/diff_panel.rs
+++ b/crates/ui/src/diff_panel.rs
@@ -18,9 +18,9 @@ use std::sync::Arc;
 use agent::{FileChange, FileChangeKind};
 use gpui::{
     AnyElement, AppContext as _, Context, Entity, HighlightStyle, InteractiveElement as _,
-    IntoElement, ListAlignment, ListSizingBehavior, ListState, MouseButton, MouseDownEvent,
-    MouseMoveEvent, ParentElement as _, Render, Role, StatefulInteractiveElement as _, Styled as _,
-    StyledText, Subscription, Window, div, list, prelude::FluentBuilder as _, px,
+    IntoElement, ListAlignment, ListState, MouseButton, MouseDownEvent, MouseMoveEvent,
+    ParentElement as _, Render, Role, StatefulInteractiveElement as _, Styled as _, StyledText,
+    Subscription, Window, div, list, prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
     ActiveTheme as _, Icon, IconName, Selectable as _, Sizable as _, StyledExt as _,
@@ -558,6 +558,8 @@ struct DiffCache {
     files: Vec<RenderedFile>,
     unified_items: Vec<DiffListItem>,
     split_items: Vec<DiffListItem>,
+    unified_content_width: f32,
+    split_content_width: f32,
     unified_list: ListState,
     split_list: ListState,
 }
@@ -593,6 +595,66 @@ fn build_list_items(files: &[RenderedFile]) -> (Vec<DiffListItem>, Vec<DiffListI
         );
     }
     (unified, split)
+}
+
+/// Conservative monospace width used by the no-wrap virtual lists. GPUI's
+/// inferred list sizing renders and measures the viewport during both layout
+/// and prepaint; fixing the list width up front keeps rendering virtualized to
+/// prepaint while still giving the horizontal scroll container real overflow.
+fn diff_content_widths(files: &[RenderedFile]) -> (f32, f32) {
+    const MONO_ADVANCE: f32 = 8.;
+    const UNIFIED_CHROME: f32 = 106.; // border + two gutters + code padding
+    const SPLIT_CHROME: f32 = 117.; // two gutters + code padding + divider
+    const HEADER_CHROME: f32 = 180.;
+
+    let mut unified_columns = 0;
+    let mut split_columns = 0;
+    let mut header_columns = 0;
+    for file in files {
+        header_columns = header_columns.max(display_columns(&file.path));
+        for row in &file.rows {
+            if let RenderedRow::Code { text, .. } = row {
+                unified_columns = unified_columns.max(display_columns(text));
+            }
+        }
+        for row in &file.split_rows {
+            if let PairedRenderedRow::Pair { left, right } = row {
+                let columns = left
+                    .as_ref()
+                    .and_then(|(_, row)| rendered_row_text(row))
+                    .map(display_columns)
+                    .unwrap_or(0)
+                    + right
+                        .as_ref()
+                        .and_then(|(_, row)| rendered_row_text(row))
+                        .map(display_columns)
+                        .unwrap_or(0);
+                split_columns = split_columns.max(columns);
+            }
+        }
+    }
+
+    let header_width = header_columns as f32 * MONO_ADVANCE + HEADER_CHROME;
+    (
+        (unified_columns as f32 * MONO_ADVANCE + UNIFIED_CHROME).max(header_width),
+        (split_columns as f32 * MONO_ADVANCE + SPLIT_CHROME).max(header_width),
+    )
+}
+
+fn rendered_row_text(row: &RenderedRow) -> Option<&str> {
+    match row {
+        RenderedRow::Code { text, .. } => Some(text),
+        RenderedRow::Gap(_) => None,
+    }
+}
+
+fn display_columns(text: &str) -> usize {
+    text.chars().fold(0, |columns, ch| match ch {
+        '\t' => columns + (4 - columns % 4),
+        ch if ch.is_ascii_control() => columns,
+        ch if ch.is_ascii() => columns + 1,
+        _ => columns + 2,
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -638,6 +700,7 @@ pub struct DiffPanel {
     render_loading_key: Option<RenderKey>,
     selection: Option<CommentSelection>,
     comment_input: Option<Entity<InputState>>,
+    observed_review_comments: Vec<ReviewComment>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -646,8 +709,12 @@ impl DiffPanel {
         // Soft-wrap defaults to the user's "Word wrap in diffs" setting.
         let wrap = app_state.read(cx).settings.word_wrap_diffs;
         let plan = cx.new(|cx| PlanPanel::new(app_state.clone(), cx));
-        let subscriptions = vec![cx.observe(&app_state, |this, _, cx| {
-            this.remeasure_lists();
+        let subscriptions = vec![cx.observe(&app_state, |this, state, cx| {
+            let comments = state.read(cx).review_comments();
+            if this.observed_review_comments != comments {
+                this.observed_review_comments = comments.to_vec();
+                this.remeasure_lists();
+            }
             cx.notify();
         })];
         Self {
@@ -663,6 +730,7 @@ impl DiffPanel {
             render_loading_key: None,
             selection: None,
             comment_input: None,
+            observed_review_comments: Vec::new(),
             _subscriptions: subscriptions,
         }
     }
@@ -745,14 +813,21 @@ impl DiffPanel {
         self.cache = None;
         self.render_loading_key = Some(key.clone());
         cx.spawn(async move |this, cx| {
-            let (files, unified_items, split_items) =
+            let (files, unified_items, split_items, unified_content_width, split_content_width) =
                 tcode_runtime::blocking::unblock(cx.background_executor(), move || {
                     let files = changes
                         .iter()
                         .map(|change| render_file(change, &cwd, &theme))
                         .collect::<Vec<_>>();
                     let (unified_items, split_items) = build_list_items(&files);
-                    (files, unified_items, split_items)
+                    let (unified_content_width, split_content_width) = diff_content_widths(&files);
+                    (
+                        files,
+                        unified_items,
+                        split_items,
+                        unified_content_width,
+                        split_content_width,
+                    )
                 })
                 .await;
             let _ = this.update(cx, |panel, cx| {
@@ -769,6 +844,8 @@ impl DiffPanel {
                         files,
                         unified_items,
                         split_items,
+                        unified_content_width,
+                        split_content_width,
                         unified_list,
                         split_list,
                     });
@@ -1521,26 +1598,37 @@ impl DiffPanel {
         } else {
             cache.unified_list.clone()
         };
+        let content_width = if split {
+            cache.split_content_width
+        } else {
+            cache.unified_content_width
+        };
         let panel = cx.entity();
         let mut rows = list(list_state, move |index, _, cx| {
             panel.update(cx, |this, cx| this.render_list_item(index, split, cx))
         })
         .flex_1()
         .min_h_0()
+        .h_full()
         .text_size(px(13.))
         .font_family(cx.theme().mono_font_family.clone());
         if self.wrap {
             rows = rows.w_full();
         } else {
-            rows = rows.with_sizing_behavior(ListSizingBehavior::Infer);
+            rows = rows.min_w(px(content_width));
         }
 
-        let viewport = div()
+        let mut viewport = div()
             .id("diff-body")
             .flex_1()
             .min_h_0()
             .overflow_x_scroll()
             .child(rows);
+        // Do not let this horizontal overflow container translate ordinary
+        // vertical wheel input into horizontal movement. The event can then
+        // bubble to the List's vertical scroll handler; explicit horizontal
+        // wheel/trackpad deltas (or Shift-wheel) still scroll this viewport.
+        viewport.style().restrict_scroll_to_axis = Some(true);
         let mut content = v_flex().size_full().min_h_0().child(viewport);
 
         if let Some(preview) = self
@@ -2079,6 +2167,44 @@ impl Render for DiffPanel {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn display_columns_accounts_for_tabs_and_wide_characters() {
+        assert_eq!(display_columns("ab\tcd"), 6);
+        assert_eq!(display_columns("a界b"), 4);
+    }
+
+    #[test]
+    fn no_wrap_widths_cover_unified_and_split_rows() {
+        let rows = vec![
+            RenderedRow::Code {
+                kind: RowKind::Removed,
+                old: Some(1),
+                new: None,
+                text: "short".into(),
+                runs: Vec::new(),
+            },
+            RenderedRow::Code {
+                kind: RowKind::Added,
+                old: None,
+                new: Some(1),
+                text: "a much longer replacement".into(),
+                runs: Vec::new(),
+            },
+        ];
+        let files = vec![RenderedFile {
+            path: "src/example.rs".into(),
+            kind: FileChangeKind::Modify,
+            added: 1,
+            removed: 1,
+            split_rows: pair_rendered_rows(&rows),
+            rows,
+        }];
+
+        let (unified, split) = diff_content_widths(&files);
+        assert!(unified >= 24. * 8. + 106.);
+        assert!(split >= (5. + 24.) * 8. + 117.);
+    }
 
     #[test]
     fn parses_bare_create_diff() {

--- a/crates/ui/src/diff_panel.rs
+++ b/crates/ui/src/diff_panel.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use agent::{FileChange, FileChangeKind};
 use gpui::{
     AnyElement, AppContext as _, Context, Entity, HighlightStyle, InteractiveElement as _,
-    IntoElement, ListAlignment, ListState, MouseButton, MouseDownEvent, MouseMoveEvent,
+    IntoElement, ListAlignment, ListOffset, ListState, MouseButton, MouseDownEvent, MouseMoveEvent,
     ParentElement as _, Render, Role, StatefulInteractiveElement as _, Styled as _, StyledText,
     Subscription, Window, div, list, prelude::FluentBuilder as _, px,
 };
@@ -597,6 +597,13 @@ fn build_list_items(files: &[RenderedFile]) -> (Vec<DiffListItem>, Vec<DiffListI
     (unified, split)
 }
 
+fn file_header_index(files: &[RenderedFile], items: &[DiffListItem], path: &str) -> Option<usize> {
+    let file_index = files.iter().position(|file| file.path == path)?;
+    items
+        .iter()
+        .position(|item| matches!(item, DiffListItem::Header(index) if *index == file_index))
+}
+
 /// Conservative monospace width used by the no-wrap virtual lists. GPUI's
 /// inferred list sizing renders and measures the viewport during both layout
 /// and prepaint; fixing the list width up front keeps rendering virtualized to
@@ -750,6 +757,48 @@ impl DiffPanel {
         }
     }
 
+    fn apply_pending_file_focus(
+        &mut self,
+        session: &str,
+        scope: DiffScope,
+        cx: &mut Context<Self>,
+    ) {
+        let DiffScope::Turn(turn) = scope else {
+            return;
+        };
+        let request = self
+            .app_state
+            .read(cx)
+            .pending_diff_focus()
+            .filter(|request| request.session == session && request.turn == turn)
+            .cloned();
+        let Some(request) = request else {
+            return;
+        };
+        let Some(cache) = self
+            .cache
+            .as_ref()
+            .filter(|cache| cache.session == session && cache.scope == scope)
+        else {
+            return;
+        };
+        if let Some(index) = file_header_index(&cache.files, &cache.unified_items, &request.path) {
+            cache.unified_list.scroll_to(ListOffset {
+                item_ix: index,
+                offset_in_item: px(0.),
+            });
+        }
+        if let Some(index) = file_header_index(&cache.files, &cache.split_items, &request.path) {
+            cache.split_list.scroll_to(ListOffset {
+                item_ix: index,
+                offset_in_item: px(0.),
+            });
+        }
+        self.app_state.update(cx, |state, _| {
+            state.take_diff_focus(session, turn);
+        });
+    }
+
     fn request_git_preview(
         &mut self,
         session: String,
@@ -850,6 +899,7 @@ impl DiffPanel {
                         split_list,
                     });
                     panel.render_loading_key = None;
+                    panel.apply_pending_file_focus(&key.session, key.scope, cx);
                     cx.notify();
                 }
             });
@@ -860,6 +910,21 @@ impl DiffPanel {
     /// Rebuild the rendered-file cache when its key (session / turn / theme)
     /// changed. Returns whether there is anything to show.
     fn ensure_cache(&mut self, cx: &mut Context<Self>) -> bool {
+        let pending_focus = self.app_state.read(cx).pending_diff_focus().cloned();
+        if let Some(request) = pending_focus {
+            let is_active = self
+                .app_state
+                .read(cx)
+                .active_session_id()
+                .is_some_and(|session| session == request.session);
+            if is_active {
+                self.scopes
+                    .insert(request.session.clone(), DiffScope::Turn(request.turn));
+            } else {
+                self.app_state
+                    .update(cx, |state, _| state.discard_diff_focus());
+            }
+        }
         let debug = {
             let state = self.app_state.read(cx);
             state.active.as_ref().map(|active| {
@@ -959,6 +1024,7 @@ impl DiffPanel {
             );
             return false;
         }
+        self.apply_pending_file_focus(&session, scope, cx);
         let debug_comment = self.app_state.read(cx).debug_review_comment
             && self.app_state.read(cx).review_comments().is_empty();
         if debug_comment
@@ -1222,6 +1288,8 @@ impl DiffPanel {
                                         this.scopes.insert(session.clone(), scope);
                                         this.cache = None;
                                         this.selection = None;
+                                        this.app_state
+                                            .update(cx, |state, _| state.discard_diff_focus());
                                         cx.notify();
                                     });
                                     popover.update(cx, |state, cx| state.dismiss(window, cx));
@@ -1295,6 +1363,8 @@ impl DiffPanel {
                                     this.scopes.insert(session.clone(), DiffScope::Turn(turn));
                                     this.cache = None;
                                     this.selection = None;
+                                    this.app_state
+                                        .update(cx, |state, _| state.discard_diff_focus());
                                     cx.notify();
                                 });
                                 popover.update(cx, |st, cx| st.dismiss(window, cx));
@@ -2204,6 +2274,48 @@ mod tests {
         let (unified, split) = diff_content_widths(&files);
         assert!(unified >= 24. * 8. + 106.);
         assert!(split >= (5. + 24.) * 8. + 117.);
+    }
+
+    #[test]
+    fn resolves_file_headers_independently_for_unified_and_split_lists() {
+        let code_row = |text: &str| RenderedRow::Code {
+            kind: RowKind::Added,
+            old: None,
+            new: Some(1),
+            text: text.into(),
+            runs: Vec::new(),
+        };
+        let first_rows = vec![code_row("one"), code_row("two"), code_row("three")];
+        let second_rows = vec![code_row("replacement")];
+        let files = vec![
+            RenderedFile {
+                path: "src/first.rs".into(),
+                kind: FileChangeKind::Modify,
+                added: 3,
+                removed: 0,
+                split_rows: vec![PairedRenderedRow::Gap(7)],
+                rows: first_rows,
+            },
+            RenderedFile {
+                path: "tests/second.rs".into(),
+                kind: FileChangeKind::Modify,
+                added: 1,
+                removed: 0,
+                split_rows: pair_rendered_rows(&second_rows),
+                rows: second_rows,
+            },
+        ];
+        let (unified, split) = build_list_items(&files);
+
+        assert_eq!(
+            file_header_index(&files, &unified, "tests/second.rs"),
+            Some(4)
+        );
+        assert_eq!(
+            file_header_index(&files, &split, "tests/second.rs"),
+            Some(2)
+        );
+        assert_eq!(file_header_index(&files, &unified, "missing.rs"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two related diff-panel changes:

**1. Fix: scrolling the diff panel froze the app** (`2107a235`)

Root cause (confirmed with a `sample` stack trace of the hung process, 91.8% CPU): the gpui list's `ListSizingBehavior::Infer` re-rendered and measured every visible syntax-highlighted row during both `request_layout` and prepaint on every frame, while the `overflow_x_scroll` container translated ordinary vertical wheel deltas into horizontal scrolling, repeatedly invalidating the view.

- Replace inferred sizing with a background-precomputed conservative content width (list stays virtualized)
- Restrict the horizontal viewport to actual horizontal wheel deltas so vertical scrolling reaches the list
- Only remeasure lists when review comments actually change, not on every AppState notification

**2. Feature: changed-file rows navigate to the file in the diff panel** (`c1bfef2e`)

Each file row in a turn's CHANGED FILES card is now an accessible button: clicking opens the diff panel, selects that turn (overriding any local scope previously picked in the panel's dropdown), and scrolls both unified and split lists so the file's header sits at the top of the viewport. The one-shot focus request is consumed only when the matching async render cache lands, and is discarded on scope change, session switch, or panel close.

## Testing

- `cargo build -p tcode`, `cargo test -p tcode-ui` (151 passed), `cargo test -p tcode-runtime` (69 passed)
- Pre/post `sample` traces of the running app: the Infer layout hot path is gone
- Eyes-on in the running app: sustained wheel scrolling on a 3000+ row diff, split view, wrap toggle, horizontal scroll — no freeze
- Eyes-on: clicking a non-first file positions its header at the viewport top; with a Working-tree scope override active, clicking a file row correctly forces the panel back to the turn scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)