### PR TITLE
refactor(ui): drop terminal pane border, keep uniform 8px padding

### DIFF
--- a/crates/ui/src/terminal_drawer.rs
+++ b/crates/ui/src/terminal_drawer.rs
@@ -39,9 +39,7 @@ const TERMINAL_FONT_FAMILY: &str = "Menlo";
 const TERMINAL_FONT_FAMILY: &str = "Consolas";
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 const TERMINAL_FONT_FAMILY: &str = "Lilex";
-const PANE_PADDING_X: f32 = 8.;
-const PANE_PADDING_Y: f32 = 5.;
-const PANE_BORDER: f32 = 1.;
+const PANE_PADDING: f32 = 8.;
 const SELECTION_DRAG_THRESHOLD: f32 = 2.;
 
 #[derive(Action, Clone, PartialEq, Eq, serde::Deserialize)]
@@ -1073,29 +1071,11 @@ impl TerminalDrawer {
             .size_full()
             .min_h_0()
             .overflow_hidden()
-            .px(px(PANE_PADDING_X))
-            .py(px(PANE_PADDING_Y))
-            .border_1()
-            .rounded(material::radius_card())
-            .border_color(
-                if self
-                    .app_state
-                    .read(cx)
-                    .active
-                    .as_ref()
-                    .is_some_and(|active| active.terminal_workspace.active_id == Some(terminal_id))
-                {
-                    cx.theme().ring.opacity(0.72)
-                } else {
-                    cx.theme().border
-                },
-            )
+            .p(px(PANE_PADDING))
             .when(link_hovered, |this| this.cursor_pointer())
             .on_prepaint(move |bounds, _window, cx| {
-                let content_width =
-                    f32::from(bounds.size.width) - 2. * (PANE_BORDER + PANE_PADDING_X);
-                let content_height =
-                    f32::from(bounds.size.height) - 2. * (PANE_BORDER + PANE_PADDING_Y);
+                let content_width = f32::from(bounds.size.width) - 2. * PANE_PADDING;
+                let content_height = f32::from(bounds.size.height) - 2. * PANE_PADDING;
                 let cols = (content_width / cell_width).floor().max(2.) as usize;
                 let rows = (content_height / cell_height).floor().max(2.) as usize;
                 if let Some(entry) = app_state
@@ -1167,8 +1147,8 @@ impl TerminalDrawer {
                 this.child(
                     Button::new(("terminal-add-context", terminal_id))
                         .absolute()
-                        .right(px(PANE_BORDER + PANE_PADDING_X))
-                        .top(px(PANE_BORDER + PANE_PADDING_Y))
+                        .right(px(PANE_PADDING))
+                        .top(px(PANE_PADDING))
                         .small()
                         .label(tcode_i18n::tr!("terminal.add_context"))
                         .tooltip(format!(

--- a/crates/ui/src/terminal_drawer.rs
+++ b/crates/ui/src/terminal_drawer.rs
@@ -1038,12 +1038,7 @@ impl TerminalDrawer {
             return div().into_any_element();
         };
 
-        let mut grid = v_flex().child(self.render_grid(
-            terminal_id,
-            &snapshot,
-            register_input,
-            cx,
-        ));
+        let mut grid = v_flex().child(self.render_grid(terminal_id, &snapshot, register_input, cx));
         if snapshot.exited {
             let status = snapshot
                 .exit_code

--- a/crates/ui/src/terminal_drawer.rs
+++ b/crates/ui/src/terminal_drawer.rs
@@ -735,7 +735,10 @@ impl TerminalDrawer {
                 });
             },
         )
-        .w_full()
+        // The pane is rarely an exact multiple of the cell metrics; it centers
+        // this canvas, so the sub-cell remainder is split evenly on both axes
+        // instead of accumulating at the right/bottom edge.
+        .w(px(cols as f32 * cell_width))
         .h(px(rows as f32 * cell_height))
         .into_any_element()
     }
@@ -1035,7 +1038,7 @@ impl TerminalDrawer {
             return div().into_any_element();
         };
 
-        let mut grid = v_flex().min_w_full().child(self.render_grid(
+        let mut grid = v_flex().child(self.render_grid(
             terminal_id,
             &snapshot,
             register_input,
@@ -1072,6 +1075,8 @@ impl TerminalDrawer {
             .min_h_0()
             .overflow_hidden()
             .p(px(PANE_PADDING))
+            .items_center()
+            .justify_center()
             .when(link_hovered, |this| this.cursor_pointer())
             .on_prepaint(move |bounds, _window, cx| {
                 let content_width = f32::from(bounds.size.width) - 2. * PANE_PADDING;


### PR DESCRIPTION
## What

The terminal pane drew a rounded border (blue `ring` when the terminal was active) around the grid. This removes the border entirely so the grid sits directly in the panel, and unifies the inner padding to a single 8px constant on all sides (previously 8px horizontal / 5px vertical plus a 1px border inset).

- Removed `.border_1() / .rounded() / .border_color()` from the terminal pane
- Unified padding: `PANE_PADDING_X 8 / PANE_PADDING_Y 5 / PANE_BORDER 1` → single `PANE_PADDING = 8`
- PTY resize math and the add-to-context overlay position updated to match

## Verification

- `cargo check` / `cargo clippy -p tcode-ui`: clean
- Built a release binary and drove the app in a tart VM: screenshot confirms no border, even ~8px padding on all sides, terminal renders correctly (dense edge-to-edge output, tab strip intact, no layout breakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)