### PR TITLE
Fix cross-platform shortcut hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ or deny. Permission modes run from "ask about everything" to "don't ask".
 
 **Queue and steer.** The composer stays live while a turn runs.
 <kbd>Enter</kbd> queues your message and sends it when the turn finishes;
-<kbd>⌘</kbd><kbd>Enter</kbd> steers — injecting it into the turn in flight so the
-agent changes course at its next step. Queued messages show above the composer
-and can be promoted to a steer with one click.
+<kbd>⌘</kbd><kbd>Enter</kbd> on macOS or <kbd>Ctrl</kbd><kbd>Enter</kbd> on
+Windows/Linux steers — injecting it into the turn in flight so the agent changes
+course at its next step. Queued messages show above the composer and can be
+promoted to a steer with one click.
 
 **A terminal, a browser, and a plan.** Per-thread terminal drawer (select output,
 send it as context), an embedded preview browser the agent can drive over MCP,

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -40,6 +40,7 @@ use crate::composer_trigger::{
 use crate::context_meter;
 use crate::palette::fuzzy_score;
 use crate::provider_card::{CLAUDE_BRAND_COLOR, provider_glyph};
+use crate::shortcut::format_secondary_shortcut;
 use crate::workspace_walk::filter_entries;
 use tcode_core::attachments::validate_attachment;
 use tcode_core::session::append_review_comments_to_prompt;
@@ -126,16 +127,6 @@ struct ModelRow {
     /// This row starts a session with an installed ACP agent rather than
     /// selecting a model (ACP agents own their model list).
     acp: bool,
-}
-
-/// The platform's "secondary" modifier as the composer spells it: gpui binds
-/// `secondary-enter` to ⌘+Enter on macOS and Ctrl+Enter everywhere else.
-fn steer_modifier() -> &'static str {
-    if cfg!(target_os = "macos") {
-        "⌘"
-    } else {
-        "Ctrl+"
-    }
 }
 
 /// Queue-strip rows are single-line: collapse whitespace and clip long messages
