### PR TITLE
feat(ui): adaptive markdown table layout with wrapping

### DIFF
--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -1038,6 +1038,7 @@ fn render_scroll_table(
 ) -> AnyElement {
     const CELL_PAD_PX: f32 = 16.;
     const CELL_MIN_PX: f32 = 48.;
+    const COL_MIN_PX: f32 = 100.;
 
     let text_style = window.text_style();
     let font_size = text_style.font_size.to_pixels(window.rem_size());
@@ -1084,7 +1085,11 @@ fn render_scroll_table(
             *slot = slot.max(f32::from(width) + CELL_PAD_PX);
         }
     }
-    let total_width = table_track_width(&widths);
+    let minimums = widths
+        .iter()
+        .map(|width| width.min(COL_MIN_PX))
+        .collect::<Vec<_>>();
+    let total_width = table_track_width(&minimums);
     let row_count = table.children.len();
     let rows = table
         .children
@@ -1105,12 +1110,25 @@ fn render_scroll_table(
                 })
                 .children(row.children.iter().enumerate().map(|(ix, cell)| {
                     let align = table.column_align(ix);
+                    let width = widths.get(ix).copied().unwrap_or(CELL_MIN_PX);
+                    let minimum = minimums.get(ix).copied().unwrap_or(CELL_MIN_PX);
+                    let cell_content = div().min_w_0().child(render_paragraph(
+                        &cell.children,
+                        &format!("{}-{row_ix}-{ix}", options.path),
+                        view,
+                        style,
+                        cx,
+                    ));
+                    #[cfg(test)]
+                    let cell_content = cell_content.debug_selector(move || {
+                        format!("markdown-table-cell-content-{row_ix}-{ix}")
+                    });
                     let rendered_cell = div()
                         .id(("table-cell", ix))
-                        .flex_basis(px(widths.get(ix).copied().unwrap_or(CELL_MIN_PX)))
-                        .flex_grow(widths.get(ix).copied().unwrap_or(CELL_MIN_PX))
-                        .flex_shrink_0()
-                        .whitespace_nowrap()
+                        .flex_basis(px(width))
+                        .flex_grow(width)
+                        .min_w(px(minimum))
+                        .whitespace_normal()
                         .flex()
                         .px_2()
                         .py_1()
@@ -1124,13 +1142,7 @@ fn render_scroll_table(
                             this.border_r_1().border_color(cx.theme().border)
                         })
                         .refine_style(&style.table_cell)
-                        .child(render_paragraph(
-                            &cell.children,
-                            &format!("{}-{row_ix}-{ix}", options.path),
-                            view,
-                            style,
-                            cx,
-                        ));
+                        .child(cell_content);
                     #[cfg(test)]
                     let rendered_cell = rendered_cell
                         .debug_selector(move || format!("markdown-table-cell-{row_ix}-{ix}"));

--- a/crates/ui/src/markdown/view.rs
+++ b/crates/ui/src/markdown/view.rs
@@ -315,7 +315,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn wide_table_keeps_its_intrinsic_width_inside_viewport(cx: &mut TestAppContext) {
+    fn wide_table_shrinks_to_viewport_and_wraps(cx: &mut TestAppContext) {
         cx.update(gpui_component::init);
         cx.update(crate::markdown::init);
         let (_, cx) = cx.add_window_view(|_, cx| {
@@ -333,10 +333,68 @@ mod tests {
         let track = cx
             .debug_bounds("markdown-table-track-root-0")
             .expect("table track was painted");
+        assert_eq!(
+            track.size.width,
+            px(320.),
+            "wide table did not shrink to the markdown viewport"
+        );
         assert!(
-            track.size.width > px(320.),
-            "wide table collapsed to viewport width {:?}",
-            track.size.width
+            track.size.height > px(68.),
+            "wide table did not grow tall enough for wrapped content: {:?}",
+            track.size.height
+        );
+    }
+
+    #[gpui::test]
+    fn small_table_stretches_to_viewport_width(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        cx.update(crate::markdown::init);
+        let (_, cx) =
+            cx.add_window_view(|_, cx| TestRoot::new("| a | b |\n| --- | --- |\n| 1 | 2 |", cx));
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        let track = cx
+            .debug_bounds("markdown-table-track-root-0")
+            .expect("table track was painted");
+        assert_eq!(
+            track.size.width,
+            px(320.),
+            "small table did not stretch to the markdown viewport"
+        );
+    }
+
+    #[gpui::test]
+    fn right_aligned_column_justifies_cell_content(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        cx.update(crate::markdown::init);
+        let (_, cx) = cx.add_window_view(|_, cx| {
+            TestRoot::new("| num | label |\n| ---: | --- |\n| 1 | value |", cx)
+        });
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        let cell = cx
+            .debug_bounds("markdown-table-cell-1-0")
+            .expect("right-aligned cell was painted");
+        let content = cx
+            .debug_bounds("markdown-table-cell-content-1-0")
+            .expect("cell content was painted");
+        // The stretched column is far wider than "1"; justify_end must push the
+        // content against the cell's right padding edge (px_2 = 8px).
+        assert!(
+            cell.right() - content.right() <= px(9.),
+            "content {content:?} is not right-justified inside cell {cell:?}"
+        );
+        assert!(
+            content.left() - cell.left() > px(20.),
+            "content {content:?} hugs the left edge of cell {cell:?}"
         );
     }
 
@@ -378,7 +436,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn streaming_table_growth_updates_track_width(cx: &mut TestAppContext) {
+    fn streaming_table_growth_updates_track_height(cx: &mut TestAppContext) {
         cx.update(gpui_component::init);
         cx.update(crate::markdown::init);
         let (view, cx) =
@@ -388,30 +446,33 @@ mod tests {
         cx.update(|window, cx| {
             let _ = window.draw(cx);
         });
-        let initial_width = cx
+        let initial_height = cx
             .debug_bounds("markdown-table-track-root-0")
             .expect("initial table track was painted")
             .size
-            .width;
+            .height;
 
         view.update(cx, |root, cx| {
             root.markdown.update(cx, |markdown, cx| {
-                markdown.push_str("-cell-that-grows-much-wider |", cx);
+                markdown.push_str(
+                    "-cell-that-grows-much-wider-and-keeps-growing-until-it-wraps |",
+                    cx,
+                );
             });
         });
         cx.run_until_parked();
         cx.update(|window, cx| {
             let _ = window.draw(cx);
         });
-        let grown_width = cx
+        let grown_height = cx
             .debug_bounds("markdown-table-track-root-0")
             .expect("grown table track was painted")
             .size
-            .width;
+            .height;
 
         assert!(
-            grown_width > initial_width,
-            "streamed table width stayed at {initial_width:?} instead of growing: {grown_width:?}"
+            grown_height > initial_height,
+            "streamed table height stayed at {initial_height:?} instead of growing: {grown_height:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Markdown tables now fill the available width instead of always sizing to intrinsic content width with horizontal scrolling.
- Each column has a minimum width of `min(natural content width, 100px)`. Columns share space proportionally to their natural content width; when the viewport is narrower than the summed natural widths, columns shrink down to their minimums and cell text wraps to multiple lines.
- Horizontal scrolling only engages when the summed minimum widths exceed the viewport, and every column still keeps its minimum width there.
- Implemented via taffy's native flex resolution (`flex_basis` = natural width, proportional `flex_grow`, default shrink with `min_w` floor) rather than a hand-rolled distribution algorithm.
- Column alignment (`:---:` / `---:`) is preserved: the inner paragraph wrapper shrinks to fit so `justify_center`/`justify_end` still position short content, with a new regression test locking this in.

## Tests
- Rewrote the three gpui tests that encoded the old always-scroll behavior: wide tables now assert clamping to viewport width plus wrapped height; the 20-column table still verifies scroll-mode geometry; the streaming test asserts height growth (wrapping) instead of width growth.
- Added tests for small tables stretching to full viewport width and right-aligned column justification.
- `cargo test -p tcode-ui` (186 passed), `cargo clippy -p tcode-ui --all-targets` clean, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)