### PR TITLE
fix(ui): bundle Windows caption icons

### DIFF
--- a/crates/ui/src/assets.rs
+++ b/crates/ui/src/assets.rs
@@ -102,3 +102,28 @@ impl AssetSource for Assets {
         Ok(paths)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn component_caption_icons_load_through_assets_facade() {
+        for path in [
+            "icons/window-minimize.svg",
+            "icons/window-maximize.svg",
+            "icons/window-restore.svg",
+            "icons/window-close.svg",
+        ] {
+            let bytes = AssetSource::load(&Assets, path)
+                .unwrap_or_else(|error| panic!("failed to load {path}: {error}"))
+                .unwrap_or_else(|| panic!("asset was not found: {path}"));
+
+            assert!(!bytes.is_empty(), "asset was empty: {path}");
+            assert!(
+                String::from_utf8_lossy(&bytes).contains("<svg"),
+                "asset was not an SVG document: {path}"
+            );
+        }
+    }
+}

--- a/crates/ui/src/window_caption.rs
+++ b/crates/ui/src/window_caption.rs
@@ -22,7 +22,7 @@ use gpui::{
     App, InteractiveElement, IntoElement, ParentElement as _, StatefulInteractiveElement as _,
     Styled as _, Window, WindowControlArea, div, px,
 };
-use gpui_component::ActiveTheme as _;
+use gpui_component::{ActiveTheme as _, Icon, IconName, Sizable as _};
 use tcode_runtime::app::{AppState, RightTab, Route};
 
 /// Height of a caption strip. Matches the shell's 52px top rows so the cluster
@@ -33,9 +33,6 @@ const CAPTION_BUTTON_WIDTH: f32 = 46.;
 /// Horizontal space the whole cluster occupies, for surfaces that must reserve
 /// room for it rather than simply place it last in a row.
 pub(crate) const CAPTION_CLUSTER_WIDTH: f32 = CAPTION_BUTTON_WIDTH * 3.;
-/// The system icon font Windows 11 ships; it carries the caption glyphs below.
-const CAPTION_FONT: &str = "Segoe Fluent Icons";
-
 /// Whether this build owns its window chrome and must draw caption buttons.
 const CLIENT_DECORATED: bool = cfg!(target_os = "windows");
 
@@ -107,14 +104,12 @@ impl CaptionButton {
         }
     }
 
-    /// Segoe Fluent Icons: ChromeMinimize, ChromeMaximize, ChromeRestore,
-    /// ChromeClose — the glyphs Windows' own caption buttons use.
-    const fn glyph(self, maximized: bool) -> &'static str {
+    fn icon(self, maximized: bool) -> IconName {
         match self {
-            Self::Minimize => "\u{e921}",
-            Self::MaximizeRestore if maximized => "\u{e923}",
-            Self::MaximizeRestore => "\u{e922}",
-            Self::Close => "\u{e8bb}",
+            Self::Minimize => IconName::WindowMinimize,
+            Self::MaximizeRestore if maximized => IconName::WindowRestore,
+            Self::MaximizeRestore => IconName::WindowMaximize,
+            Self::Close => IconName::WindowClose,
         }
     }
 }
@@ -192,11 +187,9 @@ fn caption_button(button: CaptionButton, maximized: bool, cx: &App) -> impl Into
         // header's drag listeners nor any enclosing `Drag` control area is in
         // the hit set — the platform sees a caption button, never a drag area.
         .occlude()
-        .font_family(CAPTION_FONT)
-        .text_size(px(10.))
         .hover(move |style| style.bg(hover_bg).text_color(active_fg))
         .active(move |style| style.bg(pressed_bg).text_color(active_fg))
-        .child(button.glyph(maximized))
+        .child(Icon::new(button.icon(maximized)).small())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What changed

- render Windows minimize, maximize/restore, and close controls with the SVG icons already embedded by `gpui-component-assets`
- remove the `Segoe Fluent Icons` system-font and PUA glyph dependency
- add a test proving all four caption SVGs load through the tcode `Assets` facade

## Why

PR #133 followed the Furray implementation and used `Segoe Fluent Icons`. That font ships with Windows 11 but is not included by default on Windows 10, where private-use glyphs cannot rely on normal font fallback. The existing GPUI component asset bundle already provides deterministic SVG resources for all four caption states.

## User impact

Caption controls now render from assets embedded in the application binary on every supported Windows version, while native `WindowControlArea` hit testing, maximize/restore switching, hover states, and layout remain unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tcode-ui window_caption` — 6 passed
- `cargo test -p tcode-ui assets` — 1 passed and loaded all four SVGs
- `cargo check -p tcode`
- `cargo check -p tcode --target x86_64-pc-windows-gnu`