### PR TITLE
fix(plan): make plan mode a single lifecycle folded from the event log

### DIFF
--- a/crates/agent/src/acp.rs
+++ b/crates/agent/src/acp.rs
@@ -11,6 +11,7 @@
 //! that cross the thread boundary — exactly like `claude.rs` / `codex.rs`.
 
 use std::collections::{HashMap, VecDeque};
+use std::future::Future;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
@@ -32,10 +33,10 @@ use serde_json::{Value, json};
 use crate::{
     AcpAgent, AcpLaunch, AgentError, AgentEvent, ApprovalDecision, ApprovalKind, ApprovalMode,
     ApprovalOption, ApprovalOptionKind, ApprovalRequest, Attachment, DeltaKind, FileChange,
-    FileChangeKind, ItemContent, ItemStatus, McpRegistration, OptionDescriptor, OptionSelection,
-    PlanStep, PlanStepStatus, ProviderCommand, ProviderCommandKind, ProviderKind, ResumeCursor,
-    SelectOption, SessionCommand, SessionHandle, SessionOptions, ThreadItem, TokenUsage,
-    TurnStatus,
+    FileChangeKind, InteractionMode, ItemContent, ItemStatus, McpRegistration, OptionDescriptor,
+    OptionSelection, PlanStep, PlanStepStatus, ProviderCommand, ProviderCommandKind, ProviderKind,
+    ResumeCursor, SelectOption, SessionCommand, SessionHandle, SessionOptions, ThreadItem,
+    TokenUsage, TurnStatus,
 };
 
 /// Option-descriptor ids. The composer renders an ACP agent's own
@@ -817,30 +818,39 @@ async fn handshake(
             }
         };
 
-    if opts.approval_mode == ApprovalMode::ReadOnly
-        && let Some(plan_mode) = modes.as_ref().and_then(acp_plan_mode)
+    let wants_plan = opts.approval_mode == ApprovalMode::ReadOnly
+        || opts.interaction_mode == InteractionMode::Plan;
+    let target_mode = modes.as_ref().and_then(|modes| {
+        if wants_plan {
+            acp_plan_mode(modes)
+        } else if acp_plan_mode(modes).as_ref() == Some(&modes.current_mode_id) {
+            first_non_plan_mode(modes)
+        } else {
+            None
+        }
+    });
+    if let Some(target_mode) = target_mode
         && modes
             .as_ref()
