### PR TITLE
feat(ui): draw Windows caption controls

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -8,7 +8,7 @@ use std::{borrow::Cow, time::Duration};
 
 use gpui::{
     App, AppContext as _, Entity, KeyBinding, ParentElement as _, Styled as _, TitlebarOptions,
-    WindowBackgroundAppearance, WindowBounds, WindowOptions, point, px, size,
+    WindowBackgroundAppearance, WindowBounds, WindowDecorations, WindowOptions, point, px, size,
 };
 use tcode_runtime::app::AppState;
 use tcode_services::{shell_env, store::SessionStore};
@@ -427,16 +427,25 @@ fn main() {
                 // macOS: seamless titlebar — transparent, with the traffic lights
                 // nudged down to sit vertically centered in the 52px top strip.
                 //
-                // Windows/Linux: a transparent titlebar means a *client-decorated*
-                // window, and we draw no minimize/maximize/close controls of our
-                // own (traffic_light_position is a macOS no-op) — the window would
-                // have no way to be closed from the chrome. So there we keep the
-                // native system titlebar; our top strip simply sits below it.
+                // Windows: also client-decorated — a transparent titlebar hides
+                // the system one — and `tcode_ui`'s window caption cluster draws
+                // the minimize/maximize/close controls into whichever top strip
+                // is rightmost (`crates/ui/src/window_caption.rs`).
+                //
+                // Linux: we draw no controls of our own there, so a transparent
+                // titlebar would leave the window with no way to be closed from
+                // the chrome. Keep the native system titlebar; our top strip
+                // simply sits below it.
                 titlebar: Some(TitlebarOptions {
                     title: None,
-                    appears_transparent: cfg!(target_os = "macos"),
+                    appears_transparent: cfg!(any(target_os = "macos", target_os = "windows")),
                     traffic_light_position: Some(point(px(12.), px(19.))),
                 }),
+                // Spell out that Windows is client-decorated. (This field is
+                // advisory off Wayland; leaving it `None` elsewhere keeps Linux
+                // on whatever its compositor/backend already chose.)
+                window_decorations: cfg!(target_os = "windows")
+                    .then_some(WindowDecorations::Client),
                 // macOS vibrancy: blur whatever is behind the window; theme
                 // background colors carry alpha so the material shows through.
                 window_background: if vibrancy_enabled() {

--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -38,6 +38,7 @@ use crate::git::{git_action_label_key, git_hint_key};
 use crate::markdown::{MarkdownState, MarkdownView};
 use crate::terminal_drawer::TerminalDrawer;
 use crate::time::now_millis;
+use crate::window_caption;
 use crate::window_drag_area;
 
 /// Content-column max width (T3 centers the timeline at ~760px). Shared with
@@ -2388,16 +2389,26 @@ impl ChatView {
         // lights (which sit at the window's top-left) overhang into the chat
         // header — inset the header content so the title clears them.
         let collapsed = self.app_state.read(cx).sidebar_collapsed;
+        // Windows: with no right panel open this header is the window's
+        // top-right corner, so it hosts the caption buttons — flush to the
+        // right edge, past the header's usual inset.
+        let hosts_caption = window_caption::hosts_caption(
+            window_caption::CaptionSurface::Chat,
+            self.app_state.read(cx),
+        );
         let base = h_flex()
             .flex_shrink_0()
             .h(px(52.))
             .px_4()
             .when(collapsed, |this| this.pl(px(40.)))
+            .when(hosts_caption, |this| this.pr_0())
             .gap_2()
             .items_center();
 
         // A draft shows a muted "New thread" label; an open thread its title;
-        // nothing active shows "No active thread".
+        // nothing active shows "No active thread". The title stretch carries no
+        // controls, so it doubles as the window's native drag handle where the
+        // platform needs one.
         let title_el = if is_draft {
             div()
                 .flex_1()
@@ -2440,7 +2451,7 @@ impl ChatView {
         let preview_showing = self.app_state.read(cx).preview_panel_showing();
         let terminal_open = self.app_state.read(cx).terminal_panel_open();
         window_drag_area("chat-header-drag", base, window, cx)
-            .child(title_el)
+            .child(window_caption::drag_region(title_el))
             .when(show_actions, |this| {
                 this.children(self.render_git_button(cx))
                     .children(cwd.clone().map(|cwd| self.render_open_button(cwd, cx)))
@@ -2503,6 +2514,9 @@ impl ChatView {
                             ),
                     )
             })
+            // Last child, so the header's own actions keep their places to the
+            // left of it.
+            .children(hosts_caption.then(|| window_caption::caption_controls(window, cx)))
             .into_any_element()
     }
 

--- a/crates/ui/src/diff_panel.rs
+++ b/crates/ui/src/diff_panel.rs
@@ -33,6 +33,7 @@ use gpui_component::{
 };
 
 use crate::plan_panel::PlanPanel;
+use crate::window_caption;
 use crate::{highlight, material};
 use tcode_core::session::{ReviewComment, ReviewSide};
 use tcode_runtime::app::{AppState, RightTab};
@@ -1091,10 +1092,16 @@ impl DiffPanel {
 
     // -- top strip (tab look + right icon cluster) --------------------------
 
-    fn render_tab_strip(&self, cx: &mut Context<Self>) -> AnyElement {
+    fn render_tab_strip(&self, window: &Window, cx: &mut Context<Self>) -> AnyElement {
         let state = self.app_state.read(cx);
         let expanded = state.diff_panel_expanded();
         let active = state.right_tab();
+        // Windows: the open Diff/Plan panel is the rightmost column, so this
+        // strip hosts the caption buttons. It is shorter than the 52px shell
+        // header, so grow it to match — the buttons must reach the window top,
+        // and a taller strip keeps the tabs aligned with the chat header.
+        let hosts_caption =
+            window_caption::hosts_caption(window_caption::CaptionSurface::RightPanel, state);
         // The second tab is "Plan" when a plan exists or the session is in Plan
         // mode, else "Tasks" (S1 §6).
         let plan_label = if state.plan_tab_active_label() {
@@ -1138,9 +1145,14 @@ impl DiffPanel {
             .role(Role::TabList)
             .aria_label(tcode_i18n::tr!("diff.panel_tabs"))
             .flex_none()
-            .h(px(40.))
+            .h(px(if hosts_caption {
+                window_caption::CAPTION_STRIP_HEIGHT
+            } else {
+                40.
+            }))
             .w_full()
             .px_2()
+            .when(hosts_caption, |strip| strip.pr_0())
             .gap_1()
             .items_center()
             .child(
@@ -1167,8 +1179,12 @@ impl DiffPanel {
                     app_plan.update(cx, |state, cx| state.set_right_tab(RightTab::Plan, cx));
                 }),
             )
+            // The gap between the tabs and the icon cluster holds nothing, so
+            // it doubles as the window's native drag handle where one is needed.
+            // `h_full` is load-bearing: the strip centers its children, so
+            // without it the drag hitbox collapses to zero height.
+            .child(window_caption::drag_region(div().flex_1().h_full()))
             // Right icon cluster: expand toggle, a layout no-op, close.
-            .child(div().flex_1())
             .child(
                 Button::new("diff-expand")
                     .ghost()
@@ -1207,6 +1223,8 @@ impl DiffPanel {
                         app2.update(cx, |state, cx| state.close_diff_panel(cx));
                     }),
             )
+            // Last child: the panel's own actions keep their places to its left.
+            .children(hosts_caption.then(|| window_caption::caption_controls(window, cx)))
             .into_any_element()
     }
 
@@ -2212,14 +2230,14 @@ impl DiffPanel {
 }
 
 impl Render for DiffPanel {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         self.ensure_cache(cx);
         let tab = self.app_state.read(cx).right_tab();
         let mut root = v_flex()
             .size_full()
             .min_w_0()
             .text_color(cx.theme().foreground)
-            .child(self.render_tab_strip(cx));
+            .child(self.render_tab_strip(window, cx));
         root = match tab {
             // Preview is rendered by its own panel (see ui/mod.rs); the diff
             // container only handles Diff/Plan, so treat Preview as the diff view

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -30,6 +30,7 @@ mod sidebar;
 mod terminal_drawer;
 pub mod time;
 pub(crate) mod toast;
+mod window_caption;
 mod workspace_walk;
 
 pub(crate) use shell::window_drag_area;

--- a/crates/ui/src/preview_panel.rs
+++ b/crates/ui/src/preview_panel.rs
@@ -78,7 +78,7 @@ mod native {
 
     use gpui::{
         AnyElement, AppContext as _, Context, Entity, IntoElement, ParentElement as _, Render,
-        Styled as _, Subscription, Window, div,
+        Styled as _, Subscription, Window, div, prelude::FluentBuilder as _, px,
     };
     use gpui_component::{
         ActiveTheme as _, IconName, Sizable as _,
@@ -94,6 +94,7 @@ mod native {
     use super::{
         ReplyTx, normalize_url, preview_key_for_session, unavailable_message, visible_preview_key,
     };
+    use crate::window_caption;
     use tcode_runtime::app::AppState;
 
     pub struct PreviewPanel {
@@ -691,19 +692,35 @@ mod native {
 
             v_flex()
                 .size_full()
-                .child(self.render_chrome(cx))
+                .child(self.render_chrome(window, cx))
                 .children(self.render_port_row(cx))
                 .child(body)
         }
     }
 
     impl PreviewPanel {
-        fn render_chrome(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        fn render_chrome(&self, window: &Window, cx: &mut Context<Self>) -> impl IntoElement {
+            // Windows: an open Preview tab is the rightmost column, so its
+            // chrome row hosts the caption buttons. The row is normally only as
+            // tall as its controls — pin it to the shell's 52px top strip and
+            // drop the trailing/vertical padding on the caption side so the
+            // buttons reach the window's true top-right corner.
+            let hosts_caption = window_caption::hosts_caption(
+                window_caption::CaptionSurface::Preview,
+                self.app_state.read(cx),
+            );
             h_flex()
                 .flex_none()
                 .w_full()
                 .gap_1()
                 .p_1()
+                .when(hosts_caption, |chrome| {
+                    chrome
+                        .h(px(window_caption::CAPTION_STRIP_HEIGHT))
+                        .pt_0()
+                        .pb_0()
+                        .pr_0()
+                })
                 .child(
                     Button::new("preview-back")
                         .ghost()
@@ -750,6 +767,8 @@ mod native {
                         .tooltip(tcode_i18n::tr!("preview.open_external"))
                         .on_click(cx.listener(|this, _, _, cx| this.open_in_system_browser(cx))),
                 )
+                // Last child, so the chrome's own controls stay to its left.
+                .children(hosts_caption.then(|| window_caption::caption_controls(window, cx)))
         }
 
         /// A row of quick-pick buttons for discovered localhost dev ports.

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -36,6 +36,7 @@ use crate::settings::{
 };
 use crate::shell::Quit;
 use crate::time::now_secs;
+use crate::window_caption;
 use crate::window_drag_area;
 
 /// Left inset so branding clears the native macOS 26 traffic lights near x=72.
@@ -524,6 +525,16 @@ impl SettingsPage {
     // -- content ------------------------------------------------------------
 
     fn render_header(&self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
+        // Windows: the settings route replaces the workspace, so this header is
+        // the window's top-right corner and hosts the caption buttons. The
+        // centered column must keep its position (it aligns with the content
+        // below), so the cluster is placed out of flow at the strip's right edge
+        // and the column reserves matching trailing room for it — its actions
+        // therefore end left of the buttons rather than under them.
+        let hosts_caption = window_caption::hosts_caption(
+            window_caption::CaptionSurface::Settings,
+            self.app_state.read(cx),
+        );
         // The 52px strip spans the paper full-width (drag area), but its title
         // and actions ride the same centered 768px column as the content below,
         // the way the chat header aligns with its timeline column.
@@ -535,7 +546,8 @@ impl SettingsPage {
                 .w_full()
                 .px_6()
                 .justify_center()
-                .items_center(),
+                .items_center()
+                .when(hosts_caption, |strip| strip.relative()),
             window,
             cx,
         )
@@ -543,15 +555,20 @@ impl SettingsPage {
             gpui_component::h_flex()
                 .w(px(CONTENT_MAX_WIDTH))
                 .max_w_full()
+                .when(hosts_caption, |column| {
+                    column.pr(px(window_caption::CAPTION_CLUSTER_WIDTH))
+                })
                 .items_center()
                 .gap_3()
-                .child(
+                // The title stretch carries no controls, so it doubles as the
+                // window's native drag handle where the platform needs one.
+                .child(window_caption::drag_region(
                     div()
                         .flex_1()
                         .text_size(px(15.))
                         .font_medium()
                         .child(tcode_i18n::tr!("settings.title")),
-                )
+                ))
                 .child(
                     Button::new("restore-defaults")
                         .outline()
@@ -563,6 +580,15 @@ impl SettingsPage {
                         })),
                 ),
         )
+        // Painted last so the cluster stays on top of the strip.
+        .children(hosts_caption.then(|| {
+            div()
+                .absolute()
+                .top_0()
+                .right_0()
+                .h_full()
+                .child(window_caption::caption_controls(window, cx))
+        }))
         .into_any_element()
     }
 

--- a/crates/ui/src/window_caption.rs
+++ b/crates/ui/src/window_caption.rs
@@ -1,0 +1,290 @@
+//! Windows-only caption controls: minimize, maximize/restore, close.
+//!
+//! On Windows the window is client-decorated (`crates/app/src/main.rs` marks the
+//! titlebar transparent there), so the system draws no caption buttons and the
+//! app must supply them. macOS keeps its native traffic lights and Linux keeps
+//! its system titlebar, so on both this module renders nothing.
+//!
+//! The window has no titlebar row of its own: the sidebar, chat and right-panel
+//! columns all run to the window top. So the cluster rides the top strip of
+//! whichever column is currently *rightmost* — [`caption_host`] is that routing
+//! rule, kept platform-parameterized so it stays testable off Windows, and it
+//! returns at most one surface so no layout can render two clusters.
+//!
+//! The buttons are hit-tested natively: each declares a
+//! [`gpui::WindowControlArea`], which the Windows backend answers `WM_NCHITTEST`
+//! with (`HTMINBUTTON`/`HTMAXBUTTON`/`HTCLOSE`). That gives real Windows
+//! behavior — snap layouts on maximize hover included — and means the buttons
+//! need no click handlers of their own and are never part of the surrounding
+//! drag area.
+
+use gpui::{
+    App, InteractiveElement, IntoElement, ParentElement as _, StatefulInteractiveElement as _,
+    Styled as _, Window, WindowControlArea, div, px,
+};
+use gpui_component::ActiveTheme as _;
+use tcode_runtime::app::{AppState, RightTab, Route};
+
+/// Height of a caption strip. Matches the shell's 52px top rows so the cluster
+/// sits flush with the window top on every host surface.
+pub(crate) const CAPTION_STRIP_HEIGHT: f32 = 52.;
+/// Width of one button — the width Windows uses for its own caption buttons.
+const CAPTION_BUTTON_WIDTH: f32 = 46.;
+/// Horizontal space the whole cluster occupies, for surfaces that must reserve
+/// room for it rather than simply place it last in a row.
+pub(crate) const CAPTION_CLUSTER_WIDTH: f32 = CAPTION_BUTTON_WIDTH * 3.;
+/// The system icon font Windows 11 ships; it carries the caption glyphs below.
+const CAPTION_FONT: &str = "Segoe Fluent Icons";
+
+/// Whether this build owns its window chrome and must draw caption buttons.
+const CLIENT_DECORATED: bool = cfg!(target_os = "windows");
+
+/// A top strip that can host the caption cluster.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CaptionSurface {
+    /// The chat header — rightmost when no right panel is open.
+    Chat,
+    /// The Diff/Plan panel's tab strip.
+    RightPanel,
+    /// The Preview panel's chrome row.
+    Preview,
+    /// The settings content header (the settings route replaces the workspace).
+    Settings,
+}
+
+/// Which surface's top strip owns the window's top-right corner, or `None` when
+/// the platform draws its own caption buttons.
+fn caption_host(
+    client_decorated: bool,
+    route: Route,
+    right_panel_open: bool,
+    right_tab: RightTab,
+) -> Option<CaptionSurface> {
+    if !client_decorated {
+        return None;
+    }
+    Some(match route {
+        // Settings replaces the whole workspace; its content paper is rightmost.
+        Route::Settings => CaptionSurface::Settings,
+        Route::Chat if !right_panel_open => CaptionSurface::Chat,
+        Route::Chat if right_tab == RightTab::Preview => CaptionSurface::Preview,
+        // Diff and Plan share the one right-panel container.
+        Route::Chat => CaptionSurface::RightPanel,
+    })
+}
+
+/// Whether `surface` must render the caption cluster this frame.
+pub(crate) fn hosts_caption(surface: CaptionSurface, state: &AppState) -> bool {
+    caption_host(
+        CLIENT_DECORATED,
+        state.route,
+        state.diff_panel_open(),
+        state.right_tab(),
+    ) == Some(surface)
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CaptionButton {
+    Minimize,
+    MaximizeRestore,
+    Close,
+}
+
+impl CaptionButton {
+    const fn id(self) -> &'static str {
+        match self {
+            Self::Minimize => "window-caption-minimize",
+            Self::MaximizeRestore => "window-caption-maximize",
+            Self::Close => "window-caption-close",
+        }
+    }
+
+    const fn area(self) -> WindowControlArea {
+        match self {
+            Self::Minimize => WindowControlArea::Min,
+            Self::MaximizeRestore => WindowControlArea::Max,
+            Self::Close => WindowControlArea::Close,
+        }
+    }
+
+    /// Segoe Fluent Icons: ChromeMinimize, ChromeMaximize, ChromeRestore,
+    /// ChromeClose — the glyphs Windows' own caption buttons use.
+    const fn glyph(self, maximized: bool) -> &'static str {
+        match self {
+            Self::Minimize => "\u{e921}",
+            Self::MaximizeRestore if maximized => "\u{e923}",
+            Self::MaximizeRestore => "\u{e922}",
+            Self::Close => "\u{e8bb}",
+        }
+    }
+}
+
+/// Mark an *inert* stretch of a top strip as the window's drag handle.
+///
+/// [`crate::window_drag_area`] moves the window with `start_window_move` and
+/// zooms it with `titlebar_double_click` — both no-ops on Windows, where the
+/// only way to drag (and to double-click-maximize, and to get snap) is a native
+/// `HTCAPTION` region. So on Windows the strips additionally hand their empty
+/// area to the platform.
+///
+/// Apply this only to elements with no controls inside: an `HTCAPTION` area
+/// swallows clicks on anything under it that does not [`InteractiveElement::occlude`]
+/// itself — which is exactly why the caption buttons above do occlude.
+pub(crate) fn drag_region<E: InteractiveElement>(el: E) -> E {
+    if CLIENT_DECORATED {
+        el.window_control_area(WindowControlArea::Drag)
+    } else {
+        el
+    }
+}
+
+/// The caption cluster, in Windows order: minimize, maximize/restore, close.
+/// Call only when [`hosts_caption`] is true for the surface being rendered.
+pub(crate) fn caption_controls(window: &Window, cx: &App) -> impl IntoElement {
+    let maximized = window.is_maximized();
+    div()
+        .id("window-caption")
+        .flex()
+        .flex_none()
+        .h_full()
+        .items_center()
+        .child(caption_button(CaptionButton::Minimize, maximized, cx))
+        .child(caption_button(
+            CaptionButton::MaximizeRestore,
+            maximized,
+            cx,
+        ))
+        .child(caption_button(CaptionButton::Close, maximized, cx))
+}
+
+fn caption_button(button: CaptionButton, maximized: bool, cx: &App) -> impl IntoElement {
+    // Close is destructive, so it takes the full danger fill; the ordinary
+    // controls stay subtle. The glyph on that fill is `primary_foreground`
+    // (white in both modes) — Windows' own white close glyph. Not
+    // `danger_foreground`: that token is the *red* used to write danger text on
+    // a normal background, so it would be red-on-red here.
+    let (hover_bg, pressed_bg, active_fg) = if button == CaptionButton::Close {
+        (
+            cx.theme().danger,
+            cx.theme().danger_active,
+            cx.theme().primary_foreground,
+        )
+    } else {
+        (
+            cx.theme().accent,
+            cx.theme().secondary_active,
+            cx.theme().foreground,
+        )
+    };
+
+    div()
+        .id(button.id())
+        .flex()
+        .flex_none()
+        .h_full()
+        .w(px(CAPTION_BUTTON_WIDTH))
+        .items_center()
+        .justify_center()
+        .text_color(cx.theme().muted_foreground)
+        // Native hit-testing: no click handlers needed.
+        .window_control_area(button.area())
+        // Blocking the mouse ends gpui's hit test at this button, so neither the
+        // header's drag listeners nor any enclosing `Drag` control area is in
+        // the hit set — the platform sees a caption button, never a drag area.
+        .occlude()
+        .font_family(CAPTION_FONT)
+        .text_size(px(10.))
+        .hover(move |style| style.bg(hover_bg).text_color(active_fg))
+        .active(move |style| style.bg(pressed_bg).text_color(active_fg))
+        .child(button.glyph(maximized))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SURFACES: [CaptionSurface; 4] = [
+        CaptionSurface::Chat,
+        CaptionSurface::RightPanel,
+        CaptionSurface::Preview,
+        CaptionSurface::Settings,
+    ];
+    const ROUTES: [Route; 2] = [Route::Chat, Route::Settings];
+    const TABS: [RightTab; 3] = [RightTab::Diff, RightTab::Plan, RightTab::Preview];
+
+    #[test]
+    fn chat_hosts_the_cluster_when_no_right_panel_is_open() {
+        for tab in TABS {
+            assert_eq!(
+                caption_host(true, Route::Chat, false, tab),
+                Some(CaptionSurface::Chat),
+                "closed right panel leaves chat rightmost (remembered tab {tab:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn the_right_panel_hosts_the_cluster_for_diff_and_plan() {
+        for tab in [RightTab::Diff, RightTab::Plan] {
+            assert_eq!(
+                caption_host(true, Route::Chat, true, tab),
+                Some(CaptionSurface::RightPanel),
+                "{tab:?} shares the diff container"
+            );
+        }
+    }
+
+    #[test]
+    fn preview_hosts_the_cluster_when_it_is_the_open_tab() {
+        assert_eq!(
+            caption_host(true, Route::Chat, true, RightTab::Preview),
+            Some(CaptionSurface::Preview)
+        );
+    }
+
+    #[test]
+    fn the_settings_header_hosts_the_cluster_on_the_settings_route() {
+        // Settings replaces the workspace, whatever the chat layout was.
+        for open in [false, true] {
+            for tab in TABS {
+                assert_eq!(
+                    caption_host(true, Route::Settings, open, tab),
+                    Some(CaptionSurface::Settings)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn exactly_one_surface_hosts_the_cluster_in_every_layout() {
+        for route in ROUTES {
+            for open in [false, true] {
+                for tab in TABS {
+                    let hosting = SURFACES
+                        .into_iter()
+                        .filter(|surface| caption_host(true, route, open, tab) == Some(*surface))
+                        .count();
+                    assert_eq!(
+                        hosting, 1,
+                        "route {route:?}, right panel open {open}, tab {tab:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn no_surface_hosts_the_cluster_without_client_decorations() {
+        for route in ROUTES {
+            for open in [false, true] {
+                for tab in TABS {
+                    assert_eq!(
+                        caption_host(false, route, open, tab),
+                        None,
+                        "macOS and Linux keep their platform chrome"
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- switch the Windows app window to GPUI client-side decorations with a transparent titlebar
- add Windows-native minimize, maximize/restore, and close hit-test regions using `WindowControlArea`
- render exactly one caption-control cluster in the current rightmost top surface: Chat, Diff/Plan, Preview, or Settings
- preserve macOS traffic lights and Linux native window decorations
- add focused routing tests covering every route, panel, and tab combination

## Why

Windows previously kept the operating-system titlebar because tcode did not draw its own caption controls. That left the app chrome inconsistent with the seamless in-app top strip used on macOS. This follows the proven Furray implementation while retaining native Windows hit testing, including maximize hover and snap semantics.

## User impact

On Windows, the system titlebar is replaced by caption buttons integrated into the existing top strip. Existing panel actions remain to the left of the caption cluster, and maximize changes to restore when the window is maximized.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tcode-ui window_caption` — 6 passed
- `cargo check -p tcode`
- `cargo check -p tcode --target x86_64-pc-windows-gnu`

A Windows GUI runtime was not available locally, so rendering and mouse interaction are verified theoretically through the known-good Furray pattern, GPUI Windows `WindowControlArea` implementation, unit tests, and Windows cross-compilation rather than an on-device screenshot or click-through.