### PR TITLE
fix(ci): make AUR release retryable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,7 +321,7 @@ jobs:
   publish-aur:
     name: Publish to AUR
     needs: [setup, finalize]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && needs.setup.outputs.prerelease == 'false'
+    if: needs.setup.outputs.prerelease == 'false' && ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-24.04
     container: archlinux:base-devel
     env:
@@ -376,6 +376,8 @@ jobs:
         working-directory: aur-repo
         run: |
           git config --global --add safe.directory "$PWD"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if git diff --quiet; then
             echo "No changes. AUR package is already up to date."
             exit 0


### PR DESCRIPTION
## What changed

- configure a repository-local `github-actions[bot]` name and email before committing AUR metadata
- allow the AUR job to run for a stable existing tag supplied through `workflow_dispatch`
- preserve stable tag-push behavior while continuing to exclude prereleases and ordinary branch pushes

## Why

The `v0.1.30` release successfully built and published all six platform packages and checksums, but the final AUR job failed at `git commit` with `Author identity unknown`. PR #140 fixed the preceding `safe.directory` failure; this supplies the next missing Git prerequisite and makes the existing-tag manual dispatch path usable for recovery.

Failed run: https://github.com/Tryanks/tcode/actions/runs/29918798422

## Impact

After this merges, dispatching the Release workflow with `tag=v0.1.30` can rebuild/clobber the existing release assets and finish the AUR publish without creating another version.

## Validation

- `git diff --check`
- YAML parsed with Ruby/Psych (`yaml-ok`)
- `actionlint -ignore 'SC2129' -ignore 'SC2035' .github/workflows/release.yml` (the ignored findings are pre-existing shell-style warnings outside this diff)
- reviewed the job condition truth table for stable tag push, stable manual dispatch, prerelease, and ordinary branch push
