### PR TITLE
feat(ui): show markdown link targets on hover

### DIFF
--- a/crates/ui/src/markdown/inline.rs
+++ b/crates/ui/src/markdown/inline.rs
@@ -9,11 +9,12 @@ use std::{
 
 use gpui::{
     App, BorderStyle, Bounds, CursorStyle, Edges, Element, ElementId, Entity, GlobalElementId,
-    HighlightStyle, Hitbox, HitboxBehavior, InspectorElementId, IntoElement, LayoutId, MouseButton,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, SharedString, StyledText,
-    TextLayout, Window, point, px, quad,
+    HighlightStyle, Hitbox, InspectorElementId, InteractiveText, IntoElement, LayoutId,
+    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, SharedString,
+    StyledText, TextLayout, Window, point, px, quad,
 };
 use gpui_component::ActiveTheme as _;
+use gpui_component::tooltip::Tooltip;
 
 use super::{
     link_target::{LinkTarget, resolve_link},
@@ -51,7 +52,8 @@ pub(super) struct Inline {
     links: Rc<Vec<(Range<usize>, LinkMark)>>,
     highlights: Vec<(Range<usize>, HighlightStyle)>,
     font_overrides: Vec<(Range<usize>, SharedString)>,
-    styled_text: StyledText,
+    interactive_text: InteractiveText,
+    text_layout: TextLayout,
     state: Arc<Mutex<InlineState>>,
 }
 
@@ -64,18 +66,22 @@ impl Inline {
         highlights: Vec<(Range<usize>, HighlightStyle)>,
         font_overrides: Vec<(Range<usize>, SharedString)>,
     ) -> Self {
+        let id = id.into();
         let text = state
             .lock()
             .map(|state| state.text.clone())
             .unwrap_or_default();
+        let styled_text = StyledText::new(text.clone());
+        let text_layout = styled_text.layout().clone();
         Self {
-            id: id.into(),
+            id: id.clone(),
             view,
             text: text.clone(),
             links: Rc::new(links),
             highlights,
             font_overrides,
-            styled_text: StyledText::new(text),
+            interactive_text: InteractiveText::new(id, styled_text),
+            text_layout,
             state,
         }
     }
@@ -315,11 +321,21 @@ impl Element for Inline {
         if ix < self.text.len() {
             runs.push(text_style.to_run(self.text.len() - ix));
         }
-        self.styled_text = StyledText::new(self.text.clone())
+        let styled_text = StyledText::new(self.text.clone())
             .with_runs(runs)
             .with_font_family_overrides(self.font_overrides.clone());
+        self.text_layout = styled_text.layout().clone();
+        let links = self.links.clone();
+        let view = self.view.clone();
+        self.interactive_text = InteractiveText::new(self.id.clone(), styled_text).tooltip(
+            move |position, window, cx| {
+                let (_, link) = links.iter().find(|(range, _)| range.contains(&position))?;
+                let text = resolve_link(&link.url, view.read(cx).base_dir()).tooltip_text();
+                Some(Tooltip::new(text).build(window, cx))
+            },
+        );
         let (layout, _) = self
-            .styled_text
+            .interactive_text
             .request_layout(global_id, inspector_id, window, cx);
         (layout, ())
     }
@@ -333,9 +349,8 @@ impl Element for Inline {
         window: &mut Window,
         cx: &mut App,
     ) -> Self::PrepaintState {
-        self.styled_text
-            .prepaint(id, inspector_id, bounds, &mut (), window, cx);
-        window.insert_hitbox(bounds, HitboxBehavior::Normal)
+        self.interactive_text
+            .prepaint(id, inspector_id, bounds, &mut (), window, cx)
     }
 
     fn paint(
@@ -349,9 +364,9 @@ impl Element for Inline {
         cx: &mut App,
     ) {
         let current_view = window.current_view();
-        let text_layout = self.styled_text.layout().clone();
-        self.styled_text
-            .paint(global_id, None, bounds, &mut (), &mut (), window, cx);
+        let text_layout = self.text_layout.clone();
+        self.interactive_text
+            .paint(global_id, None, bounds, &mut (), hitbox, window, cx);
 
         let (selectable, has_selection, selection) =
             self.layout_selection(&text_layout, bounds, window, cx);

--- a/crates/ui/src/markdown/link_target.rs
+++ b/crates/ui/src/markdown/link_target.rs
@@ -6,6 +6,15 @@ pub(super) enum LinkTarget {
     Local(PathBuf),
 }
 
+impl LinkTarget {
+    pub(super) fn tooltip_text(&self) -> String {
+        match self {
+            Self::Web(url) => url.clone(),
+            Self::Local(path) => path.display().to_string(),
+        }
+    }
+}
+
 pub(super) fn resolve_link(url: &str, base_dir: Option<&Path>) -> LinkTarget {
     if let Some(path) = url.strip_prefix("file://") {
         return LinkTarget::Local(PathBuf::from(path));
@@ -205,6 +214,44 @@ mod tests {
         assert_eq!(
             resolve_link("missing/file.rs:42", Some(temp.path())),
             LinkTarget::Web("missing/file.rs:42".to_string())
+        );
+    }
+
+    #[test]
+    fn web_tooltip_preserves_raw_url() {
+        let url = "https://example.com/docs?view=raw#section";
+        assert_eq!(resolve_link(url, None).tooltip_text(), url);
+    }
+
+    #[test]
+    fn local_tooltips_show_resolved_relative_absolute_and_file_paths() {
+        let temp = TempDir::new();
+        let relative = temp.create_file("src/main.rs");
+        let absolute = temp.create_file("README.md");
+        let file_url = format!("file://{}", absolute.display());
+
+        assert_eq!(
+            resolve_link("src/main.rs", Some(temp.path())).tooltip_text(),
+            relative.display().to_string()
+        );
+        assert_eq!(
+            resolve_link(absolute.to_str().expect("UTF-8 temp path"), None).tooltip_text(),
+            absolute.display().to_string()
+        );
+        assert_eq!(
+            resolve_link(&file_url, None).tooltip_text(),
+            absolute.display().to_string()
+        );
+    }
+
+    #[test]
+    fn line_suffixed_local_tooltip_shows_actual_opened_file() {
+        let temp = TempDir::new();
+        let path = temp.create_file("src/lib.rs");
+
+        assert_eq!(
+            resolve_link("src/lib.rs:42:7", Some(temp.path())).tooltip_text(),
+            path.display().to_string()
         );
     }
 }


### PR DESCRIPTION
## Summary

- show a standard delayed tooltip when hovering Markdown link text
- display the original URL for web links and the resolved concrete path for local links
- preserve the existing click, selection, pointing-cursor, and right-click context-menu behavior

## Why

Markdown labels can hide the destination users are about to open. Local links are also commonly relative or include line and column suffixes, so the visible label alone does not reveal the actual file target.

## Impact

Users can inspect the real destination before opening a blue Markdown link. Relative, absolute, file-scheme, and line-suffixed local targets all surface the path that the existing click action will open.

## Validation

- cargo fmt --all -- --check
- cargo test -p tcode-ui --lib markdown::link_target::tests — 10 passed
- cargo test -p tcode-ui --lib markdown:: — 49 passed
- cargo check -p tcode-ui
- manual hover behavior verified by the user