### PR TITLE
fix(app): use Acrylic backdrop on Windows

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -34,9 +34,7 @@ fn translucent_canvas_enabled() -> bool {
 }
 
 fn main_window_background() -> WindowBackgroundAppearance {
-    if cfg!(target_os = "windows") {
-        WindowBackgroundAppearance::MicaBackdrop
-    } else if vibrancy_enabled() {
+    if cfg!(target_os = "windows") || vibrancy_enabled() {
         WindowBackgroundAppearance::Blurred
     } else {
         WindowBackgroundAppearance::Opaque
@@ -313,7 +311,7 @@ fn main() {
                 .add_fonts(application_fonts)
                 .expect("failed to register bundled application fonts");
             // The theme's canvas color stays translucent over macOS vibrancy
-            // and Windows Mica (docs/visual-redesign.md). Opaque windows flatten
+            // and Windows Acrylic (docs/visual-redesign.md). Opaque windows flatten
             // it onto each mode's solid base first. (macOS fullscreen flattens
             // at paint time instead: material::opaque_canvas.)
             let theme_json: Cow<'_, str> = if translucent_canvas_enabled() {
@@ -460,7 +458,7 @@ fn main() {
                 window_decorations: cfg!(target_os = "windows")
                     .then_some(WindowDecorations::Client),
                 // Persistent windows use the platform's system material:
-                // macOS blur, Windows 11 base Mica, or an opaque fallback.
+                // macOS blur, Windows Acrylic, or an opaque fallback.
                 window_background: main_window_background(),
                 ..Default::default()
             };

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -48,16 +48,19 @@ Canonical values live in `themes/tcode.json` (embedded at build time).
 
 ## Window material
 
-The persistent main window uses the native long-lived-window material: macOS
-uses its existing blurred vibrancy, while Windows 11 uses base Mica
-(`WindowBackgroundAppearance::MicaBackdrop`, `DWMSBT_MAINWINDOW`). Acrylic is
-reserved for transient surfaces such as menus and popovers, not the main
-window. Both native materials retain the embedded theme's translucent canvas so
-the system backdrop can show through. `TCODE_NO_VIBRANCY=1` keeps its macOS-only
+The persistent main window uses native backdrop material: macOS keeps its
+existing blurred vibrancy, while Windows deliberately uses GPUI's
+`WindowBackgroundAppearance::Blurred`, which the locked Windows backend maps to
+Acrylic Accent state 4. Mica was rejected because it did not provide the
+perceptible live background-through blur required in the exposed T0 sidebar and
+window-edge regions. Both native materials retain the embedded theme's
+translucent canvas so the system backdrop can show through.
+`TCODE_NO_VIBRANCY=1` keeps its macOS-only
 diagnostic behavior: an opaque window with a flattened canvas. Linux and other
 platforms remain opaque and flatten that canvas to its solid RGB base. In-app
 T3 child surfaces (popovers, menus, dialogs, drawers and toasts) use the fully
-opaque `popover.background` token so lower layers never show through.
+opaque `popover.background` token so lower layers never show through; they do
+not receive native Acrylic.
 
 ## Layout metrics (at 1440×900)
 

--- a/docs/visual-redesign.md
+++ b/docs/visual-redesign.md
@@ -7,25 +7,27 @@
 ## 核心理念
 
 玻璃机壳 + 纸面阅读区 + 一条蓝色墨线贯穿。
-侧栏与窗口边缘是系统材质"机壳"（macOS vibrancy / Windows 11 Mica），
+侧栏与窗口边缘是系统材质"机壳"（macOS vibrancy / Windows 11 Acrylic），
 正文坐在一块近实的"纸面"上；
 蓝色从单一按钮色升级为贯穿选中、聚焦、强调的墨线体系。
 观感目标：一台精密仪器，而不是一个网页。用户气泡保持中性灰（用户已拍板）。
 
 ## 0. 技术底座（已验证）
 
-- gpui `WindowBackgroundAppearance::Blurred`（仅 macOS）在 Metal 层下垫
+- gpui `WindowBackgroundAppearance::Blurred` 在 macOS Metal 层下垫
   `NSVisualEffectView`；合成后 alpha < 1 的区域透出桌面毛玻璃。
-- Windows 11 的持久主窗口使用 base Mica
-  （`WindowBackgroundAppearance::MicaBackdrop` / `DWMSBT_MAINWINDOW`）；Acrylic
-  仅用于菜单、弹层等瞬态表面，不用于长驻主窗口。
-- 全窗口仅一层 blur；悬浮层半透明与其下窗口内容做普通 alpha 合成。
+- Windows 11 的持久主窗口也刻意使用
+  `WindowBackgroundAppearance::Blurred`；锁定的 GPUI Windows 后端将其映射为
+  Acrylic Accent state 4，使暴露的 T0 侧栏／窗口边缘能感知窗口后方实时变化并保持模糊。
+  Mica 因无法达到本产品所需的可感知实时 background-through blur 而被否决。
+- 全窗口仅一层原生 blur；应用内 popover/menu/dialog/drawer/toast 保持全不透明，
+  不会各自获得原生 Acrylic。
 - gpui-component `Root` 用 `colors.background` 涂画布，支持 8 位 hex alpha。
   **AppShell 不得重复涂 `background`**（已移除）——全屏例外：全屏 Space 的
   vibrancy 背景是纯黑，AppShell 根节点仅在全屏时垫一层不透明基色
   （`material::opaque_canvas`，把画布 alpha 提到 1），窗口模式仍由 Root 独自涂玻璃。
   与 Windows 材质不可用时的回退、macOS「降低透明度」同一降级策略。
-- macOS vibrancy 与 Windows Mica 保留画布 alpha，使系统材质可见；Linux
+- macOS vibrancy 与 Windows Acrylic 保留画布 alpha，使系统材质可见；Linux
   及其他平台使用 Opaque，main.rs 的 `flatten_canvas_for_opaque_window`
   把画布色压平为实色（与 JSON 字面量保持同步）。`TCODE_NO_VIBRANCY=1`
   仍只在 macOS 上切换为 Opaque 并压平画布。
@@ -182,7 +184,7 @@ material.rs 常量，禁止再写魔法数字：
 
 ## 9. 实施地图
 
-1. ✅ main.rs：Blurred 窗口（macOS gate）+ flatten fallback
+1. ✅ main.rs：Blurred 窗口（macOS vibrancy / Windows Acrylic）+ flatten fallback
 2. ✅ shell.rs：去重复涂底；chat/right/settings 涂纸面
 3. ✅ token 层：theme JSON 全表 + material.rs（常量与 helper）
 4. 组件清扫（并行，文件禁区严格隔离）：


### PR DESCRIPTION
## What changed

- replace the Windows main-window `MicaBackdrop` with GPUI `Blurred`
- retain the existing translucent T0 canvas so the Windows compositor can show live blurred content behind the sidebar and window edges
- preserve macOS vibrancy, its diagnostic opaque fallback, and Linux/other opaque behavior
- update the design contract to record the Acrylic decision and keep in-app child surfaces opaque

## Why

Mica derives a subtle backdrop from wallpaper and system theme, but it does not provide the perceptible live background-through effect expected here. The locked GPUI Windows backend maps `WindowBackgroundAppearance::Blurred` to Acrylic Accent state 4, which matches the intended frosted-glass behavior.

## User impact

On Windows 11, exposed T0 regions can now react to windows moving or changing behind tcode with a blurred color shift, while reading surfaces and popovers retain their existing opacity and legibility.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo build --locked`
- focused retries for three PTY tests, all passing individually
- `cargo test --workspace --locked -- --test-threads=1`

The local machine intermittently returned OS error `-6` while allocating multiple PTYs in parallel; failures moved between unrelated terminal tests. The serial full suite passed, and the unchanged parallel command remains enforced by the three-platform PR CI.
