### PR TITLE
fix: fall back to distro-renamed Zed CLI binaries on Linux

### DIFF
--- a/crates/services/src/desktop.rs
+++ b/crates/services/src/desktop.rs
@@ -1,8 +1,52 @@
 use std::io;
 use std::path::Path;
 
+/// Command names the Zed CLI is installed under. Upstream's installer uses
+/// `zed`, but on Linux that collides with the ZFS event daemon (also `zed`),
+/// so several distributions rename the editor's binary — Zed's own packaging
+/// docs suggest `zedit`, `zeditor`, or `zed-cli`. Try each in turn; the first
+/// one present on PATH wins.
+const ZED_CLI_CANDIDATES: &[&str] = &["zed", "zeditor", "zed-cli", "zedit"];
+
 pub fn open_in_zed(cwd: &Path) -> io::Result<()> {
-    let child = crate::process::command("zed").arg(cwd).spawn()?;
-    drop(child);
-    Ok(())
+    open_with_candidates(ZED_CLI_CANDIDATES, cwd)
+}
+
+fn open_with_candidates(candidates: &[&str], cwd: &Path) -> io::Result<()> {
+    let mut not_found = None;
+    for cmd in candidates {
+        match crate::process::command(cmd).arg(cwd).spawn() {
+            Ok(child) => {
+                drop(child);
+                return Ok(());
+            }
+            // A missing binary just means this install uses a different name.
+            Err(err) if err.kind() == io::ErrorKind::NotFound => not_found = Some(err),
+            Err(err) => return Err(err),
+        }
+    }
+    Err(not_found.unwrap_or_else(|| io::Error::from(io::ErrorKind::NotFound)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn falls_through_missing_candidates_to_not_found() {
+        let result = open_with_candidates(
+            &[
+                "tcode-definitely-missing-cli-a",
+                "tcode-definitely-missing-cli-b",
+            ],
+            Path::new("."),
+        );
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn empty_candidate_list_is_not_found() {
+        let result = open_with_candidates(&[], Path::new("."));
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::NotFound);
+    }
 }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -642,7 +642,7 @@ errors:
   update_unknown: "Don't know how to update %{provider} automatically — please update it manually."
   worktree_add: "Failed to create worktree: %{error}"
   worktree_remove: "Failed to remove worktree: %{error}"
-  zed_cli_missing: "Zed CLI not found (install via Zed → Install CLI)"
+  zed_cli_missing: "Zed CLI not found (tried `zed`, `zeditor`, `zed-cli`; install via Zed → Install CLI)"
 notice:
   switched_branch: "Switched to %{branch}"
   dirty_tree: "Working tree has uncommitted changes"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -636,7 +636,7 @@ errors:
   update_unknown: "无法自动更新 %{provider}，请手动更新。"
   worktree_add: "创建工作树失败：%{error}"
   worktree_remove: "移除工作树失败：%{error}"
-  zed_cli_missing: "找不到 Zed CLI（请通过 Zed → Install CLI 安装）"
+  zed_cli_missing: "找不到 Zed CLI（已尝试 zed / zeditor / zed-cli；请通过 Zed → Install CLI 安装）"
 notice:
   switched_branch: "已切换到 %{branch}"
   dirty_tree: "工作树中有未提交的更改"


### PR DESCRIPTION
## Problem

On Linux, `zed` collides with the ZFS event daemon (`zed` from ZFS on Linux), so several distributions rename the editor's CLI binary — commonly `zeditor` (Arch, NixOS), following [Zed's own packaging guidance](https://zed.dev/docs/development/linux) (`zedit` / `zeditor` / `zed-cli`). tcode only spawned `zed`, so **Open in Zed** reported a missing CLI on those systems even though Zed was installed.

## Fix

Try each candidate name (`zed` → `zeditor` → `zed-cli` → `zedit`) in turn, skipping `NotFound` errors; the first binary on PATH wins. Mirrors upstream t3code's editor registry (`commands: ["zed", "zeditor"]` in `packages/contracts/src/editor.ts`).

Also updates the `errors.zed_cli_missing` strings (en / zh-CN) to list the names that were tried.

## Verification

- `cargo test -p tcode-services desktop` — 2 new unit tests pass (fallback skips missing candidates, empty list → `NotFound`)
- `cargo check -p tcode-ui -p tcode-i18n` — locale keys compile
- `cargo fmt --all --check` / `cargo clippy -p tcode-services --all-targets --locked` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)