### PR TITLE
feat(app): use Mica backdrop on Windows 11

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -23,15 +23,29 @@ use gpui_component::{
 
 const TCODE_THEME: &str = include_str!("../../../themes/tcode.json");
 
-/// On platforms with an opaque window the translucent canvas colors would
-/// composite against black; flatten them to their solid RGB. Keep the literals
-/// in sync with themes/tcode.json (checked by `smoke` builds via debug_assert).
-/// Vibrancy is macOS-only and can be disabled with `TCODE_NO_VIBRANCY=1`
-/// (diagnostic escape hatch: opaque window + flattened palette).
+/// macOS vibrancy can be disabled with `TCODE_NO_VIBRANCY=1` as a diagnostic
+/// escape hatch (opaque window + flattened palette).
 fn vibrancy_enabled() -> bool {
     cfg!(target_os = "macos") && !std::env::var("TCODE_NO_VIBRANCY").is_ok_and(|v| v == "1")
 }
 
+fn translucent_canvas_enabled() -> bool {
+    cfg!(target_os = "windows") || vibrancy_enabled()
+}
+
+fn main_window_background() -> WindowBackgroundAppearance {
+    if cfg!(target_os = "windows") {
+        WindowBackgroundAppearance::MicaBackdrop
+    } else if vibrancy_enabled() {
+        WindowBackgroundAppearance::Blurred
+    } else {
+        WindowBackgroundAppearance::Opaque
+    }
+}
+
+/// With an opaque window the translucent canvas colors would composite against
+/// black; flatten them to their solid RGB. Keep the literals in sync with
+/// themes/tcode.json (checked by `smoke` builds via debug_assert).
 fn flatten_canvas_for_opaque_window(theme_json: &str) -> String {
     let flattened = theme_json
         .replace("#F2F4F7C7", "#F2F4F7")
@@ -298,12 +312,11 @@ fn main() {
             cx.text_system()
                 .add_fonts(application_fonts)
                 .expect("failed to register bundled application fonts");
-            // The theme's canvas color is translucent so the macOS vibrancy
-            // material shows through (docs/visual-redesign.md). Elsewhere the
-            // window is opaque and that alpha would composite against black,
-            // so flatten the canvas onto each mode's solid base first. (macOS
-            // fullscreen flattens at paint time instead: material::opaque_canvas.)
-            let theme_json: Cow<'_, str> = if vibrancy_enabled() {
+            // The theme's canvas color stays translucent over macOS vibrancy
+            // and Windows Mica (docs/visual-redesign.md). Opaque windows flatten
+            // it onto each mode's solid base first. (macOS fullscreen flattens
+            // at paint time instead: material::opaque_canvas.)
+            let theme_json: Cow<'_, str> = if translucent_canvas_enabled() {
                 Cow::Borrowed(TCODE_THEME)
             } else {
                 Cow::Owned(flatten_canvas_for_opaque_window(TCODE_THEME))
@@ -446,13 +459,9 @@ fn main() {
                 // on whatever its compositor/backend already chose.)
                 window_decorations: cfg!(target_os = "windows")
                     .then_some(WindowDecorations::Client),
-                // macOS vibrancy: blur whatever is behind the window; theme
-                // background colors carry alpha so the material shows through.
-                window_background: if vibrancy_enabled() {
-                    WindowBackgroundAppearance::Blurred
-                } else {
-                    WindowBackgroundAppearance::Opaque
-                },
+                // Persistent windows use the platform's system material:
+                // macOS blur, Windows 11 base Mica, or an opaque fallback.
+                window_background: main_window_background(),
                 ..Default::default()
             };
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -46,6 +46,17 @@ success-fg / destructive-fg.
 
 Canonical values live in `themes/tcode.json` (embedded at build time).
 
+## Window material
+
+The persistent main window uses the native long-lived-window material: macOS
+uses its existing blurred vibrancy, while Windows 11 uses base Mica
+(`WindowBackgroundAppearance::MicaBackdrop`, `DWMSBT_MAINWINDOW`). Acrylic is
+reserved for transient surfaces such as menus and popovers, not the main
+window. Both native materials retain the embedded theme's translucent canvas so
+the system backdrop can show through. `TCODE_NO_VIBRANCY=1` keeps its macOS-only
+diagnostic behavior: an opaque window with a flattened canvas. Linux and other
+platforms remain opaque and flatten that canvas to its solid RGB base.
+
 ## Layout metrics (at 1440×900)
 
 - Sidebar 255px, resizable; 1px right border; collapses to a 48px icon strip.

--- a/docs/visual-redesign.md
+++ b/docs/visual-redesign.md
@@ -7,7 +7,8 @@
 ## 核心理念
 
 玻璃机壳 + 纸面阅读区 + 一条蓝色墨线贯穿。
-侧栏与窗口边缘是毛玻璃"机壳"（macOS vibrancy），正文坐在一块近实的"纸面"上；
+侧栏与窗口边缘是系统材质"机壳"（macOS vibrancy / Windows 11 Mica），
+正文坐在一块近实的"纸面"上；
 蓝色从单一按钮色升级为贯穿选中、聚焦、强调的墨线体系。
 观感目标：一台精密仪器，而不是一个网页。用户气泡保持中性灰（用户已拍板）。
 
@@ -15,14 +16,19 @@
 
 - gpui `WindowBackgroundAppearance::Blurred`（仅 macOS）在 Metal 层下垫
   `NSVisualEffectView`；合成后 alpha < 1 的区域透出桌面毛玻璃。
+- Windows 11 的持久主窗口使用 base Mica
+  （`WindowBackgroundAppearance::MicaBackdrop` / `DWMSBT_MAINWINDOW`）；Acrylic
+  仅用于菜单、弹层等瞬态表面，不用于长驻主窗口。
 - 全窗口仅一层 blur；悬浮层半透明与其下窗口内容做普通 alpha 合成。
 - gpui-component `Root` 用 `colors.background` 涂画布，支持 8 位 hex alpha。
   **AppShell 不得重复涂 `background`**（已移除）——全屏例外：全屏 Space 的
   vibrancy 背景是纯黑，AppShell 根节点仅在全屏时垫一层不透明基色
   （`material::opaque_canvas`，把画布 alpha 提到 1），窗口模式仍由 Root 独自涂玻璃。
-  与 Windows Acrylic `FallbackColor`、macOS「降低透明度」同一降级策略。
-- 非 macOS：窗口 Opaque；main.rs 的 `flatten_canvas_for_opaque_window`
-  把画布色压平为实色（与 JSON 字面量保持同步）。
+  与 Windows 材质不可用时的回退、macOS「降低透明度」同一降级策略。
+- macOS vibrancy 与 Windows Mica 保留画布 alpha，使系统材质可见；Linux
+  及其他平台使用 Opaque，main.rs 的 `flatten_canvas_for_opaque_window`
+  把画布色压平为实色（与 JSON 字面量保持同步）。`TCODE_NO_VIBRANCY=1`
+  仍只在 macOS 上切换为 Opaque 并压平画布。
 
 ## 1. 材质分层
 


### PR DESCRIPTION
## Summary

- use GPUI base Mica for the persistent Windows 11 main window
- retain the translucent theme canvas on Windows so the native backdrop remains visible
- preserve macOS vibrancy and opaque fallbacks, and document the Mica/Acrylic boundary

## Verification

- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo build --locked
- cargo test --workspace --locked