### PR TITLE
feat(ui): show per-turn AI and tool timing

### DIFF
--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -177,6 +177,12 @@ pub struct TurnMeta {
     /// snapshots replace this wholesale; structured file-operation items form
     /// a partial fallback without consulting the ambient Git working tree.
     pub changes: Option<TurnChangeSet>,
+    /// Wall-clock breakdown of the finished turn. `None` while the turn runs,
+    /// whenever the turn lacks a timestamped `TurnStarted`/`TurnCompleted` pair
+    /// to measure against, and whenever the recorded clock regressed across the
+    /// turn's end — a missing or untrustworthy timestamp yields no breakdown
+    /// rather than an invented one.
+    pub timing: Option<TurnTiming>,
 }
 
 impl TurnMeta {
@@ -186,6 +192,223 @@ impl TurnMeta {
             (Some(start), Some(end)) if end >= start => Some((end - start) / 1000),
             _ => None,
         }
+    }
+}
+
+/// How a finished turn's wall clock divided between waiting on tools and
+/// everything else (the model thinking and answering). Millisecond based, and
+/// derived purely from the timestamps already recorded on the event stream, so
+/// a live session and a replay of its log agree exactly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct TurnTiming {
+    /// The observed `TurnStarted`..`TurnCompleted` span.
+    pub total_ms: u64,
+    /// The union of the intervals in which at least one tool-like item was in
+    /// progress. Tools running in parallel are counted once, never summed.
+    pub tool_ms: u64,
+}
+
+impl TurnTiming {
+    /// Build a breakdown. Tool time is already intersected with the turn's
+    /// bounds by [`ToolClock`]; the clamp here is only a last-resort guard that
+    /// keeps `ai_ms() + tool_ms == total_ms` true for hand-built values.
+    pub fn new(total_ms: u64, tool_ms: u64) -> Self {
+        Self {
+            total_ms,
+            tool_ms: tool_ms.min(total_ms),
+        }
+    }
+
+    /// The complement of the tool time inside the turn: the model thinking and
+    /// responding, plus any provider overhead between tool calls.
+    pub fn ai_ms(&self) -> u64 {
+        self.total_ms - self.tool_ms
+    }
+
+    /// The three durations in whole seconds. Truncation is absorbed by the AI
+    /// part so the rendered parts still sum to the rendered total.
+    pub fn secs(&self) -> TurnTimingSecs {
+        let total = self.total_ms / 1000;
+        let tools = (self.tool_ms / 1000).min(total);
+        TurnTimingSecs {
+            total,
+            ai: total - tools,
+            tools,
+        }
+    }
+}
+
+/// A [`TurnTiming`] rounded down to whole seconds for display.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TurnTimingSecs {
+    pub total: u64,
+    pub ai: u64,
+    pub tools: u64,
+}
+
+/// Running union-of-intervals accounting for the tool-like items of the open
+/// turn, intersected with the turn's own `TurnStarted`..`TurnCompleted` bounds.
+/// Only the current turn can have items in flight, so one accumulator is
+/// enough; it resets whenever a turn opens.
+#[derive(Debug, Clone, Default)]
+struct ToolClock {
+    /// Item ids currently known to be in progress.
+    open: HashSet<String>,
+    /// Start of the interval that opened when `open` became non-empty.
+    union_start: Option<u64>,
+    /// Union of the closed tool-active intervals so far, in ms.
+    tool_ms: u64,
+    /// Latest timestamp observed anywhere inside the turn — tool lifecycle
+    /// events, ordinary items, and deltas alike. It clamps a clock that steps
+    /// backwards, and it is the watermark a completion must not precede.
+    clock: Option<u64>,
+    /// The authoritative turn start: the timestamp of the observed
+    /// `TurnStarted`. Tool time is measured from here, never earlier, and its
+    /// absence means the turn gets no breakdown at all.
+    turn_start: Option<u64>,
+    /// A tool-like item was observed without a timestamp, so this turn cannot
+    /// produce a trustworthy breakdown.
+    untimed: bool,
+}
+
+impl ToolClock {
+    /// Anchor the clock to the authoritative `TurnStarted` time. Anything
+    /// accumulated before it belonged to earlier work and is discarded; a tool
+    /// still open across the boundary is rebased to begin exactly at the turn
+    /// start, so only the in-bounds part of its interval counts.
+    fn begin_turn(&mut self, ts: u64) {
+        self.advance(ts);
+        self.turn_start = Some(ts);
+        self.tool_ms = 0;
+        if let Some(start) = self.union_start {
+            self.union_start = Some(start.max(ts));
+        }
+    }
+
+    /// Note a timestamp seen inside the turn, whatever event carried it. The
+    /// turn's own completion is the one event excluded: it is measured
+    /// *against* this watermark rather than folded into it.
+    fn observe(&mut self, ts: Option<u64>) {
+        if let Some(ts) = ts {
+            self.advance(ts);
+        }
+    }
+
+    /// Record a tool-like lifecycle transition. `active` marks the item as in
+    /// progress; otherwise it is finished.
+    fn mark(&mut self, ts: Option<u64>, item_id: &str, active: bool) {
+        let Some(ts) = ts else {
+            self.untimed = true;
+            return;
+        };
+        let ts = self.advance(ts);
+        if active {
+            // Repeated updates for an already-open item change nothing; the
+            // first sighting opens it.
+            if self.open.insert(item_id.to_owned()) && self.open.len() == 1 {
+                self.union_start = Some(ts);
+            }
+        } else if self.open.remove(item_id) && self.open.is_empty() {
+            self.close(ts);
+        }
+    }
+
+    /// Accept a timestamp, never letting it move the clock backwards: a
+    /// backward stamp contributes a zero-length step instead of underflowing.
+    fn advance(&mut self, ts: u64) -> u64 {
+        let clamped = self.clock.map_or(ts, |clock| ts.max(clock));
+        self.clock = Some(clamped);
+        clamped
+    }
+
+    /// Charge the open interval up to `ts`, intersected with the turn start.
+    fn close(&mut self, ts: u64) {
+        if let Some(start) = self.union_start.take() {
+            let start = self.turn_start.map_or(start, |bound| start.max(bound));
+            self.tool_ms = self.tool_ms.saturating_add(ts.saturating_sub(start));
+        }
+    }
+
+    /// Close the turn at `end`, charging any still-open tools up to it. `end`
+    /// is the turn's own upper bound, so the interval never extends past it.
+    fn finish(mut self, end: u64) -> u64 {
+        self.close(end);
+        self.tool_ms
+    }
+}
+
+/// Derive the finished turn's breakdown, or `None` when the events cannot
+/// support one: no timestamped `TurnStarted`/`TurnCompleted` pair (legacy logs,
+/// or a turn opened only by a user message), a tool-like item seen without a
+/// timestamp, or a completion that precedes work already recorded inside the
+/// turn.
+///
+/// That last case is a wall clock that regressed across the turn boundary: some
+/// event inside the turn is stamped later than the turn's own end, so the true
+/// bounds are unknowable. Clamping the aggregate would keep the total honest
+/// while silently misattributing the split between the buckets — a tool that
+/// "ran" past the end would eat AI time that may never have been tool time at
+/// all. There is no defensible attribution to guess at, so the breakdown is
+/// withheld and the UI falls back to the bare completion clock.
+fn finish_timing(clock: ToolClock, end: Option<u64>) -> Option<TurnTiming> {
+    let (start, end) = (clock.turn_start?, end?);
+    if clock.untimed || end < start || clock.clock.is_some_and(|latest| end < latest) {
+        return None;
+    }
+    Some(TurnTiming::new(end - start, clock.finish(end)))
+}
+
+/// Which lifecycle event carried a tool-like item. The variant is authoritative
+/// over the item's own `status` field, which several providers drop entirely
+/// (Codex maps `webSearch` and unmodeled items to statusless content).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ToolLifecycle {
+    Started,
+    Updated,
+    Completed,
+}
+
+/// A tool-like item's own view of its state. `Unknown` is a tool-like item that
+/// reports no status of its own (`WebSearch`, `Other`); `None` from
+/// [`tool_item_state`] means the item is model output and is never timed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ToolState {
+    Active,
+    Finished,
+    Unknown,
+}
+
+/// Classify an item as tool-like — a command, file edit, tool call, subagent,
+/// web search, or an unmodeled provider item — and read the status it carries.
+fn tool_item_state(content: &ItemContent) -> Option<ToolState> {
+    let status = match content {
+        ItemContent::CommandExecution { status, .. }
+        | ItemContent::FileChange { status, .. }
+        | ItemContent::ToolCall { status, .. }
+        | ItemContent::Subagent { status, .. } => *status,
+        ItemContent::WebSearch { .. } | ItemContent::Other { .. } => {
+            return Some(ToolState::Unknown);
+        }
+        ItemContent::UserMessage { .. }
+        | ItemContent::AssistantMessage { .. }
+        | ItemContent::Reasoning { .. } => return None,
+    };
+    Some(match status {
+        ItemStatus::InProgress => ToolState::Active,
+        ItemStatus::Completed | ItemStatus::Failed | ItemStatus::Declined => ToolState::Finished,
+    })
+}
+
+/// Whether a tool-like item is in progress after this transition. The lifecycle
+/// variant wins: a start always opens the interval and a completion always
+/// closes it, whatever status the snapshot carries (or fails to carry). Only an
+/// update defers to an explicit status, and a statusless update keeps the item
+/// active.
+fn tool_is_active(lifecycle: ToolLifecycle, state: ToolState) -> bool {
+    match lifecycle {
+        ToolLifecycle::Started => true,
+        ToolLifecycle::Completed => false,
+        ToolLifecycle::Updated => state != ToolState::Finished,
     }
 }
 
