### PR TITLE
fix(ui): fully hide collapsed sidebar

### DIFF
--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -48,6 +48,10 @@ pub(crate) const CONTENT_MAX_WIDTH: f32 = 768.;
 /// Minimum horizontal padding around the content column so bubbles/cards never
 /// clip when the chat region is narrowed (e.g. the diff panel is open).
 pub(crate) const CONTENT_MIN_PADDING: f32 = 24.;
+/// Left padding on the chat header while the sidebar is collapsed, so its
+/// leading control clears the native macOS traffic lights (which end near x=72
+/// on macOS 26). Only applied on macOS: see `render_header`.
+const TRAFFIC_LIGHT_INSET: f32 = 80.;
 /// How many activity rows to show before the "+N previous log entrys" expander.
 const WORKLOG_VISIBLE_ROWS: usize = 2;
 
@@ -2385,10 +2389,14 @@ impl ChatView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
-        // With the sidebar collapsed to its 48px strip, the native traffic
-        // lights (which sit at the window's top-left) overhang into the chat
-        // header — inset the header content so the title clears them.
+        // Collapsed, the sidebar has zero width and this header starts at the
+        // window's left edge. On macOS the native traffic lights sit there, so
+        // the row's leading content (the sidebar toggle) is inset past them —
+        // but only when the platform actually draws them: they are hidden in
+        // fullscreen, and other platforms never had them.
         let collapsed = self.app_state.read(cx).sidebar_collapsed;
+        let clears_traffic_lights =
+            cfg!(target_os = "macos") && collapsed && !window.is_fullscreen();
         // Windows: with no right panel open this header is the window's
         // top-right corner, so it hosts the caption buttons — flush to the
         // right edge, past the header's usual inset.