-            .is_some_and(|modes| modes.current_mode_id != plan_mode)
+            .is_some_and(|modes| modes.current_mode_id != target_mode)
     {
         match connection
             .send_request(acp::SetSessionModeRequest::new(
                 session_id.clone(),
-                plan_mode.clone(),
+                target_mode.clone(),
             ))
             .block_task()
             .await
         {
-            Ok(_) => modes.as_mut().unwrap().current_mode_id = plan_mode,
+            Ok(_) => modes.as_mut().unwrap().current_mode_id = target_mode,
             Err(err) => {
                 // ACP has no provider-independent permission policy. If an
-                // advertised plan mode cannot be selected, retain the agent's
-                // current mode, which is the same least-privilege fallback used
-                // for Supervised sessions.
+                // advertised mode cannot be selected, retain the agent's
+                // current mode and let the pushed option correct the chip.
                 let _ = events
                     .send(AgentEvent::Warning {
                         message: format!(
-                            "{} could not enter its read-only plan mode: {}",
+                            "{} could not enter the requested interaction mode: {}",
                             agent.name,
                             describe(&err)
                         ),
@@ -848,15 +858,27 @@ async fn handshake(
                     .await;
             }
         }
+    } else if wants_plan
+        && modes
+            .as_ref()
+            .is_none_or(|modes| acp_plan_mode(modes).is_none())
+    {
+        let _ = events
+            .send(AgentEvent::Warning {
+                message: format!(
+                    "{} does not advertise a Plan mode; the mode switch was not applied.",
+                    agent.name
+                ),
+            })
+            .await;
     }
 
     let model = config_options.as_deref().and_then(current_model);
     {
         let mut state = state.lock().unwrap();
         state.session_id = Some(session_id.clone());
-        state
-            .options
-            .ingest(modes.as_ref(), config_options.as_deref());
+        state.ingest_modes(modes.as_ref());
+        state.options.ingest(None, config_options.as_deref());
     }
 
     Ok(Session {
@@ -871,6 +893,15 @@ fn acp_plan_mode(modes: &acp::SessionModeState) -> Option<acp::SessionModeId> {
         .available_modes
         .iter()
         .find(|mode| mode.id.0.eq_ignore_ascii_case("plan"))
+        .map(|mode| mode.id.clone())
+}
+
+fn first_non_plan_mode(modes: &acp::SessionModeState) -> Option<acp::SessionModeId> {
+    let plan = acp_plan_mode(modes);
+    modes
+        .available_modes
+        .iter()
+        .find(|mode| Some(&mode.id) != plan.as_ref())
         .map(|mode| mode.id.clone())
 }
 
@@ -1192,7 +1223,13 @@ async fn handle_command(
                         if let Some(options) = config_options.as_deref() {
                             state.options.ingest(None, Some(options));
                         }
-                        state.options.select(&id, value);
+                        if origin == OptionOrigin::Mode {
+                            if let Some(mode) = value.as_str() {
+                                state.select_mode(acp::SessionModeId::new(mode));
+                            }
+                        } else {
+                            state.options.select(&id, value);
+                        }
                     }
                     emit_provider_options(state, events).await;
                 }
@@ -1218,9 +1255,17 @@ async fn handle_command(
                 })
                 .await;
         }
-        SessionCommand::SetInteractionMode(_) => {
-            // Build/Plan is a session *mode* in ACP; the traits picker drives it
-            // through `SetOption` (`acp:mode`).
+        SessionCommand::SetInteractionMode(mode) => {
+            apply_interaction_mode(mode, state, events, |mode_id| async move {
+                connection
+                    .send_request(acp::SetSessionModeRequest::new(
+                        session.session_id.clone(),
+                        mode_id,
+                    ))
+                    .block_task()
+                    .await
+            })
+            .await;
         }
         SessionCommand::Rewind {
             checkpoint_id,
@@ -1275,6 +1320,56 @@ async fn set_option(
                 .block_task()
                 .await?;
             Ok(Some(response.config_options))
+        }
+    }
+}
+
+async fn apply_interaction_mode<F, Fut>(
+    mode: InteractionMode,
+    state: &Arc<Mutex<State>>,
+    events: &Sender<AgentEvent>,
+    set_mode: F,
+) where
+    F: FnOnce(acp::SessionModeId) -> Fut,
+    Fut: Future<Output = Result<acp::SetSessionModeResponse, acp::Error>>,
+{
+    let target = {
+        let state = state.lock().unwrap();
+        match mode {
+            InteractionMode::Plan => state.modes.as_ref().and_then(acp_plan_mode),
+            InteractionMode::Build => state.build_mode(),
+        }
+    };
+    let Some(target) = target else {
+        let mode_name = match mode {
+            InteractionMode::Plan => "Plan",
+            InteractionMode::Build => "Build",
+        };
+        let _ = events
+            .send(AgentEvent::Warning {
+                message: format!(
+                    "This agent does not advertise a {mode_name} mode; the mode switch was not applied."
+                ),
+            })
+            .await;
+        // Republish the actual selection so the runtime rolls back its
+        // optimistic Build/Plan toggle instead of leaving a lying chip.
+        emit_provider_options_even_if_empty(state, events).await;
+        return;
+    };
+
+    match set_mode(target.clone()).await {
+        Ok(_) => {
+            state.lock().unwrap().select_mode(target);
+            emit_provider_options(state, events).await;
+        }
+        Err(err) => {
+            let _ = events
+                .send(AgentEvent::Warning {
+                    message: format!("could not switch this agent's mode: {}", describe(&err)),
+                })
+                .await;
+            emit_provider_options_even_if_empty(state, events).await;
         }
     }
 }
@@ -1410,6 +1505,22 @@ async fn emit_provider_options(state: &Arc<Mutex<State>>, events: &Sender<AgentE
     if descriptors.is_empty() {
         return;
     }
+    let _ = events
+        .send(AgentEvent::ProviderOptions {
+            descriptors,
+            selections,
+        })
+        .await;
+}
+
+async fn emit_provider_options_even_if_empty(
+    state: &Arc<Mutex<State>>,
+    events: &Sender<AgentEvent>,
+) {
+    let (descriptors, selections) = {
+        let state = state.lock().unwrap();
+        (state.options.descriptors(), state.options.selections())
+    };
     let _ = events
         .send(AgentEvent::ProviderOptions {
             descriptors,
@@ -1620,6 +1731,8 @@ pub(crate) struct State {
     terminals: HashMap<String, Arc<Terminal>>,
     usage: Option<TokenUsage>,
     options: OptionRegistry,
+    modes: Option<acp::SessionModeState>,
+    previous_non_plan_mode: Option<acp::SessionModeId>,
 }
 
 impl State {
@@ -1639,7 +1752,44 @@ impl State {
             terminals: HashMap::new(),
             usage: None,
             options: OptionRegistry::default(),
+            modes: None,
+            previous_non_plan_mode: None,
         }
+    }
+
+    fn ingest_modes(&mut self, modes: Option<&acp::SessionModeState>) {
+        let Some(modes) = modes else {
+            return;
+        };
+        self.modes = Some(modes.clone());
+        self.select_mode(modes.current_mode_id.clone());
+        self.options.ingest(Some(modes), None);
+    }
+
+    fn select_mode(&mut self, mode: acp::SessionModeId) {
+        let is_plan = self
+            .modes
+            .as_ref()
+            .and_then(acp_plan_mode)
+            .is_some_and(|plan| plan == mode);
+        if !is_plan {
+            self.previous_non_plan_mode = Some(mode.clone());
+        }
+        if let Some(modes) = self.modes.as_mut() {
+            modes.current_mode_id = mode.clone();
+        }
+        self.options
+            .select(MODE_OPTION_ID, Value::String(mode.0.to_string()));
+    }
+
+    fn build_mode(&self) -> Option<acp::SessionModeId> {
+        let modes = self.modes.as_ref()?;
+        // ACP exposes no distinct default mode. Remember the last non-plan
+        // selection from before Plan; if the session began in Plan, fall back
+        // to the first advertised non-plan mode (the agent's ordering).
+        self.previous_non_plan_mode
+            .clone()
+            .or_else(|| first_non_plan_mode(modes))
     }
 
     /// Close the open text block, emitting its final `ItemCompleted`.
@@ -1794,10 +1944,7 @@ impl State {
                 }]
             }
             acp::SessionUpdate::CurrentModeUpdate(update) => {
-                self.options.select(
-                    MODE_OPTION_ID,
-                    Value::String(update.current_mode_id.0.to_string()),
-                );
+                self.select_mode(update.current_mode_id.clone());
                 vec![AgentEvent::ProviderOptions {
                     descriptors: self.options.descriptors(),
                     selections: self.options.selections(),
@@ -2537,6 +2684,102 @@ mod tests {
 
     fn update(json: Value) -> acp::SessionUpdate {
         serde_json::from_value(json).expect("valid session/update payload")
+    }
+
+    fn modes(current: &str, available: &[&str]) -> acp::SessionModeState {
+        serde_json::from_value(json!({
+            "currentModeId": current,
+            "availableModes": available
+                .iter()
+                .map(|id| json!({ "id": id, "name": id }))
+                .collect::<Vec<_>>()
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn set_interaction_mode_plan_issues_the_advertised_mode_request() {
+        smol::block_on(async {
+            let state = Arc::new(Mutex::new(state()));
+            state
+                .lock()
+                .unwrap()
+                .ingest_modes(Some(&modes("build", &["build", "plan"])));
+            let (events, _) = async_channel::unbounded();
+            let requested = Arc::new(Mutex::new(Vec::new()));
+
+            apply_interaction_mode(InteractionMode::Plan, &state, &events, {
+                let requested = requested.clone();
+                move |mode| async move {
+                    requested.lock().unwrap().push(mode.0.to_string());
+                    Ok(acp::SetSessionModeResponse::new())
+                }
+            })
+            .await;
+
+            assert_eq!(*requested.lock().unwrap(), vec!["plan"]);
+        });
+    }
+
+    #[test]
+    fn set_interaction_mode_build_restores_the_previous_non_plan_mode() {
+        smol::block_on(async {
+            let state = Arc::new(Mutex::new(state()));
+            state
+                .lock()
+                .unwrap()
+                .ingest_modes(Some(&modes("review", &["review", "build", "plan"])));
+            let (events, _) = async_channel::unbounded();
+            let requested = Arc::new(Mutex::new(Vec::new()));
+
+            apply_interaction_mode(InteractionMode::Plan, &state, &events, {
+                let requested = requested.clone();
+                move |mode| async move {
+                    requested.lock().unwrap().push(mode.0.to_string());
+                    Ok(acp::SetSessionModeResponse::new())
+                }
+            })
+            .await;
+            apply_interaction_mode(InteractionMode::Build, &state, &events, {
+                let requested = requested.clone();
+                move |mode| async move {
+                    requested.lock().unwrap().push(mode.0.to_string());
+                    Ok(acp::SetSessionModeResponse::new())
+                }
+            })
+            .await;
+
+            assert_eq!(*requested.lock().unwrap(), vec!["plan", "review"]);
+        });
+    }
+
+    #[test]
+    fn set_interaction_mode_plan_without_advertised_plan_warns() {
+        smol::block_on(async {
+            let state = Arc::new(Mutex::new(state()));
+            state
+                .lock()
+                .unwrap()
+                .ingest_modes(Some(&modes("build", &["build", "review"])));
+            let (events, received) = async_channel::unbounded();
+            let requested = Arc::new(Mutex::new(Vec::new()));
+
+            apply_interaction_mode(InteractionMode::Plan, &state, &events, {
+                let requested = requested.clone();
+                move |mode| async move {
+                    requested.lock().unwrap().push(mode.0.to_string());
+                    Ok(acp::SetSessionModeResponse::new())
+                }
+            })
+            .await;
+
+            assert!(requested.lock().unwrap().is_empty());
+            assert!(matches!(
+                received.recv().await.unwrap(),
+                AgentEvent::Warning { message }
+                    if message.contains("does not advertise a Plan mode")
+            ));
+        });
     }
 
     #[test]

--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -63,6 +63,37 @@ pub(crate) fn permission_mode_flag(mode: ApprovalMode) -> &'static str {
     }
 }
 
+/// Permission mode placed on the internal launch argv. Persisted Plan sessions
+/// must enter the CLI's plan sandbox before their first message, without
+/// depending on an unchecked live control request.
+fn initial_permission_mode(
+    approval_mode: ApprovalMode,
+    interaction_mode: InteractionMode,
+) -> &'static str {
+    match interaction_mode {
+        InteractionMode::Plan => "plan",
+        InteractionMode::Build => permission_mode_flag(approval_mode),
+    }
+}
+
+/// Resolve the last permission-mode value on the effective argv. Provider
+/// launch arguments intentionally follow internal arguments and may use either
+/// CLI spelling, so the mode tracker must honor both.
+fn effective_permission_mode(internal: &str, extra_args: &[String]) -> String {
+    let mut effective = internal.to_owned();
+    let mut args = extra_args.iter();
+    while let Some(arg) = args.next() {
+        if arg == "--permission-mode" {
+            if let Some(value) = args.next() {
+                effective.clone_from(value);
+            }
+        } else if let Some(value) = arg.strip_prefix("--permission-mode=") {
+            effective = value.to_owned();
+        }
+    }
+    effective
+}
+
 /// Start (or resume) a Claude Code session.
 pub async fn start(opts: SessionOptions) -> Result<SessionHandle, AgentError> {
     let native_rewind = version_ge(
@@ -78,6 +109,12 @@ pub async fn start(opts: SessionOptions) -> Result<SessionHandle, AgentError> {
     // (effort/context/fast/thinking are launch-time only; mid-session changes
     // ride the resume-restart machinery).
     let launch = ClaudeLaunchOptions::resolve(opts.model.as_deref(), &opts.option_selections);
+    let base_permission_mode = permission_mode_flag(opts.approval_mode);
+    let launch_permission_mode = initial_permission_mode(opts.approval_mode, opts.interaction_mode);
+    // Launch arguments are deliberately appended last, so the tracker must
+    // follow their effective value rather than the internal flag they replace.
+    let applied_permission_mode =
+        effective_permission_mode(launch_permission_mode, &opts.extra_args);
 
     let mut cmd = crate::process::async_command(&binary);
     cmd.arg("--print")
@@ -90,7 +127,7 @@ pub async fn start(opts: SessionOptions) -> Result<SessionHandle, AgentError> {
         .arg("--permission-prompt-tool")
         .arg("stdio")
         .arg("--permission-mode")
-        .arg(permission_mode_flag(opts.approval_mode));
+        .arg(launch_permission_mode);
 
     if native_rewind {
         // User-message UUIDs are Claude's native checkpoint ids. SDK file
@@ -127,12 +164,13 @@ pub async fn start(opts: SessionOptions) -> Result<SessionHandle, AgentError> {
         cmd.arg(arg);
     }
     log::debug!(
-        "claude spawn args: model={:?} effort={:?} settings={:?} ultrathink={} permission-mode={}",
+        "claude spawn args: model={:?} effort={:?} settings={:?} ultrathink={} permission-mode={} effective-permission-mode={}",
         launch.model_id,
         launch.effort,
         launch.settings_json,
         launch.ultrathink,
-        permission_mode_flag(opts.approval_mode),
+        launch_permission_mode,
+        applied_permission_mode,
     );
 
     cmd.current_dir(&opts.cwd)
@@ -219,7 +257,8 @@ pub async fn start(opts: SessionOptions) -> Result<SessionHandle, AgentError> {
     let session_config = SessionConfig {
         ultrathink: launch.ultrathink,
         interaction_mode: opts.interaction_mode,
-        base_permission_mode: permission_mode_flag(opts.approval_mode),
+        base_permission_mode,
+        applied_permission_mode,
         approval_mode: opts.approval_mode,
         native_rewind,
         claude_dir: opts
@@ -351,6 +390,7 @@ struct SessionConfig {
     ultrathink: bool,
     interaction_mode: InteractionMode,
     base_permission_mode: &'static str,
+    applied_permission_mode: String,
     approval_mode: ApprovalMode,
     native_rewind: bool,
     claude_dir: Option<PathBuf>,
@@ -633,7 +673,6 @@ async fn handle_command(
                         .await;
                     return Flow::Break("provider stdin write failed");
                 }
-                mapper.applied_permission_mode = desired.to_string();
             }
 
             // `ultrathink` is a prompt-prefix mode, not a `--effort` value.
@@ -707,20 +746,25 @@ async fn handle_command(
         SessionCommand::SetApprovalMode(mode) => {
             // The CLI's control protocol switches permission mode live via a
             // `set_permission_mode` control_request (same shape the Agent SDK
-            // sends). On success we emit nothing — the UI updated optimistically;
-            // only a stdin write failure warrants a Warning.
+            // sends). Plan mode is a stricter overlay: approval changes update
+            // only the Build mode to restore later.
             let flag = permission_mode_flag(mode);
             mapper.base_permission_mode = flag;
             mapper.approval_mode = mode;
-            let msg = mapper.set_permission_mode_request(mode);
-            if write_line(stdin, &msg).await.is_err() {
-                let _ = event_tx
-                    .send(AgentEvent::Warning {
-                        message: format!("claude: failed to switch permission mode to {mode:?}"),
-                    })
-                    .await;
-            } else {
-                mapper.applied_permission_mode = flag.to_string();
+            if mapper.interaction_mode == InteractionMode::Build {
+                let msg = mapper.set_permission_mode_request(mode);
+                if write_line(stdin, &msg).await.is_err() {
+                    if let Some(request_id) = msg.get("request_id").and_then(Value::as_str) {
+                        mapper.pending_permission_modes.remove(request_id);
+                    }
+                    let _ = event_tx
+                        .send(AgentEvent::Warning {
+                            message: format!(
+                                "claude: failed to write permission-mode switch for {mode:?}"
+                            ),
+                        })
+                        .await;
+                }
             }
             Flow::Continue
         }
@@ -975,8 +1019,11 @@ pub(crate) struct Mapper {
     base_permission_mode: &'static str,
     /// Permission mode currently applied on the CLI, so we only switch on change.
     applied_permission_mode: String,
-    /// Dedupe keys for captured `ExitPlanMode` plans (tool id, else plan text).
-    exit_plan_captures: HashSet<String>,
+    /// Live permission-mode requests awaiting Claude's correlated response.
+    /// A successful stdin write is not proof that the CLI applied the mode.
+    pending_permission_modes: HashMap<String, String>,
+    /// Whether an `ExitPlanMode` plan has already been captured this turn.
+    exit_plan_captured: bool,
     /// Control responses to write back (e.g. the auto-deny for `ExitPlanMode`).
     outgoing: Vec<Value>,
     /// Cumulative tokens processed across every completed turn this session
@@ -1021,7 +1068,8 @@ impl Mapper {
             interaction_mode: InteractionMode::Build,
             base_permission_mode: "default",
             applied_permission_mode: "default".to_string(),
-            exit_plan_captures: HashSet::new(),
+            pending_permission_modes: HashMap::new(),
+            exit_plan_captured: false,
             outgoing: Vec::new(),
             cumulative_processed: 0,
             pending_steers: VecDeque::new(),
@@ -1037,7 +1085,7 @@ impl Mapper {
         self.ultrathink = config.ultrathink;
         self.interaction_mode = config.interaction_mode;
         self.base_permission_mode = config.base_permission_mode;
-        self.applied_permission_mode = config.base_permission_mode.to_string();
+        self.applied_permission_mode = config.applied_permission_mode;
         self.approval_mode = config.approval_mode;
         self.native_rewind = config.native_rewind;
     }
@@ -1057,6 +1105,7 @@ impl Mapper {
         let id = format!("turn-{}", self.turn_counter);
         self.current_turn_id = Some(id.clone());
         self.awaiting_turn_checkpoint = self.native_rewind;
+        self.exit_plan_captured = false;
         id
     }
 
@@ -1066,6 +1115,7 @@ impl Mapper {
         self.turn_counter += 1;
         let id = format!("turn-{}", self.turn_counter);
         self.current_turn_id = Some(id.clone());
+        self.exit_plan_captured = false;
         id
     }
 
@@ -1147,9 +1197,12 @@ impl Mapper {
 
     /// `set_permission_mode` with a raw wire mode string (e.g. `"plan"`).
     fn set_permission_mode_request_str(&mut self, mode: &str) -> Value {
+        let request_id = self.next_control_id();
+        self.pending_permission_modes
+            .insert(request_id.clone(), mode.to_owned());
         json!({
             "type": "control_request",
-            "request_id": self.next_control_id(),
+            "request_id": request_id,
             "request": {
                 "subtype": "set_permission_mode",
                 "mode": mode,
@@ -1260,25 +1313,22 @@ impl Mapper {
             .collect()
     }
 
-    /// Emit a [`AgentEvent::ProposedPlan`] for a captured plan, deduping across
-    /// the assistant-block and permission-callback capture paths (T3 captures
-    /// from both). Returns `None` if this plan was already captured.
+    /// Emit at most one [`AgentEvent::ProposedPlan`] per turn. Claude can retry
+    /// `ExitPlanMode` after tcode's auto-deny with a fresh tool id; deduping by
+    /// id therefore re-arms the plan UI for the same turn.
     fn capture_proposed_plan(
         &mut self,
         tool_use_id: Option<&str>,
         markdown: String,
     ) -> Option<AgentEvent> {
-        let key = match tool_use_id.filter(|id| !id.is_empty()) {
-            Some(id) => format!("tool:{id}"),
-            None => format!("plan:{markdown}"),
-        };
-        if !self.exit_plan_captures.insert(key) {
+        if self.exit_plan_captured {
             return None;
         }
+        self.exit_plan_captured = true;
         let item_id = tool_use_id
             .filter(|id| !id.is_empty())
             .map(str::to_owned)
-            .unwrap_or_else(|| format!("plan-{}", self.exit_plan_captures.len()));
+            .unwrap_or_else(|| format!("plan-{}", self.turn_counter));
         Some(AgentEvent::ProposedPlan { item_id, markdown })
     }
 
@@ -1933,6 +1983,19 @@ impl Mapper {
         let Some(request_id) = response.get("request_id").and_then(Value::as_str) else {
             return Vec::new();
         };
+        if let Some(mode) = self.pending_permission_modes.remove(request_id) {
+            if response.get("subtype").and_then(Value::as_str) == Some("success") {
+                self.applied_permission_mode = mode;
+                return Vec::new();
+            }
+            let error = response
+                .get("error")
+                .and_then(Value::as_str)
+                .unwrap_or("Claude Code rejected the permission-mode request");
+            return vec![AgentEvent::Warning {
+                message: format!("claude: failed to switch permission mode: {error}"),
+            }];
+        }
         let Some(pending) = self.pending_rewinds.remove(request_id) else {
             return Vec::new();
         };
@@ -3288,6 +3351,110 @@ mod tests {
     }
 
     #[test]
+    fn plan_session_launches_with_plan_permission_mode() {
+        let launch_mode = initial_permission_mode(ApprovalMode::Supervised, InteractionMode::Plan);
+        assert_eq!(launch_mode, "plan");
+
+        let mut m = Mapper::new();
+        m.configure(SessionConfig {
+            ultrathink: false,
+            interaction_mode: InteractionMode::Plan,
+            base_permission_mode: "default",
+            applied_permission_mode: launch_mode.into(),
+            approval_mode: ApprovalMode::Supervised,
+            native_rewind: false,
+            claude_dir: None,
+        });
+
+        assert_eq!(m.applied_permission_mode, "plan");
+    }
+
+    #[test]
+    fn set_approval_mode_while_in_plan_keeps_plan_permission_mode() {
+        smol::block_on(async {
+            let mut child = crate::process::async_command("cat")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .unwrap();
+            let mut stdin = child.stdin.take().unwrap();
+            let (event_tx, _event_rx) = async_channel::unbounded();
+            let mut m = Mapper::new();
+            m.interaction_mode = InteractionMode::Plan;
+            m.applied_permission_mode = "plan".into();
+
+            let flow = handle_command(
+                SessionCommand::SetApprovalMode(ApprovalMode::FullAccess),
+                &mut m,
+                &mut stdin,
+                &event_tx,
+                &mut child,
+            )
+            .await;
+
+            assert!(matches!(flow, Flow::Continue));
+            assert_eq!(m.base_permission_mode, "bypassPermissions");
+            assert_eq!(m.applied_permission_mode, "plan");
+            assert!(m.pending_permission_modes.is_empty());
+            stdin.close().await.unwrap();
+            child.kill().unwrap();
+            child.status().await.unwrap();
+        });
+    }
+
+    #[test]
+    fn extra_permission_mode_arg_updates_launch_tracker() {
+        let extra_args = vec!["--permission-mode".into(), "plan".into()];
+        assert_eq!(
+            effective_permission_mode("default", &extra_args),
+            "plan",
+            "the last provider launch argument overrides the internal flag"
+        );
+
+        let extra_args = vec!["--permission-mode=bypassPermissions".into()];
+        assert_eq!(
+            effective_permission_mode("plan", &extra_args),
+            "bypassPermissions"
+        );
+    }
+
+    #[test]
+    fn exit_plan_mode_captures_once_per_turn() {
+        let mut m = Mapper::new();
+        m.start_turn();
+        let first = feed(
+            &mut m,
+            r##"{"type":"control_request","request_id":"req-plan-1","request":{"subtype":"can_use_tool","tool_name":"ExitPlanMode","input":{"plan":"# First plan"}}}"##,
+        );
+        assert!(matches!(
+            first.as_slice(),
+            [AgentEvent::ProposedPlan { .. }]
+        ));
+        assert_eq!(m.take_outgoing().len(), 1);
+
+        let second = feed(
+            &mut m,
+            r##"{"type":"control_request","request_id":"req-plan-2","request":{"subtype":"can_use_tool","tool_name":"ExitPlanMode","input":{"plan":"# Retried plan"}}}"##,
+        );
+        assert!(
+            second.is_empty(),
+            "a retry in the same turn must not emit another ProposedPlan"
+        );
+        assert_eq!(m.take_outgoing().len(), 1, "the retry is still denied");
+
+        m.start_turn();
+        let next_turn = feed(
+            &mut m,
+            r##"{"type":"control_request","request_id":"req-plan-3","request":{"subtype":"can_use_tool","tool_name":"ExitPlanMode","input":{"plan":"# New turn plan"}}}"##,
+        );
+        assert!(matches!(
+            next_turn.as_slice(),
+            [AgentEvent::ProposedPlan { .. }]
+        ));
+        assert_eq!(m.take_outgoing().len(), 1);
+    }
+
+    #[test]
     fn user_message_carries_image_content_blocks() {
         let attachments = vec![
             Attachment {
@@ -4273,14 +4440,41 @@ mod tests {
     fn set_permission_mode_request_shape() {
         let mut m = Mapper::new();
         let req = m.set_permission_mode_request(ApprovalMode::AutoAcceptEdits);
+        let request_id = req["request_id"].as_str().unwrap().to_owned();
         assert_eq!(req["type"], "control_request");
         assert!(req["request_id"].is_string());
         assert_eq!(req["request"]["subtype"], "set_permission_mode");
         assert_eq!(req["request"]["mode"], "acceptEdits");
+        assert_eq!(m.applied_permission_mode, "default");
+
+        let events = m.on_message(json!({
+            "type": "control_response",
+            "response": {
+                "subtype": "success",
+                "request_id": request_id,
+                "response": {},
+            }
+        }));
+        assert!(events.is_empty());
+        assert_eq!(m.applied_permission_mode, "acceptEdits");
 
         // FullAccess maps to bypassPermissions on the wire.
         let req = m.set_permission_mode_request(ApprovalMode::FullAccess);
         assert_eq!(req["request"]["mode"], "bypassPermissions");
+        let events = m.on_message(json!({
+            "type": "control_response",
+            "response": {
+                "subtype": "error",
+                "request_id": req["request_id"],
+                "error": "unsupported mode",
+            }
+        }));
+        assert!(matches!(
+            events.as_slice(),
+            [AgentEvent::Warning { message }]
+                if message.contains("unsupported mode")
+        ));
+        assert_eq!(m.applied_permission_mode, "acceptEdits");
     }
 
     #[test]

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -481,7 +481,7 @@ pub enum InteractionMode {
 /// Per-turn overrides layered on top of the session's persisted options.
 /// Codex and OpenCode apply effort/variant per turn; Claude and pi use their
 /// session-level option selection.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TurnOptions {
     pub effort: Option<String>,
     pub interaction_mode: Option<InteractionMode>,
@@ -638,6 +638,17 @@ pub async fn start_session(
 // Canonical event model: one normalized stream all providers map into
 // ---------------------------------------------------------------------------
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanResolution {
+    /// Accepted in this thread.
+    Implemented,
+    /// Accepted in a fresh thread.
+    HandedOff { session_id: String },
+    /// Explicitly dismissed by the user.
+    Dismissed,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentEvent {
@@ -648,6 +659,12 @@ pub enum AgentEvent {
         from_model: Option<String>,
         to_provider: ProviderKind,
         to_model: Option<String>,
+    },
+    /// A tcode-level decision about a captured plan. Never emitted by an
+    /// adapter; the runtime persists it so plan acceptance survives replay.
+    PlanResolved {
+        item_id: String,
+        resolution: PlanResolution,
     },
     /// The agent's self-described options (ACP `modes` / `models` /
     /// `configOptions`), pushed at session start and on every change. Reuses

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -491,6 +491,9 @@ pub enum SteeringStatus {
 pub struct ProposedPlan {
     pub item_id: String,
     pub markdown: String,
+    /// Final plans are actionable; streamed deltas remain display-only until
+    /// their provider emits the matching `ProposedPlan`.
+    pub ready: bool,
     /// Index into [`Timeline::turns`] of the turn that produced it.
     pub turn: usize,
 }
@@ -514,6 +517,10 @@ pub struct Timeline {
     /// The latest proposed plan captured this session, if any. Survives replay
     /// (it is the accept/refine anchor) until a newer plan supersedes it.
     pub proposed_plan: Option<ProposedPlan>,
+    /// Plan decisions keyed by provider item id. The value is the conversation
+    /// turn at which the decision took effect, so a rewind can drop decisions
+    /// made in the discarded future.
+    plan_resolutions: HashMap<String, usize>,
     /// The latest structured plan/task list (`PlanUpdated`), if any.
     pub plan_steps: Vec<PlanStep>,
     /// The explanation string from the latest `PlanUpdated`, if any.
@@ -565,9 +572,18 @@ impl Timeline {
         self.turn_running = false;
         self.pending_approvals.clear();
         self.pending_user_input = None;
+        self.discard_unready_plan();
         for turn in &mut self.turns {
             turn.running = false;
         }
+    }
+
+    /// The latest finalized plan, unless that exact provider item has already
+    /// been implemented, handed off, or dismissed.
+    pub fn plan_ready(&self) -> Option<&ProposedPlan> {
+        self.proposed_plan
+            .as_ref()
+            .filter(|plan| plan.ready && !self.plan_resolutions.contains_key(plan.item_id.as_str()))
     }
 
     /// First user message in the timeline, if any (used for session titles).
@@ -608,6 +624,13 @@ impl Timeline {
                     ts,
                     turn,
                 }));
+            }
+            AgentEvent::PlanResolved {
+                item_id,
+                resolution: _,
+            } => {
+                let turn = self.resolution_turn();
+                self.plan_resolutions.insert(item_id.clone(), turn);
             }
             AgentEvent::SessionStarted {
                 provider_session_id,
@@ -704,6 +727,7 @@ impl Timeline {
                 // A finished turn can no longer be waiting on approvals or input.
                 self.pending_approvals.clear();
                 self.pending_user_input = None;
+                self.discard_unready_plan();
             }
             AgentEvent::ItemStarted(item) => {
                 self.upsert_item(ts, item);
@@ -809,6 +833,7 @@ impl Timeline {
                 self.turn_running = false;
                 self.pending_approvals.clear();
                 self.pending_user_input = None;
+                self.discard_unready_plan();
                 if let Some(turn) = self.current_turn {
                     self.turns[turn].running = false;
                 }
@@ -820,23 +845,34 @@ impl Timeline {
                 self.plan_explanation = explanation.clone();
             }
             AgentEvent::ProposedPlanDelta { item_id, text } => {
+                if self.plan_resolutions.contains_key(item_id) {
+                    return;
+                }
                 let turn = self.ensure_turn(ts);
                 match &mut self.proposed_plan {
-                    Some(plan) if plan.item_id == *item_id => plan.markdown.push_str(text),
+                    Some(plan) if plan.item_id == *item_id && !plan.ready => {
+                        plan.markdown.push_str(text);
+                    }
+                    Some(plan) if plan.item_id == *item_id => {}
                     _ => {
                         self.proposed_plan = Some(ProposedPlan {
                             item_id: item_id.clone(),
                             markdown: text.clone(),
+                            ready: false,
                             turn,
                         });
                     }
                 }
             }
             AgentEvent::ProposedPlan { item_id, markdown } => {
+                if self.plan_resolutions.contains_key(item_id) {
+                    return;
+                }
                 let turn = self.ensure_turn(ts);
                 self.proposed_plan = Some(ProposedPlan {
                     item_id: item_id.clone(),
                     markdown: markdown.clone(),
+                    ready: true,
                     turn,
                 });
             }
@@ -867,6 +903,22 @@ impl Timeline {
             let turn = &self.turns[turn];
             turn.end_ts.is_none() && turn.status.is_none()
         })
+    }
+
+    /// A resolution recorded between turns belongs to the next user turn. This
+    /// lets rewinding that implementation turn revive the earlier ready plan
+    /// without manufacturing a transcript entry for a mere decision.
+    fn resolution_turn(&self) -> usize {
+        match self.current_turn {
+            Some(turn) if self.turn_is_open() => turn,
+            _ => self.turns.len(),
+        }
+    }
+
+    fn discard_unready_plan(&mut self) {
+        if self.proposed_plan.as_ref().is_some_and(|plan| !plan.ready) {
+            self.proposed_plan = None;
+        }
     }
 
     /// Feed one item lifecycle transition to the open turn's clock, ignoring
@@ -932,6 +984,8 @@ impl Timeline {
             .proposed_plan
             .take()
             .filter(|plan| plan.turn < target_turn);
+        self.plan_resolutions
+            .retain(|_, resolution_turn| *resolution_turn < target_turn);
         self.plan_steps.clear();
         self.plan_explanation = None;
         self.usage = None;
@@ -2261,6 +2315,8 @@ mod tests {
         );
         let plan = timeline.proposed_plan.as_ref().unwrap();
         assert_eq!(plan.markdown, "# Plan\nstep one");
+        assert!(!plan.ready);
+        assert!(timeline.plan_ready().is_none());
         assert_eq!(plan.turn, 0);
 
         // The final ProposedPlan replaces the accumulated text.
@@ -2275,9 +2331,163 @@ mod tests {
             timeline.proposed_plan.as_ref().unwrap().markdown,
             "# Plan\nstep one\nstep two"
         );
+        assert!(timeline.proposed_plan.as_ref().unwrap().ready);
+        assert!(timeline.plan_ready().is_some());
         // The proposed plan survives replay's mark_idle (it is the accept anchor).
         timeline.mark_idle();
         assert!(timeline.proposed_plan.is_some());
+    }
+
+    #[test]
+    fn proposed_plan_delta_alone_is_not_ready() {
+        let timeline = Timeline::fold_events([
+            AgentEvent::TurnStarted {
+                turn_id: "t1".into(),
+            },
+            AgentEvent::ProposedPlanDelta {
+                item_id: "plan-1".into(),
+                text: "# Partial plan".into(),
+            },
+        ]);
+
+        assert!(timeline.proposed_plan.is_some());
+        assert!(timeline.plan_ready().is_none());
+    }
+
+    #[test]
+    fn unfinished_streaming_plan_is_discarded_when_turn_ends() {
+        let timeline = Timeline::fold_events([
+            AgentEvent::TurnStarted {
+                turn_id: "t1".into(),
+            },
+            AgentEvent::ProposedPlanDelta {
+                item_id: "plan-1".into(),
+                text: "# Truncated plan".into(),
+            },
+            AgentEvent::TurnCompleted {
+                turn_id: "t1".into(),
+                status: TurnStatus::Interrupted,
+                usage: None,
+            },
+        ]);
+
+        assert!(timeline.proposed_plan.is_none());
+    }
+
+    #[test]
+    fn implemented_plan_stays_resolved_after_event_log_replay() {
+        let timeline = Timeline::fold_events([
+            AgentEvent::TurnStarted {
+                turn_id: "plan-turn".into(),
+            },
+            AgentEvent::ProposedPlan {
+                item_id: "plan-1".into(),
+                markdown: "# Final plan".into(),
+            },
+            AgentEvent::TurnCompleted {
+                turn_id: "plan-turn".into(),
+                status: TurnStatus::Completed,
+                usage: None,
+            },
+            AgentEvent::PlanResolved {
+                item_id: "plan-1".into(),
+                resolution: agent::PlanResolution::Implemented,
+            },
+        ]);
+
+        assert!(timeline.proposed_plan.is_some());
+        assert!(timeline.plan_ready().is_none());
+    }
+
+    #[test]
+    fn resolved_plan_ignores_late_or_duplicate_provider_events() {
+        let timeline = Timeline::fold_events([
+            AgentEvent::ProposedPlan {
+                item_id: "plan-1".into(),
+                markdown: "# Final plan".into(),
+            },
+            AgentEvent::PlanResolved {
+                item_id: "plan-1".into(),
+                resolution: agent::PlanResolution::Dismissed,
+            },
+            AgentEvent::ProposedPlanDelta {
+                item_id: "plan-1".into(),
+                text: "\nlate delta".into(),
+            },
+            AgentEvent::ProposedPlan {
+                item_id: "plan-1".into(),
+                markdown: "# Duplicate plan".into(),
+            },
+        ]);
+
+        assert_eq!(
+            timeline.proposed_plan.as_ref().unwrap().markdown,
+            "# Final plan"
+        );
+        assert!(timeline.plan_ready().is_none());
+    }
+
+    #[test]
+    fn rewind_drops_resolutions_from_target_turn_but_keeps_earlier_ones() {
+        fn history(rewind_checkpoint: &str) -> Timeline {
+            Timeline::fold_events([
+                user_msg("plan-request", "make a plan"),
+                AgentEvent::TurnStarted {
+                    turn_id: "plan-turn".into(),
+                },
+                AgentEvent::TurnCheckpoint {
+                    turn_id: "plan-turn".into(),
+                    checkpoint_id: "plan-checkpoint".into(),
+                },
+                AgentEvent::ProposedPlan {
+                    item_id: "plan-1".into(),
+                    markdown: "# Final plan".into(),
+                },
+                AgentEvent::TurnCompleted {
+                    turn_id: "plan-turn".into(),
+                    status: TurnStatus::Completed,
+                    usage: None,
+                },
+                AgentEvent::PlanResolved {
+                    item_id: "plan-1".into(),
+                    resolution: agent::PlanResolution::Implemented,
+                },
+                user_msg("implementation-request", "implement it"),
+                AgentEvent::TurnStarted {
+                    turn_id: "implementation-turn".into(),
+                },
+                AgentEvent::TurnCheckpoint {
+                    turn_id: "implementation-turn".into(),
+                    checkpoint_id: "implementation-checkpoint".into(),
+                },
+                AgentEvent::TurnCompleted {
+                    turn_id: "implementation-turn".into(),
+                    status: TurnStatus::Completed,
+                    usage: None,
+                },
+                user_msg("later-request", "follow up"),
+                AgentEvent::TurnStarted {
+                    turn_id: "later-turn".into(),
+                },
+                AgentEvent::TurnCheckpoint {
+                    turn_id: "later-turn".into(),
+                    checkpoint_id: "later-checkpoint".into(),
+                },
+                AgentEvent::TurnCompleted {
+                    turn_id: "later-turn".into(),
+                    status: TurnStatus::Completed,
+                    usage: None,
+                },
+                AgentEvent::RewindCompleted {
+                    checkpoint_id: rewind_checkpoint.into(),
+                    mode: RewindMode::Conversation,
+                    prefill: None,
+                },
+            ])
+        }
+
+        assert!(history("implementation-checkpoint").plan_ready().is_some());
+        assert!(history("later-checkpoint").plan_ready().is_none());
     }
 
     #[test]

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -8,8 +8,8 @@ use std::time::{Duration, Instant};
 use agent::{
     AgentEvent, ApprovalDecision, ApprovalMode, Attachment, ChangeCompleteness, FileChange,
     InteractionMode, ItemContent, LaunchEnv, ModelSpec, OptionDescriptor, OptionSelection,
-    ProviderCommand, ProviderKind, RewindMode, SessionCommand, SessionOptions, ThreadItem,
-    TurnOptions, TurnStatus, list_models, start_session,
+    PlanResolution, ProviderCommand, ProviderKind, RewindMode, SessionCommand, SessionOptions,
+    ThreadItem, TurnOptions, TurnStatus, list_models, start_session,
 };
 use gpui::{BackgroundExecutor, Context, EventEmitter, Task};
 use serde::{Deserialize, Serialize};
@@ -388,6 +388,9 @@ pub struct QueuedMessage {
     /// user event continues to record only `text`.
     relay_transcript: Option<String>,
     pub attachments: Vec<Attachment>,
+    /// Per-turn settings captured with the user's send gesture. A later mode
+    /// toggle must affect later messages, not rewrite work already in the FIFO.
+    options: TurnOptions,
     /// Ultrathink was armed when this message was written. It is a per-send
     /// prompt-prefix mode, so it rides with the message rather than with the
     /// session, and is applied only to the text sent on the wire (the user
@@ -455,6 +458,7 @@ impl From<&str> for QueuedMessage {
             text: text.to_string(),
             relay_transcript: None,
             attachments: Vec::new(),
+            options: TurnOptions::default(),
             ultrathink: false,
             context_len: None,
             kind: QueuedMessageKind::User,
@@ -529,9 +533,6 @@ pub struct ActiveSession {
     /// per-send annotation, consumed by the next `push_queued`, and never
     /// persisted on the session.
     pending_context_len: Option<usize>,
-    /// Whether the current proposed plan has been accepted for implementation
-    /// (drives the composer back out of its plan-ready state).
-    plan_implemented: bool,
     /// Draft-only (Group C): run in the current checkout or a new dedicated
     /// worktree. Chosen in the checkout row before the first send; locked after.
     pub draft_workspace: WorkspaceMode,
@@ -739,6 +740,7 @@ impl ActiveSession {
         self.idle_since = None;
         let id = self.next_queue_id;
         self.next_queue_id += 1;
+        let options = self.turn_options();
         let ultrathink = std::mem::take(&mut self.pending_ultrathink);
         let context_len = std::mem::take(&mut self.pending_context_len);
         self.queue.push(QueuedMessage {
@@ -746,6 +748,7 @@ impl ActiveSession {
             text,
             relay_transcript: None,
             attachments,
+            options,
             ultrathink,
             context_len,
             kind: QueuedMessageKind::User,
@@ -770,11 +773,13 @@ impl ActiveSession {
         }
         let id = self.next_queue_id;
         self.next_queue_id += 1;
+        let options = self.turn_options();
         self.queue.push(QueuedMessage {
             id,
             text,
             relay_transcript: None,
             attachments: Vec::new(),
+            options,
             ultrathink: false,
             context_len: None,
             kind: QueuedMessageKind::OrchestrateCallback,
@@ -800,12 +805,11 @@ impl ActiveSession {
         let Some(send) = self.queue.first().cloned() else {
             return Ok(false);
         };
-        let options = Some(self.turn_options());
         commands
             .try_send(SessionCommand::SendTurn {
                 delivery_id: send.id,
                 text: send.wire_text(),
-                options,
+                options: Some(send.options),
                 attachments: send.attachments,
             })
             .map_err(|_| ())?;
@@ -4867,7 +4871,6 @@ impl AppState {
             live_option_selections: Vec::new(),
             pending_ultrathink: false,
             pending_context_len: None,
-            plan_implemented: false,
             draft_workspace: WorkspaceMode::LocalCheckout,
             preparing_worktree: false,
             queue: Vec::new(),
@@ -4921,7 +4924,6 @@ impl AppState {
             live_option_selections: Vec::new(),
             pending_ultrathink: false,
             pending_context_len: None,
-            plan_implemented: false,
             draft_workspace: WorkspaceMode::LocalCheckout,
             preparing_worktree: false,
             queue: Vec::new(),
@@ -5273,7 +5275,6 @@ impl AppState {
             live_option_selections: Vec::new(),
             pending_ultrathink: false,
             pending_context_len: None,
-            plan_implemented: false,
             draft_workspace: WorkspaceMode::LocalCheckout,
             preparing_worktree: false,
             queue: Vec::new(),
@@ -6151,30 +6152,67 @@ impl AppState {
     // -- proposed-plan flow -------------------------------------------------
 
     /// The active session's captured proposed plan (markdown), if it is in the
-    /// composer's "plan ready" state (present and not yet implemented).
+    /// composer's finalized, unresolved "plan ready" state.
     pub fn plan_ready_markdown(&self) -> Option<String> {
-        let active = self.active.as_ref()?;
-        if active.plan_implemented {
-            return None;
-        }
-        active
+        self.active
+            .as_ref()?
             .timeline
-            .proposed_plan
-            .as_ref()
-            .map(|p| p.markdown.clone())
+            .plan_ready()
+            .map(|plan| plan.markdown.clone())
     }
 
     /// Accept the proposed plan: send the verbatim implementation prompt, switch
-    /// to Build mode, and clear the composer's plan-ready state.
+    /// to Build mode, and persist the decision before dispatching the turn.
     pub fn implement_plan(&mut self, cx: &mut Context<Self>) {
-        let Some(markdown) = self.plan_ready_markdown() else {
+        // A pending provider handoff makes `send_turn` defer. Validate it before
+        // resolving the plan or changing mode, or the implementation prompt can
+        // vanish while the UI claims the plan was accepted.
+        if self.relay_confirmation().is_some() {
+            return;
+        }
+        let Some((session_id, item_id, markdown)) = self.active.as_ref().and_then(|active| {
+            active.timeline.plan_ready().map(|plan| {
+                (
+                    active.meta.id.clone(),
+                    plan.item_id.clone(),
+                    plan.markdown.clone(),
+                )
+            })
+        }) else {
             return;
         };
-        if let Some(active) = self.active.as_mut() {
-            active.plan_implemented = true;
-        }
+        self.record_event(
+            &session_id,
+            &AgentEvent::PlanResolved {
+                item_id,
+                resolution: PlanResolution::Implemented,
+            },
+            cx,
+        );
         self.set_interaction_mode(InteractionMode::Build, cx);
         self.send_turn(implement_prompt(&markdown), Vec::new(), cx);
+    }
+
+    /// Leave the plan captured in history while removing its actionable
+    /// composer state.
+    pub fn dismiss_plan(&mut self, cx: &mut Context<Self>) {
+        let Some((session_id, item_id)) = self.active.as_ref().and_then(|active| {
+            active
+                .timeline
+                .plan_ready()
+                .map(|plan| (active.meta.id.clone(), plan.item_id.clone()))
+        }) else {
+            return;
+        };
+        self.record_event(
+            &session_id,
+            &AgentEvent::PlanResolved {
+                item_id,
+                resolution: PlanResolution::Dismissed,
+            },
+            cx,
+        );
+        cx.notify();
     }
 
     /// Accept the proposed plan in a fresh thread in the same project (same
@@ -6183,9 +6221,11 @@ impl AppState {
         let Some(active) = self.active.as_ref() else {
             return;
         };
-        let Some(plan) = active.timeline.proposed_plan.as_ref() else {
+        let Some(plan) = active.timeline.plan_ready() else {
             return;
         };
+        let source_session_id = active.meta.id.clone();
+        let plan_item_id = plan.item_id.clone();
         let markdown = plan.markdown.clone();
         let provider = active.meta.provider;
         let cwd = active.meta.cwd.clone();
@@ -6194,6 +6234,7 @@ impl AppState {
         let approval_mode = active.meta.approval_mode;
         let project_id = active.meta.project_id.clone();
         let acp_agent_id = active.meta.acp_agent_id.clone();
+        let profile_id = active.meta.profile_id.clone();
 
         let mut meta = SessionMeta::new(provider, cwd, model);
         meta.title = title;
@@ -6202,6 +6243,18 @@ impl AppState {
         meta.interaction_mode = InteractionMode::Build;
         meta.project_id = project_id;
         meta.acp_agent_id = acp_agent_id;
+        meta.profile_id = profile_id;
+        let destination_session_id = meta.id.clone();
+        self.record_event(
+            &source_session_id,
+            &AgentEvent::PlanResolved {
+                item_id: plan_item_id,
+                resolution: PlanResolution::HandedOff {
+                    session_id: destination_session_id,
+                },
+            },
+            cx,
+        );
         self.enqueue_store_write(
             StoreWrite::UpsertMeta {
                 meta: Box::new(meta.clone()),
@@ -6228,7 +6281,6 @@ impl AppState {
             live_option_selections: Vec::new(),
             pending_ultrathink: false,
             pending_context_len: None,
-            plan_implemented: false,
             draft_workspace: WorkspaceMode::LocalCheckout,
             preparing_worktree: false,
             queue: Vec::new(),
@@ -7023,11 +7075,7 @@ impl AppState {
             selections,
         } = &event
         {
-            if let Some(active) = self
-                .active
-                .as_mut()
-                .filter(|active| active.meta.id == session_id)
-            {
+            let apply = |active: &mut ActiveSession| {
                 active.provider_options = descriptors.clone();
                 for selection in selections {
                     active
@@ -7036,12 +7084,43 @@ impl AppState {
                         .retain(|s| s.id != selection.id);
                     active.meta.option_selections.push(selection.clone());
                 }
-                active.live_option_selections = active.meta.option_selections.clone();
-                let meta = active.meta.clone();
-                if meta.acp_agent_id.is_some() {
-                    self.persist_meta(&meta, cx);
+                if active.meta.provider == ProviderKind::Acp {
+                    let plan_mode = descriptors.iter().find_map(|descriptor| match descriptor {
+                        OptionDescriptor::Select { id, options, .. } if id == "acp:mode" => options
+                            .iter()
+                            .find(|option| option.value.eq_ignore_ascii_case("plan"))
+                            .map(|option| option.value.as_str()),
+                        _ => None,
+                    });
+                    let current_mode = selections
+                        .iter()
+                        .find(|selection| selection.id == "acp:mode")
+                        .and_then(|selection| selection.value.as_str());
+                    active.meta.interaction_mode = match (plan_mode, current_mode) {
+                        (Some(plan), Some(current)) if current.eq_ignore_ascii_case(plan) => {
+                            InteractionMode::Plan
+                        }
+                        _ => InteractionMode::Build,
+                    };
                 }
+                active.live_option_selections = active.meta.option_selections.clone();
+            };
+            let meta = if let Some(active) = self
+                .active
+                .as_mut()
+                .filter(|active| active.meta.id == session_id)
+            {
+                apply(active);
                 cx.notify();
+                Some(active.meta.clone())
+            } else if let Some(parked) = self.background.get_mut(session_id) {
+                apply(parked);
+                Some(parked.meta.clone())
+            } else {
+                None
+            };
+            if let Some(meta) = meta.filter(|meta| meta.acp_agent_id.is_some()) {
+                self.persist_meta(&meta, cx);
             }
             return;
         }
@@ -7154,9 +7233,9 @@ impl AppState {
             _ => {}
         }
 
-        // Plan surfaces: a fresh proposed plan re-arms the composer's plan-ready
-        // state; a new turn clears the per-turn auto-open suppression; the first
-        // structured plan update of a turn may auto-open the task panel.
+        // Plan surfaces: a new turn clears the per-turn auto-open suppression;
+        // the first structured plan update of a turn may auto-open the task
+        // panel. Proposed-plan readiness is entirely folded by Timeline.
         let auto_open = self.settings.auto_open_task_panel;
         if let Some(active) = self
             .active
@@ -7165,9 +7244,6 @@ impl AppState {
         {
             match &event {
                 AgentEvent::TurnStarted { .. } => active.auto_open_suppressed = false,
-                AgentEvent::ProposedPlan { .. } | AgentEvent::ProposedPlanDelta { .. } => {
-                    active.plan_implemented = false;
-                }
                 AgentEvent::PlanUpdated { .. } => {
                     let already_showing = active.diff_open && active.right_tab == RightTab::Plan;
                     if auto_open && !active.auto_open_suppressed && !already_showing {
@@ -10588,7 +10664,6 @@ mod tests {
             live_option_selections: Vec::new(),
             pending_ultrathink: false,
             pending_context_len: None,
-            plan_implemented: false,
             draft_workspace: WorkspaceMode::LocalCheckout,
             preparing_worktree: false,
             queue: Vec::new(),
@@ -10639,7 +10714,6 @@ mod tests {
             live_option_selections: Vec::new(),
             pending_ultrathink: false,
             pending_context_len: None,
-            plan_implemented: false,
             draft_workspace: WorkspaceMode::LocalCheckout,
             preparing_worktree: false,
             queue: Vec::new(),
@@ -10683,7 +10757,6 @@ mod tests {
             live_option_selections: Vec::new(),
             pending_ultrathink: false,
             pending_context_len: None,
-            plan_implemented: false,
             draft_workspace: WorkspaceMode::LocalCheckout,
             preparing_worktree: false,
             queue: Vec::new(),
@@ -10734,6 +10807,105 @@ mod tests {
         assert!(active.queue.is_empty());
     }
 
+    #[gpui::test]
+    fn implement_plan_waits_for_pending_relay_without_mutating_state(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let root =
+            std::env::temp_dir().join(format!("tcode-plan-relay-test-{}", uuid::Uuid::new_v4()));
+        let store = SessionStore::open_at(root.clone()).unwrap();
+        let state = cx.new(|_| AppState::new(store));
+        let (commands, receiver) = async_channel::unbounded();
+
+        state.update(cx, |state, cx| {
+            let mut active = live_session(ProviderKind::Codex, commands);
+            active.meta.id = "plan-relay".into();
+            active.meta.interaction_mode = InteractionMode::Plan;
+            active.pending_relay = Some(PendingRelay {
+                from_provider: ProviderKind::ClaudeCode,
+                from_model: Some("opus".into()),
+            });
+            active.timeline.apply_at(
+                None,
+                &AgentEvent::ItemCompleted(ThreadItem {
+                    id: "user-1".into(),
+                    parent_item_id: None,
+                    content: ItemContent::UserMessage {
+                        text: "make a plan".into(),
+                        context_len: None,
+                        attachments: Vec::new(),
+                    },
+                }),
+            );
+            active.timeline.apply_at(
+                None,
+                &AgentEvent::ProposedPlan {
+                    item_id: "plan-1".into(),
+                    markdown: "# Plan".into(),
+                },
+            );
+            active.timeline.apply_at(
+                None,
+                &AgentEvent::TurnCompleted {
+                    turn_id: "plan-turn".into(),
+                    status: TurnStatus::Completed,
+                    usage: None,
+                },
+            );
+            state.active = Some(active);
+
+            state.implement_plan(cx);
+
+            let active = state.active.as_ref().unwrap();
+            assert_eq!(active.meta.interaction_mode, InteractionMode::Plan);
+            assert!(state.plan_ready_markdown().is_some());
+            assert!(receiver.try_recv().is_err());
+        });
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn queued_turns_keep_the_interaction_mode_selected_at_submit_time() {
+        let (commands, receiver) = async_channel::unbounded();
+        let mut active = live_session(ProviderKind::Codex, commands);
+        active.turn_in_flight = true;
+        active.meta.interaction_mode = InteractionMode::Plan;
+        active.push_queued("plan turn".into(), Vec::new());
+        active.meta.interaction_mode = InteractionMode::Build;
+        active.turn_in_flight = false;
+
+        assert_eq!(active.dispatch_next_pending(), Ok(true));
+        let first_delivery = match receiver.try_recv() {
+            Ok(SessionCommand::SendTurn {
+                delivery_id,
+                options: Some(options),
+                ..
+            }) => {
+                assert_eq!(options.interaction_mode, Some(InteractionMode::Plan));
+                delivery_id
+            }
+            other => panic!("expected queued Plan turn, got {other:?}"),
+        };
+        active.accept_turn_delivery(first_delivery).unwrap();
+        active.turn_in_flight = false;
+
+        active.meta.interaction_mode = InteractionMode::Build;
+        active.push_queued("build turn".into(), Vec::new());
+        active.meta.interaction_mode = InteractionMode::Plan;
+        assert_eq!(active.dispatch_next_pending(), Ok(true));
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(SessionCommand::SendTurn {
+                options: Some(TurnOptions {
+                    interaction_mode: Some(InteractionMode::Build),
+                    ..
+                }),
+                ..
+            })
+        ));
+    }
+
     /// A live session with `provider`, nothing queued, no turn in flight.
     fn live_session(
         provider: ProviderKind,
@@ -10753,7 +10925,6 @@ mod tests {
             live_option_selections: Vec::new(),
             pending_ultrathink: false,
             pending_context_len: None,
-            plan_implemented: false,
             draft_workspace: WorkspaceMode::LocalCheckout,
             preparing_worktree: false,
             queue: Vec::new(),
@@ -11101,7 +11272,6 @@ mod tests {
             live_option_selections: Vec::new(),
             pending_ultrathink: false,
             pending_context_len: None,
-            plan_implemented: false,
             draft_workspace: WorkspaceMode::LocalCheckout,
             preparing_worktree: false,
             queue: Vec::new(),
@@ -11563,7 +11733,6 @@ mod tests {
             live_option_selections: Vec::new(),
             pending_ultrathink: false,
             pending_context_len: None,
-            plan_implemented: false,
             draft_workspace: WorkspaceMode::LocalCheckout,
             preparing_worktree: false,
             queue: vec!["do it".into()],

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -7301,9 +7301,9 @@ impl AppState {
         }
     }
 
-    /// Append to JSONL + fold into the active timeline (if it's this session).
-    /// The same wall-clock timestamp is persisted and folded so the on-disk
-    /// log and the live timeline agree.
+    /// Append to JSONL + fold into the matching active or background timeline.
+    /// The same wall-clock timestamp is persisted and folded exactly once so
+    /// the on-disk log and the loaded timeline agree.
     fn record_event(&mut self, session_id: &str, event: &AgentEvent, cx: &mut Context<Self>) {
         self.store_append_generation += 1;
         let ts = now_millis();
@@ -7319,6 +7319,8 @@ impl AppState {
             && active.meta.id == session_id
         {
             active.timeline.apply_at(Some(ts), event);
+        } else if let Some(background) = self.background.get_mut(session_id) {
+            background.timeline.apply_at(Some(ts), event);
         }
     }
 
@@ -10335,6 +10337,68 @@ mod tests {
         ]);
 
         assert_eq!(final_assistant_message(&timeline), "Complete answer.");
+    }
+
+    #[gpui::test]
+    fn resident_background_child_result_uses_completed_live_timeline(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let root = std::env::temp_dir().join(format!(
+            "tcode-orchestrate-resident-result-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let store = SessionStore::open_at(root.clone()).unwrap();
+        let state = cx.new(|_| AppState::new(store));
+        let report = format!("Complete child report:\n{}", "full detail ".repeat(80));
+
+        state.update(cx, |state, cx| {
+            let mut parent =
+                SessionMeta::new(ProviderKind::Codex, PathBuf::from("/tmp/project"), None);
+            parent.id = "parent".into();
+
+            let (commands, _receiver) = async_channel::unbounded();
+            let mut child = live_session(ProviderKind::Codex, commands);
+            child.meta.id = "child".into();
+            child.meta.parent_session_id = Some(parent.id.clone());
+            child.turn_in_flight = true;
+
+            state.sessions.push(parent);
+            state.sessions.push(child.meta.clone());
+            state.background.insert(child.meta.id.clone(), child);
+
+            state.on_event("child", persisted_assistant_event(&report), cx);
+            state.on_event(
+                "child",
+                AgentEvent::TurnCompleted {
+                    turn_id: "turn-1".into(),
+                    status: TurnStatus::Completed,
+                    usage: None,
+                },
+                cx,
+            );
+
+            let child = state.background.get("child").unwrap();
+            assert!(
+                child.idle_since.is_some(),
+                "completed child must remain resident in background"
+            );
+            assert!(!child.turn_in_flight);
+
+            let (reply, response) = async_channel::bounded(1);
+            state.handle_orchestrate_op(
+                orchestrate_mcp::OrchestrateOp::Result {
+                    parent_id: "parent".into(),
+                    thread_id: "child".into(),
+                },
+                reply,
+                cx,
+            );
+            let result = response.try_recv().unwrap().unwrap();
+            assert_eq!(result["state"], "completed");
+            assert_eq!(result["final_message"], report);
+        });
+
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[gpui::test]

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -719,6 +719,21 @@ impl Composer {
         cx.notify();
     }
 
+    /// Whether `submit` has anything to send. Keep the primary-action choice on
+    /// this same predicate so attachment/context-only drafts never masquerade
+    /// as an empty plan that Enter would implement.
+    fn has_sendable_content(&self, cx: &App) -> bool {
+        !self.input.read(cx).value().trim().is_empty()
+            || !self.pending_images.is_empty()
+            || self
+                .app_state
+                .read(cx)
+                .active
+                .as_ref()
+                .is_some_and(|active| !active.terminal_workspace.contexts.is_empty())
+            || !self.app_state.read(cx).review_comments().is_empty()
+    }
+
     /// Send the composer's contents. `steer` is set by the ⌘/Ctrl+Enter gesture:
     /// inject into the running turn rather than queue behind it. It is a no-op
     /// when no turn is running (`AppState::steer` just sends), and degrades to
@@ -738,7 +753,6 @@ impl Composer {
             return;
         }
         let text = input.read(cx).value().trim().to_string();
-        let has_images = !self.pending_images.is_empty();
         let terminal_contexts = self
             .app_state
             .read(cx)
@@ -747,11 +761,7 @@ impl Composer {
             .map(|active| active.terminal_workspace.contexts.clone())
             .unwrap_or_default();
         let review_comments = self.app_state.read(cx).review_comments().to_vec();
-        if text.is_empty()
-            && !has_images
-            && terminal_contexts.is_empty()
-            && review_comments.is_empty()
-        {
+        if !self.has_sendable_content(cx) {
             return;
         }
         if self.app_state.read(cx).active.is_none() {
@@ -1698,6 +1708,7 @@ impl Composer {
         let muted = cx.theme().muted_foreground;
         let mode = self.app_state.read(cx).active_approval_mode();
         let interaction = self.app_state.read(cx).active_interaction_mode();
+        let app_entity = self.app_state.clone();
 
         let trigger = Button::new("overflow-controls")
             .ghost()
@@ -1711,7 +1722,9 @@ impl Composer {
             .shadow_xl()
             .anchor(Anchor::BottomLeft)
             .trigger(trigger)
-            .content(move |_, _, cx| render_overflow_pane(usage, mode, interaction, cx))
+            .content(move |_, _, cx| {
+                render_overflow_pane(usage, mode, interaction, &app_entity, &cx.entity(), cx)
+            })
             .into_any_element()
     }
 
@@ -2144,8 +2157,7 @@ impl Composer {
             return self.render_send_or_stop(true, cx);
         }
         if self.app_state.read(cx).plan_ready_markdown().is_some() {
-            let has_text = !self.input.read(cx).value().trim().is_empty();
-            if has_text {
+            if self.has_sendable_content(cx) && self.refines_the_plan(cx) {
                 // Refine: send the feedback and stay in Plan mode (a normal send
                 // while the session is in Plan mode continues planning).
                 return Button::new("plan-refine")
@@ -2157,9 +2169,18 @@ impl Composer {
                     }))
                     .into_any_element();
             }
-            return self.render_implement_split(cx);
+            if !self.has_sendable_content(cx) {
+                return self.render_implement_split(cx);
+            }
         }
         self.render_send_or_stop(turn_running, cx)
+    }
+
+    /// Whether a send right now continues planning rather than starting work.
+    /// The plan stays implementable from either mode, but only Plan mode turns
+    /// typed feedback into refinement.
+    fn refines_the_plan(&self, cx: &App) -> bool {
+        self.app_state.read(cx).active_interaction_mode() == InteractionMode::Plan
     }
 
     /// The Implement split-button: primary "Implement" + a chevron menu with
@@ -2256,6 +2277,7 @@ impl Composer {
     /// The "Plan Ready" header strip shown atop the composer while a proposed
     /// plan awaits a decision (S1 §5).
     fn render_plan_ready_header(&self, title: String, cx: &mut Context<Self>) -> AnyElement {
+        let app_state = self.app_state.clone();
         h_flex()
             .w_full()
             .px_4()
@@ -2284,6 +2306,16 @@ impl Composer {
                     .text_size(px(13.))
                     .text_color(cx.theme().muted_foreground)
                     .child(title),
+            )
+            .child(
+                Button::new("dismiss-plan")
+                    .ghost()
+                    .compact()
+                    .icon(IconName::Close)
+                    .tooltip(tcode_i18n::tr!("plan.dismiss"))
+                    .on_click(move |_, _, cx| {
+                        app_state.update(cx, |state, cx| state.dismiss_plan(cx));
+                    }),
             )
             .into_any_element()
     }
@@ -3358,7 +3390,9 @@ impl Render for Composer {
                     .unwrap_or_else(|| tcode_i18n::tr!("plan.proposed_plan").into_owned())
             })
         };
-        let desired_placeholder = if plan_ready_title.is_some() {
+        // Only Plan mode refines: in Build a typed message is an ordinary build
+        // turn, so promising refinement there would misdescribe what Enter does.
+        let desired_placeholder = if plan_ready_title.is_some() && self.refines_the_plan(cx) {
             tcode_i18n::tr!("plan.refine_placeholder").into_owned()
         } else {
             tcode_i18n::tr!("composer.placeholder").into_owned()
@@ -4195,6 +4229,8 @@ fn render_overflow_pane(
     usage: Option<TokenUsage>,
     mode: ApprovalMode,
     interaction: InteractionMode,
+    app_entity: &Entity<AppState>,
+    popover: &Entity<PopoverState>,
     cx: &mut Context<PopoverState>,
 ) -> AnyElement {
     let muted = cx.theme().muted_foreground;
@@ -4218,16 +4254,48 @@ fn render_overflow_pane(
         InteractionMode::Build => ("icons/box.svg", tcode_i18n::tr!("composer.build")),
         InteractionMode::Plan => ("icons/ruler.svg", tcode_i18n::tr!("composer.plan")),
     };
+    let next_interaction = match interaction {
+        InteractionMode::Build => InteractionMode::Plan,
+        InteractionMode::Plan => InteractionMode::Build,
+    };
+    let interaction_app = app_entity.clone();
+    let interaction_popover = popover.clone();
     v_flex()
         .w(px(220.))
         .p_1()
         .gap_0p5()
         .child(item(Icon::new(IconName::Info), context_label(usage)))
+        // The permission row stays display-only: its full-width counterpart is
+        // an explicit picker, and cycling here would let two stray clicks
+        // escalate a Supervised session all the way to Full access.
         .child(item(Icon::empty().path(mode_icon), mode_label))
-        .child(item(
-            Icon::empty().path(interaction_icon),
-            interaction_label.into_owned(),
-        ))
+        .child(
+            h_flex()
+                .id("overflow-interaction")
+                .w_full()
+                .px_2()
+                .py_1p5()
+                .gap_1p5()
+                .items_center()
+                .rounded(px(6.))
+                .cursor_pointer()
+                .text_size(px(13.))
+                .text_color(muted)
+                .hover(|style| style.bg(cx.theme().muted))
+                .child(
+                    Icon::empty()
+                        .path(interaction_icon)
+                        .small()
+                        .text_color(muted),
+                )
+                .child(interaction_label)
+                .on_click(move |_, window, cx| {
+                    interaction_app.update(cx, |state, cx| {
+                        state.set_interaction_mode(next_interaction, cx)
+                    });
+                    interaction_popover.update(cx, |state, cx| state.dismiss(window, cx));
+                }),
+        )
         .into_any_element()
 }
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -236,6 +236,15 @@ circular send button (primary bg when input non-empty). Below the card: folder
 icon + "Local checkout" left, branch icon + current git branch right (hidden
 outside a git repo).
 
+A finalized, unresolved proposed plan adds a "Plan Ready" header with a dismiss
+button and changes the empty primary action to Implement. In Plan mode any
+sendable draft (text, images, terminal context, or review comments) uses Refine
+and the refine placeholder; in Build mode the composer keeps its ordinary Send
+affordance, because a typed message there is an ordinary build turn.
+At compact widths the overflow Build/Plan row is interactive (it toggles like the
+full-width chip and closes the popover); the permission row stays display-only,
+since its full-width counterpart is an explicit picker.
+
 Model picker popover (~360px, radius 12): left rail = favorites star + provider
 glyphs; search input; rows = model name (✓ current) + provider subtitle,
 ⌘1…⌘9 (macOS) / Ctrl+1…Ctrl+9 (Windows/Linux) chips, favorite star; footer note

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -588,6 +588,7 @@ plan:
   expand: "Expand plan"
   collapse: "Collapse plan"
   ready: "Plan Ready"
+  dismiss: "Dismiss plan"
   refine_placeholder: "Add feedback to refine the plan, or leave this blank to implement it"
   refine: "Refine"
   implement: "Implement"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -582,6 +582,7 @@ plan:
   expand: "展开计划"
   collapse: "折叠计划"
   ready: "计划就绪"
+  dismiss: "忽略计划"
   refine_placeholder: "添加反馈以完善计划，或留空以直接实施。"
   refine: "完善"
   implement: "实施"


### PR DESCRIPTION
## The bug

Clicking **Implement** could leave the composer still in its plan-mode state, plus a range of related misbehaviour. A read-only audit found the shared cause: plan **readiness**, plan **acceptance**, interaction **mode** and **queued-turn options** were four independent pieces of state with no shared plan identity.

The headline symptom had two independent causes:

1. `ActiveSession.plan_implemented` lived **only in memory**, while `Timeline.proposed_plan` deliberately survives replay. A cold reopen — app restart, or returning to a session after its idle provider was evicted — resurrected "Plan Ready" for an already-implemented plan. Worse, the restored session was correctly in Build mode, so Enter was labelled *Refine* but sent an ordinary build turn: "feedback" could start real work.
2. Every `ProposedPlan`/`ProposedPlanDelta` reset the acceptance flag unconditionally, with no plan identity check, so any late or duplicate plan event re-armed the UI.

## The fix

Plan state now folds from the canonical event log like every other durable fact.

**Core lifecycle**
- `ProposedPlan` carries `ready`: a streaming plan is display-only, and an interrupted, never-finalized plan is discarded rather than left implementable.
- A new tcode-level `PlanResolved` event (`Implemented` / `HandedOff` / `Dismissed`), modelled on the existing `ProviderRelay`, records the decision durably. `plan_implemented` is deleted.
- A resolved plan is not re-armed by late or duplicate provider events; rewinding past the implementation turn correctly un-resolves it.

**Runtime**
- `implement_plan` validates a pending provider relay *before* mutating state — it used to clear the plan and switch to Build while `send_turn` silently dropped the prompt.
- Implementing in a new thread marks the source plan handed off (it previously stayed Plan Ready forever and could be implemented again) and copies the missing `profile_id`.
- Queued messages snapshot the mode selected when they were written, so a later toggle cannot rewrite work already in the FIFO.

**Composer**
- A dismiss control gives the plan-ready state an exit that is not "implement".
- The primary action uses the same sendable-content predicate as `submit`, so an attachment-only draft no longer offers Implement while Enter sends the attachment.
- Refine semantics apply only in Plan mode; in Build the composer keeps its ordinary Send affordance while the plan stays implementable.
- The compact-width overflow Build/Plan row is finally clickable. The permission row stays display-only on purpose: its full-width counterpart is an explicit picker, and cycling there would let two stray clicks escalate a Supervised session to Full access.

**Claude**
- A persisted Plan session launches in the plan permission sandbox instead of launching in Build and relying on an unchecked control request.
- The mode tracker follows the effective argv, so a user `--permission-mode` override cannot desynchronize it.
- Changing the approval policy while planning updates only the mode to restore later, instead of silently dropping out of plan mode mid-turn.
- `ExitPlanMode` is latched per turn: a retry after the auto-deny arrives with a fresh tool id, which defeated the id-keyed dedupe.

**ACP**
- `SetInteractionMode` was a silent no-op while the UI showed *and persisted* the toggle — the chip could claim Plan while the agent remained free to edit files. Build/Plan now maps to the agent's advertised modes, stays in sync with `acp:mode` in both directions, and warns instead of lying when the agent advertises no plan mode.

## Verification

All four CI gates run locally and green:

```
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo build            # warning-free
cargo test --workspace # 702 passed, 0 failed
```

13 new tests, including the regressions for the reported bug:
- `implemented_plan_stays_resolved_after_event_log_replay` — the headline fix
- `proposed_plan_delta_alone_is_not_ready`, `unfinished_streaming_plan_is_discarded_when_turn_ends`
- `resolved_plan_ignores_late_or_duplicate_provider_events`
- `rewind_drops_resolutions_from_target_turn_but_keeps_earlier_ones`
- `implement_plan_waits_for_pending_relay_without_mutating_state`
- `queued_turns_keep_the_interaction_mode_selected_at_submit_time`
- `plan_session_launches_with_plan_permission_mode`, `set_approval_mode_while_in_plan_keeps_plan_permission_mode`, `exit_plan_mode_captures_once_per_turn`
- three ACP mode-mapping tests

No test was weakened or removed to make the gates pass.

## Note on old sessions

Session logs written before this change contain no `PlanResolved` events, so a plan implemented before upgrading will still show as plan-ready once. Retrofitting it would mean text-matching the `PLEASE IMPLEMENT THIS PLAN:` prompt, which is fragile and can't mark new-thread handoffs — deliberately not done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)