@@ -3363,11 +3354,11 @@ impl Render for Composer {
             // token would render as a murky translucent wash here.
             .bg(cx.theme().popover)
             .shadow_md()
-            // ⌘V with image clipboard content, and arrow/Escape trigger-menu
+            // Secondary+V with image clipboard content, and arrow/Escape trigger-menu
             // navigation (fires after the input's own key actions).
             .capture_key_down(cx.listener(|this, ev: &gpui::KeyDownEvent, window, cx| {
                 let key = ev.keystroke.key.as_str();
-                if key == "v" && ev.keystroke.modifiers.platform {
+                if key == "v" && ev.keystroke.modifiers.secondary() {
                     this.paste_clipboard_image(window, cx);
                     return;
                 }
@@ -3431,7 +3422,7 @@ impl Render for Composer {
                         .text_color(cx.theme().muted_foreground)
                         .child(tcode_i18n::tr!(
                             "composer.queue_hint",
-                            modifier = steer_modifier()
+                            shortcut = format_secondary_shortcut("enter")
                         )),
                 )
             })
@@ -3651,7 +3642,7 @@ fn render_model_pane(
         );
     }
 
-    // ⌘1-9 selects the corresponding row while the popover is open.
+    // Secondary+1-9 selects the corresponding row while the popover is open.
     let key_rows: Vec<ModelRow> = rows.iter().take(9).cloned().collect();
     let app_key = app_entity.clone();
     let popover_key = popover.clone();
@@ -3663,7 +3654,7 @@ fn render_model_pane(
         .rounded(px(12.))
         .overflow_hidden()
         .on_key_down(move |ev, window, cx| {
-            if !ev.keystroke.modifiers.platform {
+            if !ev.keystroke.modifiers.secondary() {
                 return;
             }
             if let Ok(n) = ev.keystroke.key.parse::<usize>()
@@ -3775,7 +3766,7 @@ fn render_model_row(
                     .border_color(cx.theme().border)
                     .text_size(px(11.))
                     .text_color(muted)
-                    .child(format!("⌘{}", index + 1)),
+                    .child(format_secondary_shortcut(&(index + 1).to_string())),
             )
         })
         .child(

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -26,6 +26,7 @@ pub mod runtime_event;
 pub mod settings;
 mod settings_page;
 mod shell;
+mod shortcut;
 mod sidebar;
 mod terminal_drawer;
 pub mod time;

--- a/crates/ui/src/shortcut.rs
+++ b/crates/ui/src/shortcut.rs
@@ -1,0 +1,31 @@
+use gpui::{Keystroke, Modifiers};
+use gpui_component::kbd::Kbd;
+
+/// Format a shortcut using GPUI's semantic secondary modifier.
+///
+/// The secondary modifier is Command on macOS and Control on Windows/Linux.
+pub(crate) fn format_secondary_shortcut(key: &str) -> String {
+    Kbd::format(&Keystroke {
+        modifiers: Modifiers::secondary_key(),
+        key: key.to_owned(),
+        key_char: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_secondary_shortcut;
+
+    #[test]
+    fn formats_secondary_shortcuts_for_current_target() {
+        if cfg!(target_os = "macos") {
+            assert_eq!(format_secondary_shortcut("k"), "⌘K");
+            assert_eq!(format_secondary_shortcut("1"), "⌘1");
+            assert_eq!(format_secondary_shortcut("enter"), "⌘⏎");
+        } else {
+            assert_eq!(format_secondary_shortcut("k"), "Ctrl+K");
+            assert_eq!(format_secondary_shortcut("1"), "Ctrl+1");
+            assert_eq!(format_secondary_shortcut("enter"), "Ctrl+Enter");
+        }
+    }
+}

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -21,6 +21,7 @@ use serde::Deserialize;
 use tcode_core::project::SessionMeta;
 use tcode_runtime::app::{AppEvent, AppState, ProjectGroup, RuntimeError};
 
+use crate::shortcut::format_secondary_shortcut;
 use crate::time::now_secs;
 use crate::window_drag_area;
 
@@ -744,7 +745,7 @@ impl SessionsSidebar {
                     .border_color(cx.theme().border)
                     .text_color(cx.theme().muted_foreground)
                     .text_size(px(10.))
-                    .child("⌘K"),
+                    .child(format_secondary_shortcut("k")),
             ),
         )
     }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -110,7 +110,8 @@ in both states.
 1. App row: "tcode" bold 14px, channel pill ("DEV"). No collapse button — the
    toggle lives in the chat header, since a collapsed sidebar has no width to
    host it.
-2. Search row: magnifier + "Search" muted + ⌘K kbd chip → opens the palette.
+2. Search row: magnifier + "Search" muted + ⌘K (macOS) / Ctrl+K
+   (Windows/Linux) kbd chip → opens the palette.
 3. "PROJECTS" header: 11px uppercase muted + sort (no-op) + add-project button
    (native directory picker).
 4. Project groups: rotating chevron + folder icon + 13px medium name; hover
@@ -236,9 +237,10 @@ icon + "Local checkout" left, branch icon + current git branch right (hidden
 outside a git repo).
 
 Model picker popover (~360px, radius 12): left rail = favorites star + provider
-glyphs; search input; rows = model name (✓ current) + provider subtitle, ⌘1…⌘9
-chips, favorite star; footer note when a live session will restart (via resume)
-on model change. Picking a different provider on a thread with at least one
+glyphs; search input; rows = model name (✓ current) + provider subtitle,
+⌘1…⌘9 (macOS) / Ctrl+1…Ctrl+9 (Windows/Linux) chips, favorite star; footer note
+when a live session will restart (via resume) on model change. Picking a
+different provider on a thread with at least one
 completed turn defers the switch until send. Send opens a “Conversation relay”
 confirmation; confirming starts that provider fresh and sends a canonical
 timeline transcript (project, original provider/model, turn messages, compact
@@ -309,7 +311,7 @@ That provider/model picker is one shared component also used by the General
 page's thread-title setting, so catalog resolution and provider switching stay
 identical across both settings surfaces.
 
-### Command palette (⌘K)
+### Command palette (⌘K on macOS, Ctrl+K on Windows/Linux)
 Centered top-anchored modal over a dim backdrop: search input; grouped results
 — Actions (new thread per project, open settings, toggle theme, toggle diff
 panel) and Threads (fuzzy over titles); footer key hints (↑↓ Navigate · Enter

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -466,7 +466,7 @@ composer:
   send: "Send message"
   stop: "Stop current turn"
   wait_turn: "Wait for the current turn"
-  queue_hint: "Enter to queue · %{modifier}Enter to steer"
+  queue_hint: "Enter to queue · %{shortcut} to steer"
   queued_title: "Queued"
   queued_count: "%{count} queued"
   steer_queued: "Steer into the running turn"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -460,7 +460,7 @@ composer:
   send: "发送消息"
   stop: "停止当前轮次"
   wait_turn: "等待当前轮次结束"
-  queue_hint: "Enter 加入队列 · %{modifier}Enter 引导"
+  queue_hint: "Enter 加入队列 · %{shortcut} 引导"
   queued_title: "队列"
   queued_count: "%{count} 条排队中"
   steer_queued: "引导至当前轮次"


### PR DESCRIPTION
## Summary

- centralize secondary-shortcut formatting through GPUI platform-aware keyboard representation
- show `⌘…` on macOS and `Ctrl+…` on Windows/Linux in the sidebar search, model picker, and queue/steer hint
- align image paste and model-index selection behavior with the displayed semantic shortcut
- update English/Chinese copy and user-facing documentation

## Root cause

The affected UI labels were rendered from macOS-only literals, while two composer handlers inspected the physical platform modifier instead of GPUI's semantic secondary modifier. On Windows/Linux this produced misleading hints and prevented the conventional Control-based gestures from matching the UI.

## Impact

Windows and Linux users now see and can use `Ctrl+K`, `Ctrl+1…9`, `Ctrl+Enter`, and `Ctrl+V`; macOS keeps the native Command notation and behavior.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p tcode-ui shortcut --locked`
- `TCODE_LIVE_TESTS=0 cargo test --workspace --locked`
- guards confirming the old production-UI hardcodings are gone