@@ -2400,10 +2408,35 @@ impl ChatView {
             .flex_shrink_0()
             .h(px(52.))
             .px_4()
-            .when(collapsed, |this| this.pl(px(40.)))
+            .when(clears_traffic_lights, |this| {
+                this.pl(px(TRAFFIC_LIGHT_INSET))
+            })
             .when(hosts_caption, |this| this.pr_0())
             .gap_2()
             .items_center();
+
+        // The sidebar toggle: the header's first control, immediately left of
+        // the title. It lives here rather than in the sidebar because a
+        // collapsed sidebar occupies no width at all (`crate::shell`), so a
+        // control mounted inside it would have nowhere to be.
+        let sidebar_toggle = Button::new("toggle-sidebar")
+            .ghost()
+            .small()
+            .compact()
+            .icon(if collapsed {
+                IconName::PanelLeftOpen
+            } else {
+                IconName::PanelLeft
+            })
+            .tooltip(if collapsed {
+                tcode_i18n::tr!("sidebar.expand")
+            } else {
+                tcode_i18n::tr!("sidebar.collapse")
+            })
+            .on_click(cx.listener(|this, _, _, cx| {
+                this.app_state
+                    .update(cx, |state, cx| state.toggle_sidebar_collapsed(cx));
+            }));
 
         // A draft shows a muted "New thread" label; an open thread its title;
         // nothing active shows "No active thread". The title stretch carries no
@@ -2451,6 +2484,7 @@ impl ChatView {
         let preview_showing = self.app_state.read(cx).preview_panel_showing();
         let terminal_open = self.app_state.read(cx).terminal_panel_open();
         window_drag_area("chat-header-drag", base, window, cx)
+            .child(sidebar_toggle)
             .child(window_caption::drag_region(title_el))
             .when(show_actions, |this| {
                 this.children(self.render_git_button(cx))

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -4,11 +4,12 @@ use std::rc::Rc;
 
 use gpui::{
     AnyElement, App, AppContext as _, Context, Div, ElementId, Entity, InteractiveElement as _,
-    IntoElement, MouseButton, MouseDownEvent, ParentElement as _, Pixels, Render, Styled as _,
-    Subscription, Window, actions, div, prelude::FluentBuilder as _, px,
+    IntoElement, MouseButton, MouseDownEvent, ParentElement as _, Pixels, Render,
+    StatefulInteractiveElement as _, Styled as _, Subscription, Window, actions, div,
+    prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
-    ActiveTheme as _, Root, WindowExt as _, h_flex,
+    ActiveTheme as _, Root, WindowExt as _,
     notification::Notification,
     resizable::{ResizableState, h_resizable, resizable_panel},
 };
@@ -115,12 +116,42 @@ pub struct AppShell {
     /// Keep restoring the sidebar width until the panel reports it, then stop
     /// so the restore never fights an in-progress drag.
     sidebar_restore_pending: bool,
+    /// Collapsed-only overlay visibility. Purely transient and never persisted;
+    /// expanded/non-workspace renders clear it synchronously.
+    sidebar_overlay_visible: bool,
     _subscriptions: Vec<Subscription>,
 }
 
 /// The right panel's default width (`docs/DESIGN.md`).
 const RIGHT_PANEL_WIDTH: f32 = 560.;
 const SIDEBAR_WIDTH: f32 = 255.;
+/// Collapsed only: width of the window's left-edge activation region.
+const SIDEBAR_HOVER_EDGE: f32 = 12.;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SidebarHoverTransition {
+    Trigger(bool),
+    Overlay(bool),
+}
+
+/// Apply the asymmetric sibling-hover contract. The fixed trigger can open the
+/// overlay but cannot close it; once mounted, the overlay owns closing itself.
+fn next_sidebar_overlay_visibility(
+    currently_visible: bool,
+    transition: SidebarHoverTransition,
+    collapsed: bool,
+    route: Route,
+) -> bool {
+    if !collapsed || route != Route::Chat {
+        return false;
+    }
+
+    match transition {
+        SidebarHoverTransition::Trigger(true) | SidebarHoverTransition::Overlay(true) => true,
+        SidebarHoverTransition::Trigger(false) => currently_visible,
+        SidebarHoverTransition::Overlay(false) => false,
+    }
+}
 
 impl AppShell {
     pub fn new(app_state: Entity<AppState>, window: &mut Window, cx: &mut Context<Self>) -> Self {
@@ -188,6 +219,7 @@ impl AppShell {
             sidebar_width: Rc::new(Cell::new(px(SIDEBAR_WIDTH))),
             last_viewport_width: None,
             sidebar_restore_pending: false,
+            sidebar_overlay_visible: false,
             _subscriptions: vec![subscription, event_subscription],
         }
     }
@@ -314,6 +346,11 @@ impl Render for AppShell {
         }
         self.palette_was_open = palette_open;
         let collapsed = self.app_state.read(cx).sidebar_collapsed;
+        // The overlay is workspace-only transient state. Clear it synchronously
+        // on route/expanded transitions rather than waiting for pointer input.
+        if !collapsed || route != Route::Chat {
+            self.sidebar_overlay_visible = false;
+        }
         let diff_open = self.app_state.read(cx).diff_panel_open();
         let right_tab = self.app_state.read(cx).right_tab();
         // "Expanded" (full-width) is a diff-only affordance; the preview tab
@@ -475,19 +512,81 @@ impl Render for AppShell {
         };
 
         let workspace: AnyElement = if collapsed {
-            // `h_flex` centers its children on the cross axis, so the icon strip
-            // needs an explicit full height — without it it (and the whole chat
-            // column) float vertically centered in the window.
-            h_flex()
+            // Zero layout width: the chat/right group owns the whole workspace
+            // and runs to the window's left edge. The trigger and overlay are
+            // independent absolute siblings, so neither reflows the columns.
+            let overlay_width = self.sidebar_width.get();
+            div()
+                .relative()
                 .size_full()
+                .child(group("chat-diff-panels").child(chat_panel).child(right))
+                // This fixed transparent strip only opens the overlay. Its
+                // inevitable false transition when the overlay occludes it is
+                // deliberately ignored by the state machine.
                 .child(
                     div()
-                        .flex_none()
-                        .w(px(48.))
+                        .id("sidebar-hover-trigger")
+                        .absolute()
+                        .left_0()
+                        .top_0()
                         .h_full()
-                        .child(self.sidebar.clone()),
+                        .w(px(SIDEBAR_HOVER_EDGE))
+                        .occlude()
+                        .on_hover(cx.listener(|this, hovered: &bool, _, cx| {
+                            let (collapsed, route) = {
+                                let state = this.app_state.read(cx);
+                                (state.sidebar_collapsed, state.route)
+                            };
+                            let visible = next_sidebar_overlay_visibility(
+                                this.sidebar_overlay_visible,
+                                SidebarHoverTransition::Trigger(*hovered),
+                                collapsed,
+                                route,
+                            );
+                            if this.sidebar_overlay_visible != visible {
+                                this.sidebar_overlay_visible = visible;
+                                cx.notify();
+                            }
+                        })),
                 )
-                .child(group("chat-diff-panels").child(chat_panel).child(right))
+                .when(self.sidebar_overlay_visible, |this| {
+                    this.child(
+                        div()
+                            .id("sidebar-hover-overlay")
+                            .absolute()
+                            .left_0()
+                            .top_0()
+                            .h_full()
+                            .w(overlay_width)
+                            // The sidebar fill is translucent, so back the
+                            // floating layer with the near-opaque popover surface
+                            // to prevent the chat beneath from bleeding through.
+                            .bg(cx.theme().popover)
+                            .shadow_lg()
+                            .border_r_1()
+                            .border_color(cx.theme().border)
+                            // The blocker and hover listener share this hitbox:
+                            // the overlay owns its full visible lifetime.
+                            .occlude()
+                            .on_hover(cx.listener(|this, hovered: &bool, _, cx| {
+                                let (collapsed, route) = {
+                                    let state = this.app_state.read(cx);
+                                    (state.sidebar_collapsed, state.route)
+                                };
+                                let visible = next_sidebar_overlay_visibility(
+                                    this.sidebar_overlay_visible,
+                                    SidebarHoverTransition::Overlay(*hovered),
+                                    collapsed,
+                                    route,
+                                );
+                                if this.sidebar_overlay_visible != visible {
+                                    this.sidebar_overlay_visible = visible;
+                                    cx.notify();
+                                }
+                            }))
+                            .child(self.sidebar.clone()),
+                    )
+                })
                 .into_any_element()
         } else {
             group("workspace-panels")
@@ -533,5 +632,56 @@ impl Render for AppShell {
             .children(sheet_layer)
             .children(dialog_layer)
             .children(notification_layer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn transition(current: bool, transition: SidebarHoverTransition) -> bool {
+        next_sidebar_overlay_visibility(current, transition, true, Route::Chat)
+    }
+
+    #[test]
+    fn trigger_true_opens_overlay() {
+        assert!(transition(false, SidebarHoverTransition::Trigger(true)));
+    }
+
+    #[test]
+    fn trigger_false_preserves_current_visibility() {
+        assert!(!transition(false, SidebarHoverTransition::Trigger(false)));
+        assert!(transition(true, SidebarHoverTransition::Trigger(false)));
+    }
+
+    #[test]
+    fn overlay_true_opens_or_keeps_overlay_open() {
+        assert!(transition(false, SidebarHoverTransition::Overlay(true)));
+        assert!(transition(true, SidebarHoverTransition::Overlay(true)));
+    }
+
+    #[test]
+    fn overlay_false_closes_overlay() {
+        assert!(!transition(true, SidebarHoverTransition::Overlay(false)));
+    }
+
+    #[test]
+    fn expanded_sidebar_forces_overlay_closed() {
+        assert!(!next_sidebar_overlay_visibility(
+            true,
+            SidebarHoverTransition::Overlay(true),
+            false,
+            Route::Chat,
+        ));
+    }
+
+    #[test]
+    fn non_workspace_route_forces_overlay_closed() {
+        assert!(!next_sidebar_overlay_visibility(
+            true,
+            SidebarHoverTransition::Overlay(true),
+            true,
+            Route::Settings,
+        ));
     }
 }

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -697,23 +697,10 @@ impl SessionsSidebar {
                 .font_semibold()
                 .child("DEV"),
         )
+        // The collapse toggle lives in the chat header (`crate::chat`), not
+        // here: collapsing takes the sidebar to zero width, so a control that
+        // rode the sidebar would take itself off screen.
         .child(div().flex_1())
-        // Far right of the sidebar header (macOS sidebar-toggle convention);
-        // sitting next to the traffic lights it reads as a misaligned fourth
-        // light.
-        .child(
-            Button::new("collapse-sidebar")
-                .ghost()
-                .small()
-                .compact()
-                .icon(IconName::PanelLeft)
-                .tooltip(tcode_i18n::tr!("sidebar.collapse"))
-                .on_click(cx.listener(|this, _, _, cx| {
-                    this.app_state.update(cx, |state, cx| {
-                        state.toggle_sidebar_collapsed(cx);
-                    });
-                })),
-        )
     }
 
     fn render_search_row(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -1357,48 +1344,6 @@ impl SessionsSidebar {
                 ),
             )
     }
-
-    fn render_collapsed(&self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        v_flex()
-            .size_full()
-            // No seam against the content column: material contrast does the work.
-            .bg(cx.theme().sidebar)
-            .items_center()
-            .pb_2()
-            .gap_2()
-            .child(window_drag_area(
-                "sidebar-collapsed-drag",
-                h_flex().h(px(52.)).w_full().flex_none(),
-                window,
-                cx,
-            ))
-            .child(
-                Button::new("expand-sidebar")
-                    .ghost()
-                    .small()
-                    .compact()
-                    .icon(IconName::PanelLeftOpen)
-                    .tooltip(tcode_i18n::tr!("sidebar.expand"))
-                    .on_click(cx.listener(|this, _, _, cx| {
-                        this.app_state.update(cx, |state, cx| {
-                            state.toggle_sidebar_collapsed(cx);
-                        });
-                    })),
-            )
-            .child(div().flex_1())
-            .child(
-                Button::new("collapsed-settings")
-                    .ghost()
-                    .small()
-                    .compact()
-                    .icon(IconName::Settings)
-                    .tooltip(tcode_i18n::tr!("settings.title"))
-                    .on_click(cx.listener(|this, _, _, cx| {
-                        this.app_state
-                            .update(cx, |state, cx| state.open_settings(cx));
-                    })),
-            )
-    }
 }
 
 /// Delete `session_id`, first asking whether to also remove an orphaned worktree.
@@ -1453,10 +1398,6 @@ fn proceed_delete(
 
 impl Render for SessionsSidebar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        if self.app_state.read(cx).sidebar_collapsed {
-            return self.render_collapsed(window, cx).into_any_element();
-        }
-
         let (groups, active_id, turn_running) = {
             let state = self.app_state.read(cx);
             let active_id = state.active_session_id().map(str::to_string);

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -61,10 +61,13 @@ opaque `popover.background` token so lower layers never show through.
 
 ## Layout metrics (at 1440×900)
 
-- Sidebar 255px, resizable; 1px right border; collapses to a 48px icon strip.
+- Sidebar 255px, resizable; 1px right border. Collapsed it occupies **0px** —
+  no icon strip, no layout node at all: the chat (and right panel) run to the
+  window's left edge. Collapsed, entering the first 12px at the window's left
+  edge reveals the sidebar as an **overlay** (see Sidebar below).
 - Window top is seamless: no app titlebar — the sidebar's first row (traffic
-  lights inset 74px, collapse button, wordmark + channel pill) and the chat
-  header (52px) form the top strip; both are window-drag areas.
+  lights inset 74px, wordmark + channel pill) and the chat header (52px) form
+  the top strip; both are window-drag areas.
 - Chat content column: max-width 768px, centered, ≥24px horizontal padding
   (must reflow, never clip, when the diff panel narrows the chat region).
 - Composer: floating card, radius 16, 1px border, subtle shadow; bottom control
@@ -88,7 +91,22 @@ remains.
 ## Surface anatomy
 
 ### Sidebar
-1. App row: collapse icon button, "tcode" bold 14px, channel pill ("DEV").
+Expanded, it is the first panel of the workspace resizable group (220–380px,
+dragged width remembered across collapse/expand and window resizes). Collapsed,
+it is **not in the layout at all**. A fixed, invisible 12px-wide element-level
+hover trigger sits at the left edge and only opens the sidebar. The revealed
+sidebar is a separate absolute sibling at its remembered width, rendered as a
+shadowed overlay
+*painted on top of* the chat: the content columns never reflow when it appears
+or disappears. The trigger ignores hover-exit; the overlay's own occluding
+hitbox and hover listener keep it open while occupied and close it when the
+pointer leaves. It is strictly transient state, never persisted, and command
+palette / dialogs / toasts still layer above it. Its own contents are identical
+in both states.
+
+1. App row: "tcode" bold 14px, channel pill ("DEV"). No collapse button — the
+   toggle lives in the chat header, since a collapsed sidebar has no width to
+   host it.
 2. Search row: magnifier + "Search" muted + ⌘K kbd chip → opens the palette.
 3. "PROJECTS" header: 11px uppercase muted + sort (no-op) + add-project button
    (native directory picker).
@@ -104,8 +122,14 @@ remains.
 5. Footer: gear + "Settings" → settings route.
 
 ### Chat header
-52px; thread title 16px medium left ("No active thread" muted when empty);
-right: two icon buttons (layout placeholder · diff-panel toggle).
+52px. The first control is the **sidebar toggle**, immediately left of the
+title: `PanelLeft` + "Collapse sidebar" while expanded, `PanelLeftOpen` +
+"Expand sidebar" while collapsed. Then the thread title 16px medium ("No active
+thread" muted when empty); right: the git/Open actions and the terminal · plan ·
+preview · diff panel toggles. The title stretch is the window-drag handle; the
+toggle is a real button and never arms a drag. Collapsed on macOS (windowed) the
+row is inset 80px so the toggle clears the native traffic lights; no other
+platform pays that inset.
 
 ### Timeline
 - **Turn separation is rhythm, not rules.** Turns are 44px apart; inside a turn


### PR DESCRIPTION
## Summary

- move the sidebar toggle into the chat content header, immediately before the title
- remove the collapsed sidebar strip so chat content uses the full window width
- reveal a full floating sidebar from a fixed, invisible 12px element-level hover trigger at the left edge
- keep the overlay interactive while the pointer moves across it, and close it only after leaving the overlay
- document the zero-width collapsed and floating-overlay behavior

## Interaction contract

The trigger and overlay are separate sibling elements. Entering the invisible 12px trigger opens the overlay; leaving the trigger alone does not close it because the overlay occludes that hitbox. Entering the overlay keeps it open, and leaving the overlay closes it. Expanded mode and non-chat routes force the overlay closed.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo build --locked`
- `cargo test --workspace --locked`
- `git diff --check origin/main...HEAD`

Native UI verification in an isolated app bundle/data directory:

- collapsing removes the sidebar completely
- moving to x=6 opens the overlay
- moving through x=80, x=160, and x=240 keeps it open and interactive
- sidebar Search remains usable
- moving past the overlay to x=300 closes it
- three repeated open/stay/close cycles passed
- the overlay uses the opaque popover surface with no content bleed-through