@@ -311,6 +534,8 @@ pub struct Timeline {
     /// FileChange items known to have completed successfully. The ids rebuild
     /// deterministically from persisted ItemCompleted events during replay.
     committed_file_change_items: HashSet<String>,
+    /// Tool-time accounting for the open turn (see [`TurnMeta::timing`]).
+    tool_clock: ToolClock,
 }
 
 impl Timeline {
@@ -355,6 +580,14 @@ impl Timeline {
 
     /// Apply one event recorded at `ts` (unix ms). Mutates in place.
     pub fn apply_at(&mut self, ts: Option<u64>, event: &AgentEvent) {
+        // Every timestamped event inside the open turn raises the turn's
+        // watermark, not just tool lifecycle ones: a completion stamped before
+        // any of them means the wall clock regressed, and the breakdown is
+        // withheld rather than guessed at. The completion itself is excluded —
+        // it is what gets compared against the watermark.
+        if self.turn_is_open() && !matches!(event, AgentEvent::TurnCompleted { .. }) {
+            self.tool_clock.observe(ts);
+        }
         match event {
             AgentEvent::ProviderRelay {
                 from_provider,
@@ -395,9 +628,11 @@ impl Timeline {
                     _ => self.push_turn(ts),
                 };
                 // TurnStarted is the authoritative turn start; prefer it over
-                // the opening user message's time when known.
-                if ts.is_some() {
-                    self.turns[turn].start_ts = ts;
+                // the opening user message's time when known. It is also the
+                // only start the timing breakdown will measure from.
+                if let Some(ts) = ts {
+                    self.turns[turn].start_ts = Some(ts);
+                    self.tool_clock.begin_turn(ts);
                 }
                 self.turns[turn].provider_turn_id = Some(turn_id.clone());
                 self.turns[turn].running = true;
@@ -456,6 +691,12 @@ impl Timeline {
                     }
                     self.turns[turn].status = Some(*status);
                     self.turns[turn].running = false;
+                    let clock = std::mem::take(&mut self.tool_clock);
+                    // A repeated completion finds an already-spent clock; it
+                    // must not erase the breakdown the first one derived.
+                    if let Some(timing) = finish_timing(clock, self.turns[turn].end_ts) {
+                        self.turns[turn].timing = Some(timing);
+                    }
                 }
                 if usage.is_some() {
                     self.usage = *usage;
@@ -464,11 +705,17 @@ impl Timeline {
                 self.pending_approvals.clear();
                 self.pending_user_input = None;
             }
-            AgentEvent::ItemStarted(item) | AgentEvent::ItemUpdated(item) => {
-                self.upsert_item(ts, item)
+            AgentEvent::ItemStarted(item) => {
+                self.upsert_item(ts, item);
+                self.track_tool_item(ts, item, ToolLifecycle::Started);
+            }
+            AgentEvent::ItemUpdated(item) => {
+                self.upsert_item(ts, item);
+                self.track_tool_item(ts, item, ToolLifecycle::Updated);
             }
             AgentEvent::ItemCompleted(item) => {
                 self.upsert_item(ts, item);
+                self.track_tool_item(ts, item, ToolLifecycle::Completed);
                 if matches!(
                     &item.content,
                     ItemContent::FileChange {
@@ -610,9 +857,36 @@ impl Timeline {
         }
     }
 
+    /// Whether the current turn is still accumulating. A turn is finished once
+    /// a `TurnCompleted` has been folded, which records a status even when the
+    /// event carried no timestamp to store as `end_ts`; both must be checked or
+    /// a stray later transition would leak into the next turn's accounting
+    /// (`TurnStarted` reuses a turn whose `end_ts` is unset).
+    fn turn_is_open(&self) -> bool {
+        self.current_turn.is_some_and(|turn| {
+            let turn = &self.turns[turn];
+            turn.end_ts.is_none() && turn.status.is_none()
+        })
+    }
+
+    /// Feed one item lifecycle transition to the open turn's clock, ignoring
+    /// items that are not tool-like. Transitions arriving after the turn has
+    /// already been finalized are ignored too, so a settled breakdown cannot be
+    /// reopened.
+    fn track_tool_item(&mut self, ts: Option<u64>, item: &ThreadItem, lifecycle: ToolLifecycle) {
+        let Some(state) = tool_item_state(&item.content) else {
+            return;
+        };
+        if self.turn_is_open() {
+            self.tool_clock
+                .mark(ts, &item.id, tool_is_active(lifecycle, state));
+        }
+    }
+
     /// Push a new (open) turn and make it current. `start_ts` seeds the turn's
     /// start time (refined later by a TurnStarted event if one arrives).
     fn push_turn(&mut self, start_ts: Option<u64>) -> usize {
+        self.tool_clock = ToolClock::default();
         self.turns.push(TurnMeta {
             provider_turn_id: None,
             provider_checkpoint_id: None,
@@ -621,6 +895,7 @@ impl Timeline {
             status: None,
             running: false,
             changes: None,
+            timing: None,
         });
         let idx = self.turns.len() - 1;
         self.current_turn = Some(idx);
@@ -649,6 +924,7 @@ impl Timeline {
             .retain(|parent_id| self.children.contains_key(parent_id));
         self.turns.truncate(target_turn);
         self.current_turn = self.turns.len().checked_sub(1);
+        self.tool_clock = ToolClock::default();
         self.turn_running = false;
         self.pending_approvals.clear();
         self.pending_user_input = None;
@@ -2276,5 +2552,522 @@ mod tests {
                 attachments: Vec::new(),
             },
         })
+    }
+
+    // -- turn timing --------------------------------------------------------
+
+    fn at(ts: u64, event: AgentEvent) -> StoredEvent {
+        StoredEvent {
+            ts: Some(ts),
+            event,
+        }
+    }
+
+    fn started(ts: u64, item: ThreadItem) -> StoredEvent {
+        at(ts, AgentEvent::ItemStarted(item))
+    }
+
+    fn updated(ts: u64, item: ThreadItem) -> StoredEvent {
+        at(ts, AgentEvent::ItemUpdated(item))
+    }
+
+    fn completed(ts: u64, item: ThreadItem) -> StoredEvent {
+        at(ts, AgentEvent::ItemCompleted(item))
+    }
+
+    fn command(id: &str, status: ItemStatus) -> ThreadItem {
+        ThreadItem {
+            id: id.into(),
+            parent_item_id: None,
+            content: ItemContent::CommandExecution {
+                command: "ls".into(),
+                output: String::new(),
+                exit_code: None,
+                status,
+            },
+        }
+    }
+
+    /// A shell command that is still running.
+    fn running(id: &str) -> ThreadItem {
+        command(id, ItemStatus::InProgress)
+    }
+
+    /// The same command, finished.
+    fn ran(id: &str) -> ThreadItem {
+        command(id, ItemStatus::Completed)
+    }
+
+    fn subagent(id: &str, status: ItemStatus) -> ThreadItem {
+        ThreadItem {
+            id: id.into(),
+            parent_item_id: None,
+            content: ItemContent::Subagent {
+                agent_type: "explore".into(),
+                description: "look around".into(),
+                status,
+                summary: None,
+            },
+        }
+    }
+
+    fn assistant(id: &str, text: &str) -> AgentEvent {
+        AgentEvent::ItemCompleted(ThreadItem {
+            id: id.into(),
+            parent_item_id: None,
+            content: ItemContent::AssistantMessage { text: text.into() },
+        })
+    }
+
+    /// A statusless tool-like item: its lifecycle is only knowable from the
+    /// event variant that carried it (Codex maps `webSearch` this way).
+    fn web_search(id: &str) -> ThreadItem {
+        ThreadItem {
+            id: id.into(),
+            parent_item_id: None,
+            content: ItemContent::WebSearch {
+                query: "rust union of intervals".into(),
+            },
+        }
+    }
+
+    /// The other statusless shape: a provider item canonicalization does not
+    /// model yet.
+    fn other_item(id: &str) -> ThreadItem {
+        ThreadItem {
+            id: id.into(),
+            parent_item_id: None,
+            content: ItemContent::Other {
+                provider_kind: "customTool".into(),
+                summary: "doing something".into(),
+            },
+        }
+    }
+
+    fn turn_started() -> AgentEvent {
+        AgentEvent::TurnStarted {
+            turn_id: "turn-1".into(),
+        }
+    }
+
+    fn turn_completed() -> AgentEvent {
+        AgentEvent::TurnCompleted {
+            turn_id: "turn-1".into(),
+            status: TurnStatus::Completed,
+            usage: None,
+        }
+    }
+
+    /// Fold timestamped events and return the first turn's breakdown.
+    fn timing_of(events: Vec<StoredEvent>) -> Option<TurnTiming> {
+        Timeline::fold_events(events).turns[0].timing
+    }
+
+    #[test]
+    fn sequential_tools_leave_the_remaining_span_to_the_model() {
+        let timing = timing_of(vec![
+            at(1_000, turn_started()),
+            started(2_000, running("a")),
+            completed(3_000, ran("a")),
+            started(5_000, running("b")),
+            completed(6_000, ran("b")),
+            at(10_000, turn_completed()),
+        ])
+        .expect("a fully timestamped turn has a breakdown");
+
+        assert_eq!(timing.total_ms, 9_000);
+        assert_eq!(timing.tool_ms, 2_000);
+        assert_eq!(timing.ai_ms(), 7_000);
+        assert_eq!(timing.ai_ms() + timing.tool_ms, timing.total_ms);
+    }
+
+    #[test]
+    fn overlapping_tools_count_as_a_union_not_a_sum() {
+        let timing = timing_of(vec![
+            at(0, turn_started()),
+            started(1_000, running("a")),
+            // A second tool starts while the first still runs, and a third
+            // opens and closes wholly inside their overlap.
+            started(1_500, subagent("b", ItemStatus::InProgress)),
+            started(1_800, running("c")),
+            completed(2_000, ran("c")),
+            completed(2_500, ran("a")),
+            completed(3_000, subagent("b", ItemStatus::Completed)),
+            at(4_000, turn_completed()),
+        ])
+        .expect("a fully timestamped turn has a breakdown");
+
+        // Summing the three intervals would give 1500 + 1500 + 200 = 3200ms;
+        // the union [1000, 3000] is 2000ms.
+        assert_eq!(timing.tool_ms, 2_000);
+        assert_eq!(timing.total_ms, 4_000);
+        assert_eq!(timing.ai_ms(), 2_000);
+    }
+
+    #[test]
+    fn repeated_updates_do_not_restart_an_open_tool_interval() {
+        let timing = timing_of(vec![
+            at(0, turn_started()),
+            started(1_000, running("a")),
+            updated(1_400, running("a")),
+            updated(2_200, running("a")),
+            completed(3_000, ran("a")),
+            // Re-using the same id after completion opens a fresh interval.
+            started(4_000, running("a")),
+            completed(4_500, ran("a")),
+            at(6_000, turn_completed()),
+        ])
+        .expect("a fully timestamped turn has a breakdown");
+
+        assert_eq!(timing.tool_ms, 2_500);
+        assert_eq!(timing.total_ms, 6_000);
+    }
+
+    #[test]
+    fn a_tool_first_seen_as_an_in_progress_update_still_opens_its_interval() {
+        let timing = timing_of(vec![
+            at(0, turn_started()),
+            // No ItemStarted: some providers announce the item mid-flight.
+            updated(1_000, running("a")),
+            completed(2_500, ran("a")),
+            at(5_000, turn_completed()),
+        ])
+        .expect("a fully timestamped turn has a breakdown");
+
+        assert_eq!(timing.tool_ms, 1_500);
+        assert_eq!(timing.ai_ms(), 3_500);
+    }
+
+    #[test]
+    fn a_failed_tool_still_closes_its_interval() {
+        let timing = timing_of(vec![
+            at(0, turn_started()),
+            started(1_000, running("a")),
+            updated(2_000, command("a", ItemStatus::Failed)),
+            at(5_000, turn_completed()),
+        ])
+        .expect("a fully timestamped turn has a breakdown");
+
+        assert_eq!(timing.tool_ms, 1_000);
+    }
+
+    #[test]
+    fn an_ai_only_turn_reports_a_zero_tool_share() {
+        let timing = timing_of(vec![
+            at(1_000, turn_started()),
+            at(2_000, assistant("m1", "thinking out loud")),
+            at(9_000, turn_completed()),
+        ])
+        .expect("an AI-only turn still has a breakdown");
+
+        assert_eq!(timing.total_ms, 8_000);
+        assert_eq!(timing.tool_ms, 0);
+        assert_eq!(timing.ai_ms(), 8_000);
+    }
+
+    #[test]
+    fn a_tool_left_open_is_charged_up_to_the_turn_end() {
+        let timing = timing_of(vec![
+            at(1_000, turn_started()),
+            started(2_000, running("a")),
+            at(5_000, turn_completed()),
+        ])
+        .expect("a fully timestamped turn has a breakdown");
+
+        assert_eq!(timing.tool_ms, 3_000);
+        assert_eq!(timing.ai_ms(), 1_000);
+    }
+
+    #[test]
+    fn legacy_events_without_timestamps_invent_no_breakdown() {
+        let legacy = Timeline::fold_events([
+            user_msg("u1", "hi"),
+            turn_started(),
+            AgentEvent::ItemStarted(running("a")),
+            AgentEvent::ItemCompleted(ran("a")),
+            turn_completed(),
+        ]);
+        assert_eq!(legacy.turns[0].timing, None);
+
+        // A turn whose bounds are timestamped but whose tool activity is not
+        // cannot be trusted either.
+        let mixed = timing_of(vec![
+            at(1_000, turn_started()),
+            AgentEvent::ItemStarted(running("a")).into(),
+            AgentEvent::ItemCompleted(ran("a")).into(),
+            at(9_000, turn_completed()),
+        ]);
+        assert_eq!(mixed, None);
+    }
+
+    #[test]
+    fn a_running_turn_has_no_breakdown_yet() {
+        let live = Timeline::fold_events(vec![
+            at(1_000, turn_started()),
+            started(2_000, running("a")),
+        ]);
+        assert!(live.turns[0].running);
+        assert_eq!(live.turns[0].timing, None);
+    }
+
+    #[test]
+    fn a_backward_timestamp_neither_underflows_nor_inflates_a_bucket() {
+        let timing = timing_of(vec![
+            at(10_000, turn_started()),
+            started(12_000, running("a")),
+            // The clock steps backwards: the interval is clamped to zero rather
+            // than wrapping around or crediting negative time.
+            completed(11_000, ran("a")),
+            started(13_000, running("b")),
+            completed(15_000, ran("b")),
+            // The clock recovered, and the turn end is still at or past every
+            // timestamp seen inside the turn, so clamping the one backward step
+            // is enough — this turn keeps its breakdown.
+            at(20_000, turn_completed()),
+        ])
+        .expect("a fully timestamped turn has a breakdown");
+
+        assert_eq!(timing.total_ms, 10_000);
+        assert_eq!(timing.tool_ms, 2_000);
+        assert_eq!(timing.ai_ms(), 8_000);
+
+        // A turn that ends before it started yields no breakdown at all.
+        let inverted = timing_of(vec![at(9_000, turn_started()), at(1_000, turn_completed())]);
+        assert_eq!(inverted, None);
+    }
+
+    #[test]
+    fn a_tool_interval_wholly_before_the_turn_start_is_discarded() {
+        // Work from the previous exchange closes while this turn's user message
+        // is already open; only the in-bounds interval may be charged.
+        let timing = timing_of(vec![
+            at(1_000, user_msg("u1", "go")),
+            started(1_100, running("stale")),
+            completed(2_000, ran("stale")),
+            at(5_000, turn_started()),
+            started(6_000, running("a")),
+            completed(6_500, ran("a")),
+            at(9_000, turn_completed()),
+        ])
+        .expect("a fully timestamped turn has a breakdown");
+
+        assert_eq!(timing.total_ms, 4_000);
+        assert_eq!(timing.tool_ms, 500);
+        // The pre-start second is real AI/idle time and must survive.
+        assert_eq!(timing.ai_ms(), 3_500);
+    }
+
+    #[test]
+    fn a_tool_straddling_the_turn_start_counts_only_from_the_start() {
+        let timing = timing_of(vec![
+            at(1_000, user_msg("u1", "go")),
+            started(1_100, running("a")),
+            at(5_000, turn_started()),
+            completed(6_000, ran("a")),
+            at(9_000, turn_completed()),
+        ])
+        .expect("a fully timestamped turn has a breakdown");
+
+        assert_eq!(timing.total_ms, 4_000);
+        // [1_100, 6_000] intersected with [5_000, 9_000] is 1_000ms, not 4_900.
+        assert_eq!(timing.tool_ms, 1_000);
+        assert_eq!(timing.ai_ms(), 3_000);
+    }
+
+    #[test]
+    fn statusless_tool_items_are_timed_by_their_lifecycle_events() {
+        for (label, item) in [
+            ("web search", web_search as fn(&str) -> ThreadItem),
+            ("other", other_item as fn(&str) -> ThreadItem),
+        ] {
+            let timing = timing_of(vec![
+                at(1_000, turn_started()),
+                started(2_000, item("t")),
+                // A statusless update keeps the item active rather than
+                // silently closing it.
+                updated(3_000, item("t")),
+                completed(4_500, item("t")),
+                at(6_000, turn_completed()),
+            ])
+            .unwrap_or_else(|| panic!("{label}: a timestamped turn has a breakdown"));
+
+            assert_eq!(timing.total_ms, 5_000, "{label}");
+            assert_eq!(timing.tool_ms, 2_500, "{label}");
+            assert_eq!(timing.ai_ms(), 2_500, "{label}");
+        }
+    }
+
+    #[test]
+    fn a_started_tool_opens_even_when_its_snapshot_claims_to_be_finished() {
+        // Providers that stamp a terminal status on the opening snapshot still
+        // describe a real interval; the lifecycle variant is authoritative.
+        let timing = timing_of(vec![
+            at(0, turn_started()),
+            started(1_000, ran("a")),
+            completed(3_000, ran("a")),
+            at(5_000, turn_completed()),
+        ])
+        .expect("a fully timestamped turn has a breakdown");
+
+        assert_eq!(timing.tool_ms, 2_000);
+    }
+
+    #[test]
+    fn a_tool_completing_after_the_turn_end_withholds_the_breakdown() {
+        // The wall clock regressed across the turn boundary: tool B is stamped
+        // as finishing 5s after the turn itself finished. Charging the union as
+        // recorded would report 7s of tool time against a 20s turn, and even
+        // clamping the aggregate to the total cannot fix the attribution — the
+        // 18s the model may actually have spent is unknowable. Withhold it.
+        let timing = timing_of(vec![
+            at(0, turn_started()),
+            started(1_000, running("a")),
+            completed(2_000, ran("a")),
+            started(19_000, running("b")),
+            completed(25_000, ran("b")),
+            at(20_000, turn_completed()),
+        ]);
+        assert_eq!(timing, None);
+    }
+
+    #[test]
+    fn a_model_item_stamped_after_the_turn_end_withholds_the_breakdown() {
+        // The watermark is not tool-only: an assistant or reasoning item stamped
+        // past the turn end regresses the clock just as badly.
+        for (label, item) in [
+            ("assistant", assistant("m1", "late answer")),
+            (
+                "reasoning",
+                AgentEvent::ItemCompleted(ThreadItem {
+                    id: "r1".into(),
+                    parent_item_id: None,
+                    content: ItemContent::Reasoning {
+                        text: "late thought".into(),
+                    },
+                }),
+            ),
+        ] {
+            let timing = timing_of(vec![
+                at(1_000, turn_started()),
+                at(30_000, item),
+                at(20_000, turn_completed()),
+            ]);
+            assert_eq!(timing, None, "{label}");
+        }
+    }
+
+    #[test]
+    fn a_turn_finalized_without_a_timestamp_rejects_later_tool_transitions() {
+        // An untimestamped TurnCompleted records a status but no end_ts, and a
+        // following TurnStarted therefore *reuses* that turn. A stray tool
+        // transition in between must not survive into the reopened turn's
+        // accounting — otherwise the ghost item stays open and eats the whole
+        // next turn.
+        let timeline = Timeline::fold_events(vec![
+            at(1_000, turn_started()),
+            turn_completed().into(),
+            started(3_000, running("ghost")),
+            at(4_000, turn_started()),
+            at(10_000, turn_completed()),
+        ]);
+
+        let timing = timeline.turns[0]
+            .timing
+            .expect("the reopened turn is fully timestamped");
+        assert_eq!(timing.total_ms, 6_000);
+        assert_eq!(timing.tool_ms, 0);
+        assert_eq!(timing.ai_ms(), 6_000);
+    }
+
+    #[test]
+    fn a_breakdown_needs_an_observed_timestamped_turn_start() {
+        // A user message seeds start_ts, but it is not an observed TurnStarted.
+        let no_turn_started = timing_of(vec![
+            at(1_000, user_msg("u1", "go")),
+            started(2_000, running("a")),
+            completed(3_000, ran("a")),
+            at(9_000, turn_completed()),
+        ]);
+        assert_eq!(no_turn_started, None);
+
+        // A TurnStarted that carries no timestamp is no anchor either.
+        let untimed_turn_started = timing_of(vec![
+            at(1_000, user_msg("u1", "go")),
+            turn_started().into(),
+            at(9_000, turn_completed()),
+        ]);
+        assert_eq!(untimed_turn_started, None);
+
+        // The user message's start_ts is untouched by any of this.
+        let timeline = Timeline::fold_events(vec![
+            at(1_000, user_msg("u1", "go")),
+            at(9_000, turn_completed()),
+        ]);
+        assert_eq!(timeline.turns[0].start_ts, Some(1_000));
+        assert_eq!(timeline.turns[0].duration_secs(), Some(8));
+        assert_eq!(timeline.turns[0].timing, None);
+    }
+
+    #[test]
+    fn replaying_a_stored_turn_reproduces_the_live_breakdown() {
+        let events = vec![
+            at(1_000, user_msg("u1", "run it")),
+            at(1_100, turn_started()),
+            started(2_000, running("a")),
+            started(2_500, subagent("b", ItemStatus::InProgress)),
+            completed(4_000, ran("a")),
+            completed(4_800, subagent("b", ItemStatus::Completed)),
+            at(7_100, turn_completed()),
+        ];
+
+        let mut live = Timeline::default();
+        for stored in &events {
+            live.apply_at(stored.ts, &stored.event);
+        }
+        let replayed = Timeline::fold_events(events);
+
+        assert_eq!(live.turns[0].timing, replayed.turns[0].timing);
+        let timing = replayed.turns[0].timing.expect("breakdown");
+        assert_eq!(timing.total_ms, 6_000);
+        assert_eq!(timing.tool_ms, 2_800);
+        assert_eq!(timing.ai_ms(), 3_200);
+    }
+
+    #[test]
+    fn each_turn_gets_its_own_breakdown() {
+        let timeline = Timeline::fold_events(vec![
+            at(0, turn_started()),
+            started(1_000, running("a")),
+            completed(2_000, ran("a")),
+            at(4_000, turn_completed()),
+            at(5_000, user_msg("u2", "again")),
+            at(5_000, turn_started()),
+            at(9_000, turn_completed()),
+        ]);
+
+        assert_eq!(timeline.turns.len(), 2);
+        assert_eq!(timeline.turns[0].timing.unwrap().tool_ms, 1_000);
+        // The second turn starts from a clean clock — no leakage across turns.
+        assert_eq!(timeline.turns[1].timing.unwrap().tool_ms, 0);
+        assert_eq!(timeline.turns[1].timing.unwrap().total_ms, 4_000);
+    }
+
+    #[test]
+    fn rendered_second_parts_sum_to_the_rendered_total() {
+        let timing = TurnTiming::new(10_500, 3_600);
+        let secs = timing.secs();
+        assert_eq!((secs.total, secs.ai, secs.tools), (10, 7, 3));
+        assert_eq!(secs.ai + secs.tools, secs.total);
+
+        // Tool time is clamped into the observed total, so the invariant holds
+        // even for a nonsensical accumulation.
+        let clamped = TurnTiming::new(1_000, 5_000);
+        assert_eq!(clamped.tool_ms, 1_000);
+        assert_eq!(clamped.ai_ms(), 0);
+        let clamped_secs = clamped.secs();
+        assert_eq!(
+            (clamped_secs.total, clamped_secs.ai, clamped_secs.tools),
+            (1, 0, 1)
+        );
     }
 }

--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -27,7 +27,7 @@ use gpui_component::{
 
 use tcode_core::git::GitAction;
 use tcode_core::session::{
-    EntryContent, OrchestrateCallback, SteeringStatus, TimelineEntry, TurnMeta,
+    EntryContent, OrchestrateCallback, SteeringStatus, TimelineEntry, TurnMeta, TurnTiming,
     parse_orchestrate_callback,
 };
 use tcode_runtime::app::{AppState, RightTab};
@@ -471,6 +471,8 @@ fn index_turns(
                 turn.start_ts.hash(&mut content);
                 turn.end_ts.hash(&mut content);
                 turn.running.hash(&mut content);
+                // The finished bottom row renders the turn's breakdown.
+                turn.timing.hash(&mut content);
                 turn.status
                     .as_ref()
                     .map(std::mem::discriminant)
@@ -986,7 +988,7 @@ impl ChatView {
         if !turn.running
             && let Some(ts) = turn.end_ts.or(entries.last().and_then(|e| e.ts))
         {
-            column = column.child(self.render_timestamp(ts, cx));
+            column = column.child(self.render_timestamp(ts, turn.timing, cx));
         }
 
         // Pending steers float below every live transcript/work-log element.
@@ -2379,7 +2381,14 @@ impl ChatView {
         cx.notify();
     }
 
-    fn render_timestamp(&self, ts: u64, cx: &mut Context<Self>) -> AnyElement {
+    /// The finished turn's bottom row: the local completion clock, followed by
+    /// the wall-clock breakdown when the turn's events supported deriving one.
+    fn render_timestamp(
+        &self,
+        ts: u64,
+        timing: Option<TurnTiming>,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
         h_flex()
             .w_full()
             .gap_1p5()
@@ -2387,7 +2396,7 @@ impl ChatView {
             .text_size(px(13.))
             .text_color(cx.theme().muted_foreground)
             .child(Icon::new(IconName::Info).xsmall())
-            .child(format_local_time(ts))
+            .child(turn_time_row(format_local_time(ts), timing))
             .into_any_element()
     }
 
@@ -3235,6 +3244,41 @@ fn format_duration(secs: u64) -> String {
     }
 }
 
+/// A finished turn's duration. Long turns roll up into hours rather than
+/// growing an unreadable minute count (a full day reads `24h 00m 59s`, not
+/// `1440m 59s`), keeping the seconds because this row reports actual elapsed
+/// time. The live "Working for" indicator keeps [`format_duration`].
+fn format_span(secs: u64) -> String {
+    if secs >= 3600 {
+        tcode_i18n::tr!(
+            "time.duration_hours",
+            hours = secs / 3600,
+            minutes = format!("{:02}", (secs % 3600) / 60),
+            seconds = format!("{:02}", secs % 60)
+        )
+        .into_owned()
+    } else {
+        format_duration(secs)
+    }
+}
+
+/// The text of a finished turn's bottom row: the completion clock, plus the
+/// turn's wall-clock breakdown when one was derivable. Legacy sessions without
+/// timestamps keep exactly the clock they showed before.
+fn turn_time_row(clock: String, timing: Option<TurnTiming>) -> String {
+    let Some(timing) = timing else {
+        return clock;
+    };
+    let parts = timing.secs();
+    [
+        clock,
+        tcode_i18n::tr!("chat.turn_total", duration = format_span(parts.total)).into_owned(),
+        tcode_i18n::tr!("chat.turn_ai", duration = format_span(parts.ai)).into_owned(),
+        tcode_i18n::tr!("chat.turn_tools", duration = format_span(parts.tools)).into_owned(),
+    ]
+    .join(" · ")
+}
+
 /// Count added / removed lines in a unified diff (ignoring the `+++`/`---`
 /// file headers).
 fn diff_stats(diff: Option<&str>) -> (u32, u32) {
@@ -3468,9 +3512,10 @@ mod tests {
     use super::{
         ChatView, FileEditRowStyle, ListSync, LiveEditRow, MdState, MdSync, Segment, WorkLogCounts,
         copy_payload, diff_stats, displayed_error_text, file_edit_row, finished_work_log_label,
-        index_turns, list_sync, live_edit_counts, live_edit_rows, md_sync, plain_text_as_markdown,
-        previous_logs_toggle_label, segment_entries, timeline_overdraw, turn_work_log_summary,
-        work_log_auto_expands, work_log_counts, work_log_row_entries, work_log_summary,
+        format_duration, format_span, index_turns, list_sync, live_edit_counts, live_edit_rows,
+        md_sync, plain_text_as_markdown, previous_logs_toggle_label, segment_entries,
+        timeline_overdraw, turn_time_row, turn_work_log_summary, work_log_auto_expands,
+        work_log_counts, work_log_row_entries, work_log_summary,
     };
     use crate::markdown::MarkdownState;
     use agent::{FileChange, FileChangeKind, ItemStatus};
@@ -3478,7 +3523,7 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::path::Path;
     use std::sync::Arc;
-    use tcode_core::session::{EntryContent, SteeringStatus, TimelineEntry, TurnMeta};
+    use tcode_core::session::{EntryContent, SteeringStatus, TimelineEntry, TurnMeta, TurnTiming};
 
     #[gpui::test]
     fn long_markdown_paints_middle_blocks_when_scrolled_in_chat_outer_list(
@@ -4835,5 +4880,79 @@ This begins after the hard break."#;
             (0, px(0.)),
             "the timeline list must not co-scroll under the card"
         );
+    }
+
+    // -- finished turn time row --------------------------------------------
+
+    #[test]
+    fn finished_time_row_spells_out_the_turn_breakdown_in_both_locales() {
+        let _locale_guard = crate::settings::TestLocaleGuard::acquire();
+        // 1m 20s total, 35s of it inside tool calls.
+        let timing = TurnTiming::new(80_000, 35_000);
+
+        tcode_i18n::set_locale(tcode_i18n::LANGUAGE_ENGLISH);
+        assert_eq!(
+            turn_time_row("3:04 PM".into(), Some(timing)),
+            "3:04 PM · Total 1m 20s · AI thinking & response 45s · Tool calls 35s"
+        );
+
+        tcode_i18n::set_locale(tcode_i18n::LANGUAGE_SIMPLIFIED_CHINESE);
+        assert_eq!(
+            turn_time_row("3:04 PM".into(), Some(timing)),
+            "3:04 PM · 总计 1 分 20 秒 · AI 思考与回答 45 秒 · 工具调用 35 秒"
+        );
+        tcode_i18n::set_locale(tcode_i18n::LANGUAGE_ENGLISH);
+    }
+
+    #[test]
+    fn an_ai_only_turn_still_shows_all_three_durations() {
+        let _locale_guard = crate::settings::TestLocaleGuard::acquire();
+        tcode_i18n::set_locale(tcode_i18n::LANGUAGE_ENGLISH);
+        assert_eq!(
+            turn_time_row("9:00 AM".into(), Some(TurnTiming::new(8_000, 0))),
+            "9:00 AM · Total 8s · AI thinking & response 8s · Tool calls 0s"
+        );
+    }
+
+    #[test]
+    fn a_turn_without_a_derivable_breakdown_keeps_the_bare_clock() {
+        let _locale_guard = crate::settings::TestLocaleGuard::acquire();
+        tcode_i18n::set_locale(tcode_i18n::LANGUAGE_ENGLISH);
+        assert_eq!(turn_time_row("9:00 AM".into(), None), "9:00 AM");
+    }
+
+    #[test]
+    fn day_long_turns_read_in_hours_in_both_locales() {
+        let _locale_guard = crate::settings::TestLocaleGuard::acquire();
+        // 24h 00m 59s total, 23h 30m 00s of it waiting on tools. The seconds
+        // survive the hour rollup — this row reports real elapsed time.
+        let timing = TurnTiming::new(86_459_000, 84_600_000);
+
+        tcode_i18n::set_locale(tcode_i18n::LANGUAGE_ENGLISH);
+        assert_eq!(
+            turn_time_row("1:00 AM".into(), Some(timing)),
+            "1:00 AM · Total 24h 00m 59s · AI thinking & response 30m 59s · Tool calls 23h 30m 00s"
+        );
+
+        tcode_i18n::set_locale(tcode_i18n::LANGUAGE_SIMPLIFIED_CHINESE);
+        assert_eq!(
+            turn_time_row("1:00 AM".into(), Some(timing)),
+            "1:00 AM · 总计 24 小时 00 分 59 秒 · AI 思考与回答 30 分 59 秒 · 工具调用 23 小时 30 分 00 秒"
+        );
+        tcode_i18n::set_locale(tcode_i18n::LANGUAGE_ENGLISH);
+    }
+
+    #[test]
+    fn the_live_working_indicator_keeps_its_own_format() {
+        let _locale_guard = crate::settings::TestLocaleGuard::acquire();
+        tcode_i18n::set_locale(tcode_i18n::LANGUAGE_ENGLISH);
+        // The running row is untouched by the breakdown's hour rollup.
+        assert_eq!(format_duration(3_600), "60m 00s");
+        assert_eq!(format_duration(90_061), "1501m 01s");
+        // The finished row rolls up, and keeps every second it claims.
+        assert_eq!(format_span(3_600), "1h 00m 00s");
+        assert_eq!(format_span(90_061), "25h 01m 01s");
+        assert_eq!(format_span(59), "59s");
+        assert_eq!(format_span(90), "1m 30s");
     }
 }

--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -2389,15 +2389,11 @@ impl ChatView {
         timing: Option<TurnTiming>,
         cx: &mut Context<Self>,
     ) -> AnyElement {
-        h_flex()
-            .w_full()
-            .gap_1p5()
-            .items_center()
-            .text_size(px(13.))
-            .text_color(cx.theme().muted_foreground)
-            .child(Icon::new(IconName::Info).xsmall())
-            .child(turn_time_row(format_local_time(ts), timing))
-            .into_any_element()
+        turn_time_footer(
+            turn_time_parts(format_local_time(ts), timing),
+            cx.theme().muted_foreground,
+        )
+        .into_any_element()
     }
 
     // -- top-level surfaces -------------------------------------------------
@@ -3262,21 +3258,81 @@ fn format_span(secs: u64) -> String {
     }
 }
 
-/// The text of a finished turn's bottom row: the completion clock, plus the
-/// turn's wall-clock breakdown when one was derivable. Legacy sessions without
-/// timestamps keep exactly the clock they showed before.
-fn turn_time_row(clock: String, timing: Option<TurnTiming>) -> String {
+/// A finished turn's bottom row, one clause per renderable unit: the completion
+/// clock, plus the turn's wall-clock breakdown when one was derivable. Legacy
+/// sessions without timestamps keep exactly the clock they showed before.
+///
+/// The row reads as the same middle-dot sentence it always did — the split only
+/// tells the layout where it may break the line.
+fn turn_time_parts(clock: String, timing: Option<TurnTiming>) -> Vec<String> {
     let Some(timing) = timing else {
-        return clock;
+        return vec![clock];
     };
     let parts = timing.secs();
-    [
+    vec![
         clock,
         tcode_i18n::tr!("chat.turn_total", duration = format_span(parts.total)).into_owned(),
         tcode_i18n::tr!("chat.turn_ai", duration = format_span(parts.ai)).into_owned(),
         tcode_i18n::tr!("chat.turn_tools", duration = format_span(parts.tools)).into_owned(),
     ]
-    .join(" · ")
+}
+
+/// The finished turn's bottom row, laid out from [`turn_time_parts`]. Each
+/// clause is its own item in a wrapping flow rather than one long string, so a
+/// narrow chat column (a diff panel is open, say) reflows the row at the middle
+/// dots instead of clipping the last clause at the divider. On a comfortable
+/// width the items pack onto one line and the row reads exactly as before.
+fn turn_time_footer(clauses: Vec<String>, muted: Hsla) -> Div {
+    /// Layout handles for the clauses, in render order (the last three only
+    /// exist when the turn had a derivable breakdown).
+    const SELECTORS: [&str; 4] = [
+        "turn-time-clock",
+        "turn-time-total",
+        "turn-time-ai",
+        "turn-time-tools",
+    ];
+
+    let last = clauses.len().saturating_sub(1);
+    h_flex()
+        .w_full()
+        .gap_1p5()
+        .items_start()
+        .text_size(px(13.))
+        .text_color(muted)
+        .debug_selector(|| "turn-time-row".into())
+        // The icon sits outside the wrapping flow, nudged onto the first line's
+        // optical center: wrapped clauses then hang under the clock rather than
+        // sliding under the icon.
+        .child(
+            div()
+                .flex_none()
+                .mt(px(3.))
+                .debug_selector(|| "turn-time-icon".into())
+                .child(Icon::new(IconName::Info).xsmall()),
+        )
+        .child(
+            h_flex()
+                .flex_1()
+                .min_w_0()
+                .flex_wrap()
+                .gap_x(px(4.))
+                .gap_y(px(2.))
+                .children(clauses.into_iter().enumerate().map(|(ix, clause)| {
+                    // Each clause carries the dot that follows it, so a line
+                    // break never strands a separator at the start of the next
+                    // line. `min_w_0` lets a clause too wide for a line of its
+                    // own wrap inside itself instead of spilling out of the row.
+                    let selector = SELECTORS.get(ix).copied().unwrap_or("turn-time-clause");
+                    div()
+                        .min_w_0()
+                        .debug_selector(move || selector.into())
+                        .child(if ix == last {
+                            clause
+                        } else {
+                            format!("{clause} ·")
+                        })
+                })),
+        )
 }
 
 /// Count added / removed lines in a unified diff (ignoring the `+++`/`---`
@@ -3514,8 +3570,8 @@ mod tests {
         copy_payload, diff_stats, displayed_error_text, file_edit_row, finished_work_log_label,
         format_duration, format_span, index_turns, list_sync, live_edit_counts, live_edit_rows,
         md_sync, plain_text_as_markdown, previous_logs_toggle_label, segment_entries,
-        timeline_overdraw, turn_time_row, turn_work_log_summary, work_log_auto_expands,
-        work_log_counts, work_log_row_entries, work_log_summary,
+        timeline_overdraw, turn_time_footer, turn_time_parts, turn_work_log_summary,
+        work_log_auto_expands, work_log_counts, work_log_row_entries, work_log_summary,
     };
     use crate::markdown::MarkdownState;
     use agent::{FileChange, FileChangeKind, ItemStatus};
@@ -4883,6 +4939,145 @@ This begins after the hard break."#;
     }
 
     // -- finished turn time row --------------------------------------------
+
+    /// The row as the reader sees it on one line: the clauses joined by the
+    /// middle dot the layout also draws between them.
+    fn turn_time_row(clock: String, timing: Option<TurnTiming>) -> String {
+        turn_time_parts(clock, timing).join(" · ")
+    }
+
+    /// Renders the production footer builder itself, so this layout test cannot
+    /// drift from what a finished turn actually paints.
+    struct TurnTimeFooterProbe {
+        clauses: Vec<String>,
+    }
+
+    impl gpui::Render for TurnTimeFooterProbe {
+        fn render(
+            &mut self,
+            _: &mut gpui::Window,
+            cx: &mut gpui::Context<Self>,
+        ) -> impl gpui::IntoElement {
+            // The turn column stacks the footer under the answer, so the row is
+            // content-height there; reproduce that rather than letting the window
+            // stretch it and mask a wrap.
+            use gpui::{ParentElement as _, Styled as _};
+            use gpui_component::ActiveTheme as _;
+            gpui_component::v_flex().size_full().child(turn_time_footer(
+                self.clauses.clone(),
+                cx.theme().muted_foreground,
+            ))
+        }
+    }
+
+    #[gpui::test]
+    fn the_time_row_wraps_its_clauses_instead_of_clipping_at_narrow_widths(
+        cx: &mut TestAppContext,
+    ) {
+        use gpui::{VisualTestContext, px, size};
+
+        let _locale_guard = crate::settings::TestLocaleGuard::acquire();
+        tcode_i18n::set_locale(tcode_i18n::LANGUAGE_ENGLISH);
+        let clauses = turn_time_parts("10:18 AM".into(), Some(TurnTiming::new(99_000, 0)));
+        // The footer's clauses, in render order (mirrors `turn_time_footer`).
+        let selectors = [
+            "turn-time-clock",
+            "turn-time-total",
+            "turn-time-ai",
+            "turn-time-tools",
+        ];
+        assert_eq!(clauses.len(), selectors.len());
+
+        cx.update(gpui_component::init);
+        let (_, cx) = cx.add_window_view(|_, _| TurnTimeFooterProbe { clauses });
+        let cx: &mut VisualTestContext = cx;
+        let draw = |cx: &mut VisualTestContext| {
+            cx.run_until_parked();
+            cx.update(|window, cx| {
+                _ = window.draw(cx);
+            });
+        };
+
+        // A comfortable chat width: the restrained single-line baseline.
+        cx.simulate_resize(size(px(900.), px(120.)));
+        draw(cx);
+        let baseline = cx.debug_bounds("turn-time-row").expect("row bounds");
+        let first = cx.debug_bounds(selectors[0]).expect("clock bounds");
+        let icon = cx.debug_bounds("turn-time-icon").expect("icon bounds");
+        assert!(
+            (icon.center().y - first.center().y).abs() <= px(1.5),
+            "the icon is not anchored to the first line: icon={icon:?}, clock={first:?}"
+        );
+        for selector in &selectors[1..] {
+            let clause = cx.debug_bounds(selector).expect("clause bounds");
+            assert_eq!(
+                clause.top(),
+                first.top(),
+                "{selector} left the single line at 900px: {clause:?}"
+            );
+        }
+
+        // Opening the diff panel squeezes the chat column; sweep well below any
+        // practical width. Every clause must stay inside the row and hang under
+        // the clock instead of spilling past the divider.
+        let mut wrapped = false;
+        for width in 260..=900 {
+            cx.simulate_resize(size(px(width as f32), px(120.)));
+            draw(cx);
+
+            let row = cx.debug_bounds("turn-time-row").expect("row bounds");
+            for selector in &selectors {
+                let clause = cx.debug_bounds(selector).expect("clause bounds");
+                assert!(
+                    clause.left() >= row.left() && clause.right() <= row.right(),
+                    "{selector} escaped the row at {width}px: row={row:?}, clause={clause:?}"
+                );
+                assert!(
+                    clause.left() >= first.left(),
+                    "{selector} broke the hanging indent at {width}px: {clause:?}"
+                );
+                assert!(
+                    clause.size.width > px(0.) && clause.size.height > px(0.),
+                    "{selector} was squeezed away at {width}px: {clause:?}"
+                );
+            }
+            wrapped |= row.size.height > baseline.size.height;
+        }
+        assert!(
+            wrapped,
+            "the row never reflowed onto a second line, so a narrow column must be clipping it"
+        );
+    }
+
+    #[test]
+    fn the_time_row_breaks_into_one_wrappable_unit_per_clause() {
+        let _locale_guard = crate::settings::TestLocaleGuard::acquire();
+        tcode_i18n::set_locale(tcode_i18n::LANGUAGE_ENGLISH);
+        // The footer wraps at clause boundaries, so each clause has to be its
+        // own unit — never one string the narrow column would have to clip.
+        assert_eq!(
+            turn_time_parts("3:04 PM".into(), Some(TurnTiming::new(80_000, 35_000))),
+            vec![
+                "3:04 PM",
+                "Total 1m 20s",
+                "AI thinking & response 45s",
+                "Tool calls 35s",
+            ]
+        );
+        // No clause carries a separator of its own: the row's dots belong to the
+        // layout, so a wrapped line can never open with an orphaned one.
+        for clause in turn_time_parts("3:04 PM".into(), Some(TurnTiming::new(80_000, 35_000))) {
+            assert!(
+                !clause.contains('·'),
+                "clause {clause:?} embeds a separator"
+            );
+        }
+        // The legacy fallback stays a single unit, so it renders dot-free.
+        assert_eq!(
+            turn_time_parts("9:00 AM".into(), None),
+            vec!["9:00 AM".to_string()]
+        );
+    }
 
     #[test]
     fn finished_time_row_spells_out_the_turn_breakdown_in_both_locales() {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -217,7 +217,12 @@ platform pays that inset.
   (N) · +A -D" + "Collapse all" ghost + "View diff" bordered button; body =
   directory tree, file rows with right-aligned per-file +a/-d; paths relative to
   the session cwd.
-- Small muted local-time row after each finished turn.
+- Finished turn's bottom row keeps the muted local completion clock; when the
+  turn has a trustworthy timestamped breakdown, it appends "Total", "AI
+  thinking & response", and "Tool calls" durations via the row's existing
+  middle-dot grammar, rolling hour-scale spans up to `Hh MMm SSs` so they stay
+  readable. Turns with legacy or untrustworthy timestamps show just the bare
+  clock.
 - Floating "⌄ Scroll to end" pill when not at bottom.
 
 ### Composer

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -12,6 +12,9 @@ chat:
   subagent_row: "%{agent}: %{description}"
   earlier_steps_truncated: "+earlier steps truncated"
   working_for: "Working for %{duration}"
+  turn_total: "Total %{duration}"
+  turn_ai: "AI thinking & response %{duration}"
+  turn_tools: "Tool calls %{duration}"
   summary_command_one: "Ran 1 command"
   summary_commands: "Ran %{count} commands"
   summary_file_one: "Edited 1 file"
@@ -625,6 +628,7 @@ time:
   days_ago: "%{count}d ago"
   duration_minutes: "%{minutes}m %{seconds}s"
   duration_seconds: "%{seconds}s"
+  duration_hours: "%{hours}h %{minutes}m %{seconds}s"
 errors:
   terminal_start: "Failed to start terminal: %{error}"
   terminal_restart: "Failed to restart terminal: %{error}"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -12,6 +12,9 @@ chat:
   subagent_row: "%{agent}：%{description}"
   earlier_steps_truncated: "+更早的步骤已截断"
   working_for: "已工作 %{duration}"
+  turn_total: "总计 %{duration}"
+  turn_ai: "AI 思考与回答 %{duration}"
+  turn_tools: "工具调用 %{duration}"
   summary_command_one: "已执行 1 条命令"
   summary_commands: "已执行 %{count} 条命令"
   summary_file_one: "编辑 1 个文件"
@@ -619,6 +622,7 @@ time:
   days_ago: "%{count} 天前"
   duration_minutes: "%{minutes} 分 %{seconds} 秒"
   duration_seconds: "%{seconds} 秒"
+  duration_hours: "%{hours} 小时 %{minutes} 分 %{seconds} 秒"
 errors:
   terminal_start: "启动终端失败：%{error}"
   terminal_restart: "重新启动终端失败：%{error}"


### PR DESCRIPTION
## Summary

- derive a trustworthy per-turn elapsed-time breakdown from timestamped TurnStarted through TurnCompleted events
- measure tool time as the union of active tool intervals and report AI thinking & response as the remaining elapsed time
- append Total, AI thinking & response, and Tool calls to the existing finished-turn clock in English and Simplified Chinese
- preserve a bare-clock fallback for legacy or inconsistent timestamps, retain seconds for hour-scale tasks, and wrap the footer cleanly in narrow chat layouts
- document the finished-turn timing-row contract

## Validation

- cargo fmt --all --check — passed
- cargo clippy --workspace --all-targets --locked -- -D warnings — passed
- cargo test -p tcode-core --locked — 117 passed
- cargo test -p tcode-ui --lib --locked — 184 passed
- cargo test --workspace --locked — all affected and preceding crates passed; the macOS term crate encountered its known transient PTY allocation error Os code -6 in two tests
- cargo test -p term --lib --locked — exact retry passed: 22 passed, 3 ignored, 0 failed
- visual QA — passed in light and dark themes at normal width and with the diff pane narrowing chat; all timing clauses remain visible without clipping or overlap
