### PR TITLE
feat(ui): markdown link targets with context menus

### DIFF
--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -903,6 +903,7 @@ impl ChatView {
                             index,
                             &entry.id,
                             text,
+                            cwd,
                             *context_len,
                             attachments,
                             *steering,
@@ -921,6 +922,7 @@ impl ChatView {
                     column = column.child(self.render_assistant(
                         &entry.id,
                         text,
+                        cwd,
                         pinned.1 == Some(entry.id.as_str()),
                         !streaming,
                         cx,
@@ -960,7 +962,8 @@ impl ChatView {
                 .filter(|plan| plan.turn == index)
                 .map(|plan| (plan.item_id.clone(), plan.markdown.clone()))
         } {
-            column = column.child(self.render_proposed_plan_card(index, &item_id, &markdown, cx));
+            column =
+                column.child(self.render_proposed_plan_card(index, &item_id, &markdown, cwd, cx));
         }
 
         // 4. CHANGED FILES card (aggregated across the turn's file changes).
@@ -1008,6 +1011,7 @@ impl ChatView {
                 index,
                 &entry.id,
                 text,
+                cwd,
                 *context_len,
                 attachments,
                 *steering,
@@ -1094,6 +1098,9 @@ impl ChatView {
         let app_state = self.app_state.clone();
         Some(
             Popover::new(("rewind-menu", turn))
+                // T3 overlay contour (shadow_xl at the 14px overlay radius).
+                .rounded(crate::material::radius_overlay())
+                .shadow_xl()
                 .anchor(Anchor::TopRight)
                 .trigger(trigger)
                 .content(move |_state, _window, cx| {
@@ -1115,18 +1122,13 @@ impl ChatView {
                         RewindMode::Files,
                         tcode_i18n::tr!("chat.rewind_files").into_owned(),
                     ));
-                    let mut menu = crate::material::overlay_contour(
-                        v_flex()
-                            .w(px(240.))
-                            .p_1()
-                            .gap_0p5()
-                            .rounded(crate::material::radius_overlay())
-                            .overflow_hidden(),
-                        cx,
-                    )
-                    .id(("rewind-options", turn))
-                    .role(Role::Menu)
-                    .aria_label(tcode_i18n::tr!("chat.rewind"));
+                    let mut menu = v_flex()
+                        .w(px(240.))
+                        .p_1()
+                        .gap_0p5()
+                        .id(("rewind-options", turn))
+                        .role(Role::Menu)
+                        .aria_label(tcode_i18n::tr!("chat.rewind"));
                     for (index, (mode, label)) in modes.into_iter().enumerate() {
                         let app_state = app_state.clone();
                         let popover = popover.clone();
@@ -1172,6 +1174,7 @@ impl ChatView {
         turn: usize,
         entry_id: &str,
         text: &str,
+        cwd: &Path,
         context_len: Option<usize>,
         attachments: &[String],
         steering: Option<SteeringStatus>,
@@ -1261,6 +1264,7 @@ impl ChatView {
             |md| {
                 MarkdownView::new(&md.state)
                     .selectable(true)
+                    .base_dir(cwd)
                     .into_any_element()
             },
         );
@@ -1473,6 +1477,7 @@ impl ChatView {
         &self,
         id: &str,
         text: &str,
+        cwd: &Path,
         pinned: bool,
         show_actions: bool,
         cx: &mut Context<Self>,
@@ -1482,6 +1487,7 @@ impl ChatView {
             (
                 MarkdownView::new(&md.state)
                     .selectable(true)
+                    .base_dir(cwd)
                     .into_any_element(),
                 md.synced.clone(),
             )
@@ -2220,6 +2226,7 @@ impl ChatView {
         turn: usize,
         item_id: &str,
         markdown: &str,
+        cwd: &Path,
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let title = tcode_core::session::plan_title(markdown)
@@ -2235,7 +2242,7 @@ impl ChatView {
                 .w_full()
                 .text_size(px(15.))
                 .line_height(px(22.))
-                .child(MarkdownView::new(&md.state).selectable(true))
+                .child(MarkdownView::new(&md.state).selectable(true).base_dir(cwd))
                 .into_any_element()
         } else {
             div()
@@ -2634,6 +2641,9 @@ impl ChatView {
         // context, so `cx.listener` is unavailable here).
         let chat = cx.entity();
         let chevron = Popover::new("git-menu")
+            // T3 overlay contour (shadow_xl at the 14px overlay radius).
+            .rounded(crate::material::radius_overlay())
+            .shadow_xl()
             .anchor(Anchor::TopRight)
             .trigger(
                 Button::new("git-menu-trigger")
@@ -2686,12 +2696,7 @@ impl ChatView {
                     }
                     menu = menu.child(row);
                 }
-                crate::material::overlay_contour(
-                    menu.rounded(crate::material::radius_overlay())
-                        .overflow_hidden(),
-                    cx,
-                )
-                .into_any_element()
+                menu.into_any_element()
             });
 
         Some(
@@ -2758,6 +2763,9 @@ impl ChatView {
         let menu_cwd = cwd;
 
         let chevron = Popover::new("open-menu")
+            // T3 overlay contour (shadow_xl at the 14px overlay radius).
+            .rounded(crate::material::radius_overlay())
+            .shadow_xl()
             .anchor(Anchor::TopRight)
             .trigger(
                 Button::new("open-menu-trigger")
@@ -2790,53 +2798,48 @@ impl ChatView {
                         .child(Icon::new(icon).xsmall().text_color(muted))
                         .child(label)
                 };
-                crate::material::overlay_contour(
-                    v_flex()
-                        .w(px(180.))
-                        .p_1()
-                        .gap_0p5()
-                        .rounded(crate::material::radius_overlay())
-                        .overflow_hidden()
-                        .child(
-                            menu_item(
-                                "open-zed",
-                                IconName::ExternalLink,
-                                tcode_i18n::tr!("chat.open_zed").into_owned().into(),
-                            )
-                            .on_click(move |_, window, cx| {
-                                open_in_zed(&zed_cwd, window, cx);
-                                p1.update(cx, |st, cx| st.dismiss(window, cx));
-                            }),
+                v_flex()
+                    .w(px(180.))
+                    .p_1()
+                    .gap_0p5()
+                    .child(
+                        menu_item(
+                            "open-zed",
+                            IconName::ExternalLink,
+                            tcode_i18n::tr!("chat.open_zed").into_owned().into(),
                         )
-                        .child(
-                            menu_item(
-                                "reveal-in-file-manager",
-                                IconName::FolderOpen,
-                                tcode_i18n::tr!("chat.reveal_in_file_manager")
-                                    .into_owned()
-                                    .into(),
-                            )
-                            .on_click(move |_, window, cx| {
-                                reveal_in_file_manager(&reveal_cwd, cx);
-                                p2.update(cx, |st, cx| st.dismiss(window, cx));
-                            }),
+                        .on_click(move |_, window, cx| {
+                            open_in_zed(&zed_cwd, window, cx);
+                            p1.update(cx, |st, cx| st.dismiss(window, cx));
+                        }),
+                    )
+                    .child(
+                        menu_item(
+                            "reveal-in-file-manager",
+                            IconName::FolderOpen,
+                            tcode_i18n::tr!("chat.reveal_in_file_manager")
+                                .into_owned()
+                                .into(),
                         )
-                        .child(
-                            menu_item(
-                                "copy-path",
-                                IconName::Copy,
-                                tcode_i18n::tr!("chat.copy_path").into_owned().into(),
-                            )
-                            .on_click(move |_, window, cx| {
-                                cx.write_to_clipboard(ClipboardItem::new_string(
-                                    copy_cwd.display().to_string(),
-                                ));
-                                p3.update(cx, |st, cx| st.dismiss(window, cx));
-                            }),
-                        ),
-                    cx,
-                )
-                .into_any_element()
+                        .on_click(move |_, window, cx| {
+                            reveal_in_file_manager(&reveal_cwd, cx);
+                            p2.update(cx, |st, cx| st.dismiss(window, cx));
+                        }),
+                    )
+                    .child(
+                        menu_item(
+                            "copy-path",
+                            IconName::Copy,
+                            tcode_i18n::tr!("chat.copy_path").into_owned().into(),
+                        )
+                        .on_click(move |_, window, cx| {
+                            cx.write_to_clipboard(ClipboardItem::new_string(
+                                copy_cwd.display().to_string(),
+                            ));
+                            p3.update(cx, |st, cx| st.dismiss(window, cx));
+                        }),
+                    )
+                    .into_any_element()
             });
 
         h_flex()

--- a/crates/ui/src/markdown/inline.rs
+++ b/crates/ui/src/markdown/inline.rs
@@ -16,9 +16,10 @@ use gpui::{
 use gpui_component::ActiveTheme as _;
 
 use super::{
+    link_target::{LinkTarget, resolve_link},
     nodes::LinkMark,
     selection::word_range_at,
-    state::{MarkdownMultiClickKind, MarkdownState},
+    state::{MarkdownMultiClickKind, MarkdownState, PendingLinkMenu},
     window_selection,
 };
 
@@ -84,11 +85,19 @@ impl Inline {
         links: &[(Range<usize>, LinkMark)],
         position: Point<Pixels>,
     ) -> Option<LinkMark> {
+        Self::link_and_range_for_position(layout, links, position).map(|(_, link)| link)
+    }
+
+    fn link_and_range_for_position(
+        layout: &TextLayout,
+        links: &[(Range<usize>, LinkMark)],
+        position: Point<Pixels>,
+    ) -> Option<(Range<usize>, LinkMark)> {
         let offset = layout.index_for_position(position).ok()?;
         links
             .iter()
             .find(|(range, _)| range.contains(&offset))
-            .map(|(_, link)| link.clone())
+            .map(|(range, link)| (range.clone(), link.clone()))
     }
 
     fn layout_selection(
@@ -426,6 +435,33 @@ impl Element for Inline {
             }
         });
 
+        window.on_mouse_event({
+            let hitbox = hitbox.clone();
+            let layout = text_layout.clone();
+            let links = self.links.clone();
+            let text = self.text.clone();
+            let view = self.view.clone();
+            move |event: &MouseDownEvent, phase, window, cx| {
+                if !phase.bubble()
+                    || event.button != MouseButton::Right
+                    || !hitbox.is_hovered(window)
+                {
+                    return;
+                }
+                let pending = Self::link_and_range_for_position(&layout, &links, event.position)
+                    .map(|(range, link)| {
+                        let target = resolve_link(&link.url, view.read(cx).base_dir());
+                        let text = text.get(range).map(SharedString::from).unwrap_or_default();
+                        PendingLinkMenu {
+                            target,
+                            text,
+                            raw_url: link.url,
+                        }
+                    });
+                view.update(cx, |state, cx| state.set_pending_context_link(pending, cx));
+            }
+        });
+
         if !has_selection {
             window.on_mouse_event({
                 let links = self.links.clone();
@@ -443,7 +479,10 @@ impl Element for Inline {
                     if let Some(link) = Self::link_for_position(&layout, &links, event.position) {
                         window_selection::finish_drag(window, cx);
                         cx.stop_propagation();
-                        cx.open_url(&link.url);
+                        match resolve_link(&link.url, view.read(cx).base_dir()) {
+                            LinkTarget::Web(url) => cx.open_url(&url),
+                            LinkTarget::Local(path) => cx.open_with_system(&path),
+                        }
                     }
                 }
             });

--- a/crates/ui/src/markdown/inline_flow.rs
+++ b/crates/ui/src/markdown/inline_flow.rs
@@ -18,6 +18,7 @@ use gpui_component::tooltip::Tooltip;
 
 use super::{
     inline::{Inline, InlineState},
+    link_target::{LinkTarget, resolve_link},
     nodes::LinkMark,
     state::MarkdownState,
     window_selection,
@@ -144,6 +145,7 @@ impl InlineFlow {
 
     fn image_element(
         ix: usize,
+        view: Entity<MarkdownState>,
         url: &SharedUri,
         link: &Option<LinkMark>,
         title: &str,
@@ -162,7 +164,10 @@ impl InlineFlow {
                     .on_click(move |_, window, cx| {
                         window_selection::finish_drag(window, cx);
                         cx.stop_propagation();
-                        cx.open_url(&link.url);
+                        match resolve_link(&link.url, view.read(cx).base_dir()) {
+                            LinkTarget::Web(url) => cx.open_url(&url),
+                            LinkTarget::Local(path) => cx.open_with_system(&path),
+                        }
                     })
             })
             .into_any_element()
@@ -333,8 +338,14 @@ impl Element for InlineFlow {
                     else {
                         continue;
                     };
-                    let mut element =
-                        Self::image_element(elements.len(), url, link, title, fragment_size);
+                    let mut element = Self::image_element(
+                        elements.len(),
+                        self.view.clone(),
+                        url,
+                        link,
+                        title,
+                        fragment_size,
+                    );
                     element.prepaint_as_root(
                         bounds.origin + origin,
                         size(

--- a/crates/ui/src/markdown/link_target.rs
+++ b/crates/ui/src/markdown/link_target.rs
@@ -1,0 +1,210 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum LinkTarget {
+    Web(String),
+    Local(PathBuf),
+}
+
+pub(super) fn resolve_link(url: &str, base_dir: Option<&Path>) -> LinkTarget {
+    if let Some(path) = url.strip_prefix("file://") {
+        return LinkTarget::Local(PathBuf::from(path));
+    }
+    if url.contains("://") || url.starts_with("mailto:") {
+        return LinkTarget::Web(url.to_string());
+    }
+
+    let mut candidates = vec![url.to_string()];
+    let mut index = 0;
+    while index < candidates.len() {
+        let candidate = &candidates[index];
+        for stripped in [strip_line_suffix(candidate), strip_line_fragment(candidate)]
+            .into_iter()
+            .flatten()
+        {
+            if !candidates.contains(&stripped) {
+                candidates.push(stripped);
+            }
+        }
+        index += 1;
+    }
+
+    for candidate in candidates {
+        let candidate = expand_home(&candidate);
+        let resolved = if candidate.is_absolute() {
+            Some(candidate)
+        } else {
+            base_dir.map(|base_dir| base_dir.join(candidate))
+        };
+        if let Some(path) = resolved
+            && path.exists()
+        {
+            return LinkTarget::Local(path);
+        }
+    }
+
+    LinkTarget::Web(url.to_string())
+}
+
+fn expand_home(path: &str) -> PathBuf {
+    let Some(rest) = path.strip_prefix("~/") else {
+        return PathBuf::from(path);
+    };
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .map(|home| home.join(rest))
+        .unwrap_or_else(|| PathBuf::from(path))
+}
+
+fn strip_line_suffix(path: &str) -> Option<String> {
+    let (without_last, last) = path.rsplit_once(':')?;
+    if last.is_empty() || !last.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    if let Some((without_line, line)) = without_last.rsplit_once(':')
+        && !line.is_empty()
+        && line.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Some(without_line.to_string());
+    }
+    Some(without_last.to_string())
+}
+
+fn strip_line_fragment(path: &str) -> Option<String> {
+    let (without_fragment, line) = path.rsplit_once("#L")?;
+    (!line.is_empty() && line.bytes().all(|byte| byte.is_ascii_digit()))
+        .then(|| without_fragment.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs, process,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use super::*;
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new() -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after Unix epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "tcode-markdown-link-target-{}-{nonce}",
+                process::id()
+            ));
+            fs::create_dir_all(&path).expect("create temporary test directory");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+
+        fn create_file(&self, relative: &str) -> PathBuf {
+            let path = self.0.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create parent directory");
+            }
+            fs::write(&path, b"test").expect("create temporary test file");
+            path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn classifies_web_schemes_and_mailto() {
+        assert_eq!(
+            resolve_link("https://example.com/docs", None),
+            LinkTarget::Web("https://example.com/docs".to_string())
+        );
+        assert_eq!(
+            resolve_link("custom://resource", None),
+            LinkTarget::Web("custom://resource".to_string())
+        );
+        assert_eq!(
+            resolve_link("mailto:hello@example.com", None),
+            LinkTarget::Web("mailto:hello@example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn file_scheme_is_always_local() {
+        assert_eq!(
+            resolve_link("file:///tmp/does-not-need-to-exist", None),
+            LinkTarget::Local(PathBuf::from("/tmp/does-not-need-to-exist"))
+        );
+    }
+
+    #[test]
+    fn resolves_existing_absolute_and_relative_paths() {
+        let temp = TempDir::new();
+        let absolute = temp.create_file("absolute.md");
+        let relative = temp.create_file("src/main.rs");
+
+        assert_eq!(
+            resolve_link(absolute.to_str().expect("UTF-8 temp path"), None),
+            LinkTarget::Local(absolute)
+        );
+        assert_eq!(
+            resolve_link("src/main.rs", Some(temp.path())),
+            LinkTarget::Local(relative)
+        );
+        assert_eq!(
+            resolve_link("src/main.rs", None),
+            LinkTarget::Web("src/main.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn expands_leading_home_directory() {
+        let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+            return;
+        };
+        assert_eq!(resolve_link("~/", None), LinkTarget::Local(home));
+    }
+
+    #[test]
+    fn strips_line_and_column_suffixes_for_existing_paths() {
+        let temp = TempDir::new();
+        let path = temp.create_file("src/lib.rs");
+
+        assert_eq!(
+            resolve_link("src/lib.rs:42", Some(temp.path())),
+            LinkTarget::Local(path.clone())
+        );
+        assert_eq!(
+            resolve_link("src/lib.rs:42:7", Some(temp.path())),
+            LinkTarget::Local(path)
+        );
+    }
+
+    #[test]
+    fn strips_line_fragment_for_existing_path() {
+        let temp = TempDir::new();
+        let path = temp.create_file("README.md");
+
+        assert_eq!(
+            resolve_link("README.md#L12", Some(temp.path())),
+            LinkTarget::Local(path)
+        );
+    }
+
+    #[test]
+    fn nonexistent_path_falls_back_to_original_web_target() {
+        let temp = TempDir::new();
+        assert_eq!(
+            resolve_link("missing/file.rs:42", Some(temp.path())),
+            LinkTarget::Web("missing/file.rs:42".to_string())
+        );
+    }
+}

--- a/crates/ui/src/markdown/mod.rs
+++ b/crates/ui/src/markdown/mod.rs
@@ -6,6 +6,7 @@
 
 mod inline;
 mod inline_flow;
+mod link_target;
 pub(crate) mod nodes;
 pub(crate) mod parse;
 mod render;

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -26,6 +26,7 @@ use crate::highlight;
 use super::{
     inline::{Inline, InlineState},
     inline_flow::{InlineCodeStyle, InlineFlow, InlineFlowItem},
+    link_target::{LinkTarget, resolve_link},
     nodes::{BlockNode, CodeBlock, ColumnumnAlign, Paragraph, Table, TextMark},
     state::MarkdownState,
     style::TextViewStyle,
@@ -512,12 +513,14 @@ fn render_paragraph(
             .children
             .iter()
             .filter_map(|child| child.image.as_ref());
+        let view = view.clone();
         return h_flex()
             .id(id.to_string())
             .flex_wrap()
             .gap_1()
-            .children(images.enumerate().map(|(ix, image)| {
+            .children(images.enumerate().map(move |(ix, image)| {
                 let title = image.title();
+                let view = view.clone();
                 img(image.url.clone())
                     .id(ix)
                     .object_fit(ObjectFit::Contain)
@@ -535,7 +538,10 @@ fn render_paragraph(
                             .on_click(move |_, window, cx| {
                                 window_selection::finish_drag(window, cx);
                                 cx.stop_propagation();
-                                cx.open_url(&link.url);
+                                match resolve_link(&link.url, view.read(cx).base_dir()) {
+                                    LinkTarget::Web(url) => cx.open_url(&url),
+                                    LinkTarget::Local(path) => cx.open_with_system(&path),
+                                }
                             })
                     })
             }))

--- a/crates/ui/src/markdown/state.rs
+++ b/crates/ui/src/markdown/state.rs
@@ -1,13 +1,24 @@
 //! Synchronous Markdown state, structurally adapted from gpui-component's
 //! Apache-2.0 `text/state.rs` implementation.
 
+use std::path::{Path, PathBuf};
+
 use gpui::{
     App, Bounds, Context, EntityId, FocusHandle, IntoElement, ListAlignment, ListState,
-    ParentElement as _, Pixels, Point, Render, Styled as _, Window, px,
+    ParentElement as _, Pixels, Point, Render, SharedString, Styled as _, Window, px,
 };
 use gpui_component::{ElementExt as _, v_flex};
 
-use super::{nodes::BlockNode, render, style::TextViewStyle, window_selection};
+use super::{
+    link_target::LinkTarget, nodes::BlockNode, render, style::TextViewStyle, window_selection,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct PendingLinkMenu {
+    pub(super) target: LinkTarget,
+    pub(super) text: SharedString,
+    pub(super) raw_url: SharedString,
+}
 
 /// State backing a [`super::MarkdownView`].
 pub struct MarkdownState {
@@ -15,6 +26,8 @@ pub struct MarkdownState {
     pub(super) entity_id: EntityId,
     pub(super) bounds: Bounds<Pixels>,
     pub(super) selectable: bool,
+    pub(super) base_dir: Option<PathBuf>,
+    pub(super) pending_context_link: Option<PendingLinkMenu>,
     pub(super) style: TextViewStyle,
     pub(super) is_selecting: bool,
     multi_click_selection: Option<MarkdownMultiClickSelection>,
@@ -36,6 +49,8 @@ impl MarkdownState {
             entity_id: cx.entity_id(),
             bounds: Bounds::default(),
             selectable: false,
+            base_dir: None,
+            pending_context_link: None,
             style: TextViewStyle::default(),
             is_selecting: false,
             multi_click_selection: None,
@@ -110,6 +125,31 @@ impl MarkdownState {
             self.reset_selection();
             window_selection::clear_selection_for_view(self.entity_id, cx);
         }
+        cx.notify();
+    }
+
+    /// Set the directory used to resolve relative Markdown links.
+    pub fn set_base_dir(&mut self, base_dir: Option<PathBuf>, cx: &mut Context<Self>) {
+        if self.base_dir == base_dir {
+            return;
+        }
+        self.base_dir = base_dir;
+        cx.notify();
+    }
+
+    pub(super) fn base_dir(&self) -> Option<&Path> {
+        self.base_dir.as_deref()
+    }
+
+    pub(super) fn set_pending_context_link(
+        &mut self,
+        pending_context_link: Option<PendingLinkMenu>,
+        cx: &mut Context<Self>,
+    ) {
+        if self.pending_context_link == pending_context_link {
+            return;
+        }
+        self.pending_context_link = pending_context_link;
         cx.notify();
     }
 

--- a/crates/ui/src/markdown/view.rs
+++ b/crates/ui/src/markdown/view.rs
@@ -1,15 +1,50 @@
 //! Markdown view element adapted from gpui-component's Apache-2.0
 //! `text/text_view.rs` implementation.
 
-use gpui::{
-    AnyElement, App, Bounds, ClipboardItem, Element, ElementId, Entity, GlobalElementId, Hitbox,
-    HitboxBehavior, InspectorElementId, InteractiveElement as _, IntoElement, LayoutId,
-    ParentElement as _, Pixels, StyleRefinement, Styled, Window, div,
-};
-use gpui_component::StyledExt as _;
-use gpui_component::input::{Copy, SelectAll};
+use std::path::{Path, PathBuf};
 
-use super::{state::MarkdownState, style::TextViewStyle, window_selection};
+use gpui::{
+    Action, AnyElement, App, Bounds, ClipboardItem, Element, ElementId, Entity, GlobalElementId,
+    Hitbox, HitboxBehavior, InspectorElementId, InteractiveElement as _, IntoElement, LayoutId,
+    MouseButton, MouseDownEvent, ParentElement as _, Pixels, StyleRefinement, Styled, Window, div,
+    prelude::FluentBuilder as _,
+};
+use gpui_component::{
+    StyledExt as _, WindowExt as _,
+    input::{Copy, SelectAll},
+    menu::ContextMenuExt as _,
+    notification::Notification,
+};
+use serde::Deserialize;
+
+use super::{
+    link_target::LinkTarget, state::MarkdownState, style::TextViewStyle, window_selection,
+};
+
+#[derive(Action, Clone, PartialEq, Eq, Deserialize)]
+#[action(namespace = tcode_markdown_link, no_json)]
+struct OpenLink(String);
+#[derive(Action, Clone, PartialEq, Eq, Deserialize)]
+#[action(namespace = tcode_markdown_link, no_json)]
+struct CopyLinkAddress(String);
+#[derive(Action, Clone, PartialEq, Eq, Deserialize)]
+#[action(namespace = tcode_markdown_link, no_json)]
+struct CopyLinkText(String);
+#[derive(Action, Clone, PartialEq, Eq, Deserialize)]
+#[action(namespace = tcode_markdown_link, no_json)]
+struct OpenPath(String);
+#[derive(Action, Clone, PartialEq, Eq, Deserialize)]
+#[action(namespace = tcode_markdown_link, no_json)]
+struct OpenPathInZed(String);
+#[derive(Action, Clone, PartialEq, Eq, Deserialize)]
+#[action(namespace = tcode_markdown_link, no_json)]
+struct RevealPath(String);
+#[derive(Action, Clone, PartialEq, Eq, Deserialize)]
+#[action(namespace = tcode_markdown_link, no_json)]
+struct CopyPath(String);
+#[derive(Action, Clone, PartialEq, Eq, Deserialize)]
+#[action(namespace = tcode_markdown_link, no_json)]
+struct CopyRelativePath(String);
 
 /// A GPUI element that renders an [`Entity<MarkdownState>`].
 #[derive(Clone)]
@@ -19,6 +54,7 @@ pub struct MarkdownView {
     text_view_style: TextViewStyle,
     style: StyleRefinement,
     selectable: Option<bool>,
+    base_dir: Option<PathBuf>,
 }
 
 impl MarkdownView {
@@ -30,6 +66,7 @@ impl MarkdownView {
             text_view_style: TextViewStyle::default(),
             style: StyleRefinement::default(),
             selectable: None,
+            base_dir: None,
         }
     }
 
@@ -42,6 +79,12 @@ impl MarkdownView {
     /// Set whether text participates in window-level selection.
     pub fn selectable(mut self, selectable: bool) -> Self {
         self.selectable = Some(selectable);
+        self
+    }
+
+    /// Set the directory used to resolve relative Markdown links.
+    pub fn base_dir(mut self, base_dir: impl Into<PathBuf>) -> Self {
+        self.base_dir = Some(base_dir.into());
         self
     }
 }
@@ -85,6 +128,9 @@ impl Element for MarkdownView {
             if let Some(selectable) = self.selectable {
                 state.set_selectable(selectable, cx);
             }
+            if let Some(base_dir) = &self.base_dir {
+                state.set_base_dir(Some(base_dir.clone()), cx);
+            }
         });
         let focus_handle = state.read(cx).focus_handle.clone();
         let copy_state = state.clone();
@@ -116,8 +162,83 @@ impl Element for MarkdownView {
                     state.update(cx, |state, cx| state.select_all(cx));
                 }
             })
+            .on_action(|action: &OpenLink, _, cx| cx.open_url(&action.0))
+            .on_action(|action: &CopyLinkAddress, _, cx| {
+                cx.write_to_clipboard(ClipboardItem::new_string(action.0.clone()))
+            })
+            .on_action(|action: &CopyLinkText, _, cx| {
+                cx.write_to_clipboard(ClipboardItem::new_string(action.0.clone()))
+            })
+            .on_action(|action: &OpenPath, _, cx| cx.open_with_system(Path::new(&action.0)))
+            .on_action(|action: &OpenPathInZed, window, cx| {
+                open_in_zed(Path::new(&action.0), window, cx)
+            })
+            .on_action(|action: &RevealPath, _, cx| cx.reveal_path(Path::new(&action.0)))
+            .on_action(|action: &CopyPath, _, cx| {
+                cx.write_to_clipboard(ClipboardItem::new_string(action.0.clone()))
+            })
+            .on_action(|action: &CopyRelativePath, _, cx| {
+                cx.write_to_clipboard(ClipboardItem::new_string(action.0.clone()))
+            })
             .child(state.clone())
             .refine_style(&self.style)
+            .context_menu({
+                let state = state.clone();
+                move |menu, _window, cx| {
+                    let markdown = state.read(cx);
+                    let Some(pending) = markdown.pending_context_link.clone() else {
+                        return menu;
+                    };
+                    match pending.target {
+                        LinkTarget::Web(url) => menu
+                            .menu(
+                                tcode_i18n::tr!("markdown.link_open").into_owned(),
+                                Box::new(OpenLink(url)),
+                            )
+                            .separator()
+                            .menu(
+                                tcode_i18n::tr!("markdown.link_copy_address").into_owned(),
+                                Box::new(CopyLinkAddress(pending.raw_url.to_string())),
+                            )
+                            .menu(
+                                tcode_i18n::tr!("markdown.link_copy_text").into_owned(),
+                                Box::new(CopyLinkText(pending.text.to_string())),
+                            ),
+                        LinkTarget::Local(path) => {
+                            let path = path.to_string_lossy().into_owned();
+                            let relative_path = markdown.base_dir().map(|base_dir| {
+                                tcode_runtime::ui_facade::relativize_to_workspace(&path, base_dir)
+                            });
+                            menu.menu(
+                                tcode_i18n::tr!("chat.open").into_owned(),
+                                Box::new(OpenPath(path.clone())),
+                            )
+                            .menu(
+                                tcode_i18n::tr!("chat.open_zed").into_owned(),
+                                Box::new(OpenPathInZed(path.clone())),
+                            )
+                            .menu(
+                                tcode_i18n::tr!("chat.reveal_in_file_manager").into_owned(),
+                                Box::new(RevealPath(path.clone())),
+                            )
+                            .separator()
+                            .menu(
+                                tcode_i18n::tr!("chat.copy_path").into_owned(),
+                                Box::new(CopyPath(path)),
+                            )
+                            .when_some(
+                                relative_path,
+                                |menu, relative_path| {
+                                    menu.menu(
+                                        tcode_i18n::tr!("markdown.path_copy_relative").into_owned(),
+                                        Box::new(CopyRelativePath(relative_path)),
+                                    )
+                                },
+                            )
+                        }
+                    }
+                }
+            })
             .into_any_element();
         let layout_id = element.request_layout(window, cx);
         (layout_id, (state, element))
@@ -149,7 +270,31 @@ impl Element for MarkdownView {
         if request_layout.0.read(cx).is_selectable() {
             window_selection::register_selectable_text_view(&request_layout.0, hitbox, window, cx);
         }
+        // Capture-phase so this runs before the Inline children's bubble-phase
+        // handlers repopulate the pending link: a right-click on a non-link
+        // area must not resurface the previous link's context menu.
+        window.on_mouse_event({
+            let hitbox = hitbox.clone();
+            let state = request_layout.0.clone();
+            move |event: &MouseDownEvent, phase, window, cx| {
+                if phase.capture()
+                    && event.button == MouseButton::Right
+                    && hitbox.is_hovered(window)
+                {
+                    state.update(cx, |state, cx| state.set_pending_context_link(None, cx));
+                }
+            }
+        });
         request_layout.1.paint(window, cx);
+    }
+}
+
+fn open_in_zed(path: &Path, window: &mut Window, cx: &mut App) {
+    if tcode_runtime::ui_facade::open_in_zed(path).is_err() {
+        window.push_notification(
+            Notification::error(tcode_i18n::tr!("errors.zed_cli_missing")),
+            cx,
+        );
     }
 }
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -65,6 +65,11 @@ chat:
   rewind_all_done: "Claude Code restored the code and conversation."
   rewind_conversation_done: "Claude Code restored the conversation. The original prompt is ready to edit."
   rewind_files_done: "Claude Code restored the tracked files."
+markdown:
+  link_open: "Open link"
+  link_copy_address: "Copy link address"
+  link_copy_text: "Copy link text"
+  path_copy_relative: "Copy relative path"
 sidebar:
   collapse: "Collapse sidebar"
   expand: "Expand sidebar"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -65,6 +65,11 @@ chat:
   rewind_all_done: "Claude Code 已恢复代码和对话。"
   rewind_conversation_done: "Claude Code 已恢复对话，原始提示已放回输入框，可编辑后重发。"
   rewind_files_done: "Claude Code 已恢复其跟踪的文件。"
+markdown:
+  link_open: "打开链接"
+  link_copy_address: "复制链接地址"
+  link_copy_text: "复制链接文字"
+  path_copy_relative: "复制相对路径"
 sidebar:
   collapse: "折叠侧边栏"
   expand: "展开侧边栏"


### PR DESCRIPTION
## Summary
- Classify markdown link URLs into web links vs local paths (`crates/ui/src/markdown/link_target.rs`): absolute/relative paths, `~` expansion, `file://`, and `:line[:col]` / `#L<n>` suffixes resolve to local files; anything else falls back to the existing browser behavior.
- Left click: web links open in the system browser (unchanged); local paths open with the OS default application (`cx.open_with_system`). Applies to text links and image links.
- Right-click context menus on markdown links:
  - Web: Open link · Copy link address · Copy link text
  - Local: Open · Open in Zed · Reveal in file manager · Copy path · Copy relative path (when a workspace cwd is known)
- Thread cwd is plumbed into chat markdown views (`MarkdownView::base_dir`) so relative paths resolve against the session workspace.
- New i18n strings in en + zh-CN; existing keys reused where identical.
- Also includes the popover contour cleanup in `chat.rs` (shadow_xl on `Popover` replacing the `overlay_contour` wrapper) that was pending in the working tree.

## Test plan
- `cargo test -p tcode-ui`: 193 passed (includes 7 new `link_target` resolver unit tests)
- `cargo check` (workspace) clean, `cargo fmt --all -- --check` clean
- Manually verified in the running app: link clicks, context menus on web/local links, and that right-clicking a non-link area no longer resurfaces the previous link's menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)