### PR TITLE
Preview: fix URL-bar window drag, add close-and-release, port agent-side parity tools

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -457,6 +457,13 @@ fn main() {
                     appears_transparent: cfg!(any(target_os = "macos", target_os = "windows")),
                     traffic_light_position: Some(point(px(12.), px(19.))),
                 }),
+                // macOS: the app owns titlebar dragging. AppKit's native
+                // titlebar-region drag sits on top of whatever gpui draws in the
+                // top strip — dragging the Preview URL bar moved the window
+                // instead of selecting text. Every draggable strip already goes
+                // through `window_drag_area` (`start_window_move`), so hand the
+                // whole content view to the app and let controls own their input.
+                app_owns_titlebar_drag: true,
                 // Spell out that Windows is client-decorated. (This field is
                 // advisory off Wayland; leaving it `None` elsewhere keeps Linux
                 // on whatever its compositor/backend already chose.)

--- a/crates/preview-mcp/src/js.rs
+++ b/crates/preview-mcp/src/js.rs
@@ -128,6 +128,130 @@ pub fn type_text(selector: &str, text: &str) -> String {
     )
 }
 
+/// JS to dispatch a keydown/keyup pair to the focused element. Printable keys
+/// also update editable targets because untrusted keyboard events have no
+/// browser default action.
+pub fn press(key: &str, modifiers: &[String]) -> String {
+    let key = json_string(key);
+    let alt = modifiers.iter().any(|modifier| modifier == "Alt");
+    let control = modifiers.iter().any(|modifier| modifier == "Control");
+    let meta = modifiers.iter().any(|modifier| modifier == "Meta");
+    let shift = modifiers.iter().any(|modifier| modifier == "Shift");
+    format!(
+        r#"(() => {{
+  try {{
+    const key = {key};
+    const target = document.activeElement || document.body;
+    if (!target) return {{ error: "document has no key target" }};
+    const opts = {{
+      key, bubbles: true, cancelable: true,
+      altKey: {alt}, ctrlKey: {control}, metaKey: {meta}, shiftKey: {shift}
+    }};
+    target.dispatchEvent(new KeyboardEvent("keydown", opts));
+    if (Array.from(key).length === 1 && !opts.ctrlKey && !opts.metaKey) {{
+      if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {{
+        const start = target.selectionStart == null ? target.value.length : target.selectionStart;
+        const end = target.selectionEnd == null ? start : target.selectionEnd;
+        const value = target.value.slice(0, start) + key + target.value.slice(end);
+        const proto = target instanceof HTMLTextAreaElement
+          ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+        const setter = Object.getOwnPropertyDescriptor(proto, "value");
+        if (setter && setter.set) setter.set.call(target, value); else target.value = value;
+        try {{ target.setSelectionRange(start + key.length, start + key.length); }} catch (_) {{}}
+        target.dispatchEvent(new InputEvent("input", {{
+          bubbles: true, data: key, inputType: "insertText"
+        }}));
+      }} else if (target.isContentEditable) {{
+        const selection = getSelection();
+        let range = selection && selection.rangeCount ? selection.getRangeAt(0) : null;
+        if (!range || !target.contains(range.commonAncestorContainer)) {{
+          range = document.createRange();
+          range.selectNodeContents(target);
+          range.collapse(false);
+        }}
+        range.deleteContents();
+        const node = document.createTextNode(key);
+        range.insertNode(node);
+        range.setStartAfter(node);
+        range.collapse(true);
+        if (selection) {{
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }}
+        target.dispatchEvent(new InputEvent("input", {{
+          bubbles: true, data: key, inputType: "insertText"
+        }}));
+      }}
+    }}
+    if (key === "Enter" && target instanceof HTMLInputElement) {{
+      const form = target.closest("form");
+      if (form && typeof form.requestSubmit === "function") form.requestSubmit();
+    }}
+    target.dispatchEvent(new KeyboardEvent("keyup", opts));
+    return {{ ok: true, key, target: target.tagName.toLowerCase() }};
+  }} catch (e) {{ return {{ error: String(e) }}; }}
+}})()"#
+    )
+}
+
+/// JS to scroll the window or the first `selector` match and report its final
+/// position.
+pub fn scroll(delta_x: f64, delta_y: f64, selector: Option<&str>) -> String {
+    let selector = selector
+        .map(json_string)
+        .unwrap_or_else(|| "null".to_string());
+    format!(
+        r#"(() => {{
+  try {{
+    const selector = {selector};
+    if (selector !== null) {{
+      const el = document.querySelector(selector);
+      if (!el) return {{ error: "no element matches selector" }};
+      el.scrollBy({{ left: {delta_x}, top: {delta_y}, behavior: "instant" }});
+      return {{ scrollLeft: el.scrollLeft, scrollTop: el.scrollTop }};
+    }}
+    window.scrollBy({{ left: {delta_x}, top: {delta_y}, behavior: "instant" }});
+    return {{ x: window.scrollX, y: window.scrollY }};
+  }} catch (e) {{ return {{ error: String(e) }}; }}
+}})()"#
+    )
+}
+
+/// JS to test all requested wait conditions once. The UI polls this probe so
+/// the WebView does not need to retain timers or callbacks across evaluations.
+pub fn wait_for_probe(
+    selector: Option<&str>,
+    text: Option<&str>,
+    url_includes: Option<&str>,
+) -> String {
+    let selector = selector
+        .map(json_string)
+        .unwrap_or_else(|| "null".to_string());
+    let text = text.map(json_string).unwrap_or_else(|| "null".to_string());
+    let url_includes = url_includes
+        .map(json_string)
+        .unwrap_or_else(|| "null".to_string());
+    format!(
+        r#"(() => {{
+  const selector = {selector};
+  const text = {text};
+  const urlIncludes = {url_includes};
+  const pending = [];
+  if (selector !== null) {{
+    try {{
+      if (!document.querySelector(selector)) pending.push("selector");
+    }} catch (_) {{
+      pending.push("selector");
+    }}
+  }}
+  const documentText = document.body ? (document.body.innerText || document.body.textContent || "") : "";
+  if (text !== null && !documentText.includes(text)) pending.push("text");
+  if (urlIncludes !== null && !location.href.includes(urlIncludes)) pending.push("urlIncludes");
+  return {{ matched: pending.length === 0, url: location.href, pending }};
+}})()"#
+    )
+}
+
 /// Wrap an arbitrary user expression so its value is returned to the callback.
 pub fn evaluate(expression: &str) -> String {
     // Parenthesize so an object-literal expression isn't parsed as a block.
@@ -204,5 +328,33 @@ mod tests {
         let js = type_text("#in", "he\"llo");
         assert!(js.contains(r##""#in""##));
         assert!(js.contains(r#""he\"llo""#));
+    }
+
+    #[test]
+    fn press_snippet_embeds_key_and_modifiers() {
+        let js = press("\"", &["Control".into(), "Shift".into()]);
+        assert!(js.contains(r#""\"""#));
+        assert!(js.contains("ctrlKey: true"));
+        assert!(js.contains("shiftKey: true"));
+        assert!(js.contains("requestSubmit"));
+    }
+
+    #[test]
+    fn scroll_snippet_targets_selector_and_deltas() {
+        let js = scroll(12.5, -40.0, Some("#feed"));
+        assert!(js.contains(r##""#feed""##));
+        assert!(js.contains("left: 12.5"));
+        assert!(js.contains("top: -40"));
+        assert!(js.contains("scrollLeft"));
+    }
+
+    #[test]
+    fn wait_probe_embeds_each_condition() {
+        let js = wait_for_probe(Some(".ready"), Some("Done"), Some("/result"));
+        assert!(js.contains(r#"".ready""#));
+        assert!(js.contains(r#""Done""#));
+        assert!(js.contains(r#""/result""#));
+        assert!(js.contains(r#"pending.push("selector")"#));
+        assert!(js.contains(r#"pending.push("urlIncludes")"#));
     }
 }

--- a/crates/preview-mcp/src/lib.rs
+++ b/crates/preview-mcp/src/lib.rs
@@ -23,12 +23,27 @@ pub mod js;
 pub mod ports;
 mod tools;
 
+/// Fixed preview canvas presets as `(id, portrait_width, portrait_height)` in
+/// CSS pixels.
+pub const PREVIEW_PRESETS: &[(&str, u32, u32)] = &[
+    ("iphone-se", 375, 667),
+    ("iphone-xr", 414, 896),
+    ("iphone-12-pro", 390, 844),
+    ("iphone-14-pro-max", 430, 932),
+    ("pixel-7", 412, 915),
+    ("galaxy-s20-ultra", 412, 915),
+    ("ipad-mini", 768, 1024),
+    ("ipad-air", 820, 1180),
+    ("ipad-pro-12-9", 1024, 1366),
+    ("surface-pro-7", 912, 1368),
+];
+
 /// A single automation operation requested by the agent, routed to the UI.
 ///
 /// Names/semantics mirror T3's preview toolkit, reduced to the subset a raw
 /// WKWebView (`evaluate_script` + `load_url`, no Chrome DevTools Protocol) can
 /// serve.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum PreviewOp {
     /// Open a URL (creating/showing the webview); `None` just reports status.
     Open { url: Option<String> },
@@ -42,6 +57,26 @@ pub enum PreviewOp {
     Click { selector: String },
     /// Focus `selector` and type `text` into it (dispatching input events).
     Type { selector: String, text: String },
+    /// Set a fixed WebView canvas, or clear it when both dimensions are `None`.
+    Resize {
+        width: Option<u32>,
+        height: Option<u32>,
+    },
+    /// Dispatch a keyboard press to the focused page element.
+    Press { key: String, modifiers: Vec<String> },
+    /// Scroll the window or the first element matching `selector`.
+    Scroll {
+        delta_x: f64,
+        delta_y: f64,
+        selector: Option<String>,
+    },
+    /// Poll page state until all requested conditions match or time out.
+    WaitFor {
+        selector: Option<String>,
+        text: Option<String>,
+        url_includes: Option<String>,
+        timeout_ms: u64,
+    },
     /// Build a DOM outline of interactive elements (role/name/selector), capped.
     Snapshot,
     /// Capture the visible webview region as a PNG.
@@ -157,7 +192,7 @@ pub fn start() -> std::io::Result<PreviewMcpServer> {
     let (req_tx, req_rx) = async_channel::unbounded::<BrokerRequest>();
     let broker = Broker {
         requests: req_tx,
-        timeout: Duration::from_secs(30),
+        timeout: Duration::from_secs(65),
     };
     let services = Arc::new(RwLock::new(tools::Services::new()));
     let tokens = TokenRegistry {

--- a/crates/preview-mcp/src/tools.rs
+++ b/crates/preview-mcp/src/tools.rs
@@ -20,7 +20,7 @@ use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, Stream
 use rmcp::{ErrorData, ServerHandler, tool, tool_handler, tool_router};
 use serde::Deserialize;
 
-use crate::{Broker, PreviewOp, PreviewReply};
+use crate::{Broker, PREVIEW_PRESETS, PreviewOp, PreviewReply};
 
 /// Optional-URL argument for `preview_open`.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -58,6 +58,133 @@ pub struct TypeParams {
     pub selector: String,
     /// Text to set as the field's value.
     pub text: String,
+}
+
+/// Fixed-canvas dimensions or a named device preset.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ResizeParams {
+    /// Canvas mode: `fill` uses the whole panel; `fixed` uses a device-sized canvas.
+    pub mode: String,
+    /// Fixed canvas width in CSS pixels.
+    #[serde(default)]
+    pub width: Option<i64>,
+    /// Fixed canvas height in CSS pixels.
+    #[serde(default)]
+    pub height: Option<i64>,
+    /// Named device preset, as an alternative to width and height.
+    #[serde(default)]
+    pub preset: Option<String>,
+    /// `portrait` (default) or `landscape`.
+    #[serde(default)]
+    pub orientation: Option<String>,
+}
+
+/// A key and optional modifier keys to dispatch.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct PressParams {
+    /// A `KeyboardEvent.key` value such as `Enter`, `Escape`, `Tab`, `a`, or `F5`.
+    pub key: String,
+    /// Zero or more of `Alt`, `Control`, `Meta`, and `Shift`.
+    #[serde(default)]
+    pub modifiers: Vec<String>,
+}
+
+/// Relative scrolling parameters.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ScrollParams {
+    /// Horizontal scroll delta in CSS pixels.
+    #[serde(default)]
+    pub delta_x: Option<f64>,
+    /// Vertical scroll delta in CSS pixels.
+    #[serde(default)]
+    pub delta_y: Option<f64>,
+    /// CSS selector of a scroll container; omitted to scroll the window.
+    #[serde(default)]
+    pub selector: Option<String>,
+}
+
+/// Page conditions to poll until all are satisfied.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WaitForParams {
+    /// CSS selector that must match an element.
+    #[serde(default)]
+    pub selector: Option<String>,
+    /// Substring that must appear in the document text.
+    #[serde(default)]
+    pub text: Option<String>,
+    /// Substring that must appear in the current URL.
+    #[serde(default)]
+    pub url_includes: Option<String>,
+    /// Maximum wait in milliseconds (default 15000, clamped to 1000..=60000).
+    #[serde(default)]
+    pub timeout_ms: Option<i64>,
+}
+
+const MIN_CANVAS_DIMENSION: i64 = 240;
+const MAX_CANVAS_DIMENSION: i64 = 3840;
+const MAX_CANVAS_AREA: u64 = 3840 * 2160;
+
+fn resize_op(params: ResizeParams) -> Result<PreviewOp, String> {
+    let landscape = match params.orientation.as_deref().unwrap_or("portrait") {
+        "portrait" => false,
+        "landscape" => true,
+        other => {
+            return Err(format!(
+                "invalid orientation {other:?}; use portrait or landscape"
+            ));
+        }
+    };
+    match params.mode.as_str() {
+        "fill" => Ok(PreviewOp::Resize {
+            width: None,
+            height: None,
+        }),
+        "fixed" => {
+            let (mut width, mut height) = if let Some(preset) = params.preset {
+                if params.width.is_some() || params.height.is_some() {
+                    return Err(
+                        "preset is an alternative to width and height; provide only one".into(),
+                    );
+                }
+                PREVIEW_PRESETS
+                    .iter()
+                    .find(|(id, _, _)| *id == preset)
+                    .map(|(_, width, height)| (*width, *height))
+                    .ok_or_else(|| format!("unknown preview preset {preset:?}"))?
+            } else {
+                let width = params
+                    .width
+                    .ok_or_else(|| "fixed mode requires width and height, or a preset".to_string())?
+                    .clamp(MIN_CANVAS_DIMENSION, MAX_CANVAS_DIMENSION)
+                    as u32;
+                let height = params
+                    .height
+                    .ok_or_else(|| "fixed mode requires width and height, or a preset".to_string())?
+                    .clamp(MIN_CANVAS_DIMENSION, MAX_CANVAS_DIMENSION)
+                    as u32;
+                (width, height)
+            };
+            if u64::from(width) * u64::from(height) > MAX_CANVAS_AREA {
+                return Err(format!(
+                    "fixed canvas area must not exceed {MAX_CANVAS_AREA} CSS pixels"
+                ));
+            }
+            if landscape {
+                std::mem::swap(&mut width, &mut height);
+            }
+            Ok(PreviewOp::Resize {
+                width: Some(width),
+                height: Some(height),
+            })
+        }
+        other => Err(format!("invalid mode {other:?}; use fill or fixed")),
+    }
+}
+
+fn tool_error(message: impl Into<String>) -> CallToolResult {
+    CallToolResult::error(vec![ContentBlock::text(message.into())])
 }
 
 /// The MCP server handler: one shared [`Broker`] plus the generated tool router.
@@ -144,6 +271,90 @@ impl PreviewTools {
             .await)
     }
 
+    /// Set the preview to fill the panel or use a fixed device-sized canvas.
+    #[tool(
+        description = "Resize the preview canvas. mode is fill or fixed. Fixed mode accepts width/height or one preset: iphone-se, iphone-xr, iphone-12-pro, iphone-14-pro-max, pixel-7, galaxy-s20-ultra, ipad-mini, ipad-air, ipad-pro-12-9, surface-pro-7."
+    )]
+    async fn preview_resize(
+        &self,
+        Parameters(params): Parameters<ResizeParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let op = match resize_op(params) {
+            Ok(op) => op,
+            Err(message) => return Ok(tool_error(message)),
+        };
+        Ok(self.run(op).await)
+    }
+
+    /// Dispatch a keyboard press to the focused page element.
+    #[tool(
+        description = "Press a key in the preview page, optionally with Alt, Control, Meta, or Shift modifiers."
+    )]
+    async fn preview_press(
+        &self,
+        Parameters(params): Parameters<PressParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Some(modifier) = params
+            .modifiers
+            .iter()
+            .find(|modifier| !matches!(modifier.as_str(), "Alt" | "Control" | "Meta" | "Shift"))
+        {
+            return Ok(tool_error(format!(
+                "invalid modifier {modifier:?}; use Alt, Control, Meta, or Shift"
+            )));
+        }
+        Ok(self
+            .run(PreviewOp::Press {
+                key: params.key,
+                modifiers: params.modifiers,
+            })
+            .await)
+    }
+
+    /// Scroll the page window or a selected scroll container.
+    #[tool(
+        description = "Scroll the preview window or a CSS-selected container by deltaX and deltaY."
+    )]
+    async fn preview_scroll(
+        &self,
+        Parameters(params): Parameters<ScrollParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if params.delta_x.is_none() && params.delta_y.is_none() {
+            return Ok(tool_error("preview_scroll requires deltaX or deltaY"));
+        }
+        Ok(self
+            .run(PreviewOp::Scroll {
+                delta_x: params.delta_x.unwrap_or(0.0),
+                delta_y: params.delta_y.unwrap_or(0.0),
+                selector: params.selector,
+            })
+            .await)
+    }
+
+    /// Wait until all specified page conditions match.
+    #[tool(
+        description = "Wait for a selector, document-text substring, and/or URL substring in the preview page."
+    )]
+    async fn preview_wait_for(
+        &self,
+        Parameters(params): Parameters<WaitForParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if params.selector.is_none() && params.text.is_none() && params.url_includes.is_none() {
+            return Ok(tool_error(
+                "preview_wait_for requires selector, text, or urlIncludes",
+            ));
+        }
+        let timeout_ms = params.timeout_ms.unwrap_or(15_000).clamp(1_000, 60_000) as u64;
+        Ok(self
+            .run(PreviewOp::WaitFor {
+                selector: params.selector,
+                text: params.text,
+                url_includes: params.url_includes,
+                timeout_ms,
+            })
+            .await)
+    }
+
     /// Build a DOM outline of the page's interactive elements (role/name/selector).
     #[tool(
         description = "Snapshot the preview page: URL, title, visible text, and interactive elements (role/name/selector)."
@@ -183,7 +394,8 @@ impl ServerHandler for PreviewTools {
             .with_server_info(Implementation::from_build_env())
             .with_instructions(
                 "Drive the tcode embedded preview browser: open/navigate URLs, inspect and \
-                 automate the page, and capture screenshots.",
+                 automate the page, resize its canvas, press keys, scroll, wait for page \
+                 conditions, and capture screenshots.",
             )
     }
 }
@@ -329,6 +541,10 @@ mod tests {
             "preview_evaluate",
             "preview_click",
             "preview_type",
+            "preview_resize",
+            "preview_press",
+            "preview_scroll",
+            "preview_wait_for",
             "preview_snapshot",
             "preview_screenshot",
         ] {

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -6436,6 +6436,22 @@ impl AppState {
         }
     }
 
+    /// The preview chrome's close button: close the right panel when it is
+    /// showing Preview. The PreviewPanel pairs this with dropping the
+    /// conversation's WebView so the page itself is torn down, not just hidden.
+    pub fn close_preview_panel(&mut self, cx: &mut Context<Self>) {
+        if let Some(active) = self.active.as_mut()
+            && active.diff_open
+            && active.right_tab == RightTab::Preview
+        {
+            active.diff_open = false;
+            if active.timeline.turn_running {
+                active.auto_open_suppressed = true;
+            }
+            cx.notify();
+        }
+    }
+
     /// Open the right panel on the Preview tab (used when the agent drives the
     /// preview so the webview surfaces without a manual toggle).
     pub fn open_preview_panel(&mut self, cx: &mut Context<Self>) {

--- a/crates/ui/src/diff/view.rs
+++ b/crates/ui/src/diff/view.rs
@@ -676,7 +676,7 @@ impl DiffPanel {
 
     // -- top strip (tab look + right icon cluster) --------------------------
 
-    fn render_tab_strip(&self, window: &Window, cx: &mut Context<Self>) -> AnyElement {
+    fn render_tab_strip(&self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
         let state = self.app_state.read(cx);
         let expanded = state.diff_panel_expanded();
         let active = state.right_tab();
@@ -764,10 +764,16 @@ impl DiffPanel {
                 }),
             )
             // The gap between the tabs and the icon cluster holds nothing, so
-            // it doubles as the window's native drag handle where one is needed.
-            // `h_full` is load-bearing: the strip centers its children, so
-            // without it the drag hitbox collapses to zero height.
-            .child(window_caption::drag_region(div().flex_1().h_full()))
+            // it doubles as the window's drag handle: `window_drag_area` for the
+            // app-owned move (macOS), `drag_region` for native HTCAPTION
+            // (Windows). `h_full` is load-bearing: the strip centers its
+            // children, so without it the drag hitbox collapses to zero height.
+            .child(window_caption::drag_region(crate::window_drag_area(
+                "right-panel-tabs-drag",
+                div().flex_1().h_full(),
+                window,
+                cx,
+            )))
             // Right icon cluster: expand toggle, a layout no-op, close.
             .child(
                 Button::new("diff-expand")

--- a/crates/ui/src/preview_panel.rs
+++ b/crates/ui/src/preview_panel.rs
@@ -380,6 +380,24 @@ mod native {
             }
         }
 
+        /// The chrome's X: close the Preview tab *and* drop this conversation's
+        /// WebView, so the page is torn down (scripts, media, sockets) rather
+        /// than kept running behind a closed panel. The next open or agent op
+        /// recreates a fresh webview on demand.
+        fn close_panel(&mut self, cx: &mut Context<Self>) {
+            if let Some(key) = self.active_key(cx) {
+                self.webviews.remove(&key);
+                self.urls.remove(&key);
+                self.warm.remove(&key);
+            }
+            // Un-mirror so a later reopen refreshes the address bar from the
+            // (now empty) URL map instead of showing the stale address.
+            self.mirrored = None;
+            self.app_state
+                .update(cx, |state, cx| state.close_preview_panel(cx));
+            cx.notify();
+        }
+
         fn rescan_ports(&mut self, cx: &mut Context<Self>) {
             self.port_scan_generation = self.port_scan_generation.wrapping_add(1);
             let generation = self.port_scan_generation;
@@ -783,6 +801,15 @@ mod native {
                         .icon(IconName::ExternalLink)
                         .tooltip(tcode_i18n::tr!("preview.open_external"))
                         .on_click(cx.listener(|this, _, _, cx| this.open_in_system_browser(cx))),
+                )
+                .child(
+                    Button::new("preview-close")
+                        .ghost()
+                        .small()
+                        .compact()
+                        .icon(IconName::Close)
+                        .tooltip(tcode_i18n::tr!("preview.close"))
+                        .on_click(cx.listener(|this, _, _, cx| this.close_panel(cx))),
                 )
                 // Last child, so the chrome's own controls stay to its left.
                 .children(hosts_caption.then(|| window_caption::caption_controls(window, cx)))

--- a/crates/ui/src/preview_panel.rs
+++ b/crates/ui/src/preview_panel.rs
@@ -97,6 +97,13 @@ mod native {
     use crate::window_caption;
     use tcode_runtime::app::AppState;
 
+    fn wait_timeout_message(pending: &[String]) -> String {
+        format!(
+            "preview_wait_for timed out; unmet conditions: {}",
+            pending.join(", ")
+        )
+    }
+
     pub struct PreviewPanel {
         app_state: Entity<AppState>,
         /// One native WebView per session id, created on first use.
@@ -108,6 +115,8 @@ mod native {
         warm: HashSet<String>,
         /// Last URL loaded per session (drives the address bar + reload).
         urls: HashMap<String, String>,
+        /// Fixed WebView canvas dimensions per stable conversation key.
+        canvases: HashMap<String, (u32, u32)>,
         /// The shared address-bar input (reflects the active session's URL).
         url_input: Entity<InputState>,
         /// Session id whose URL is currently mirrored into `url_input`.
@@ -152,6 +161,7 @@ mod native {
                 webviews: HashMap::new(),
                 warm: HashSet::new(),
                 urls: HashMap::new(),
+                canvases: HashMap::new(),
                 url_input,
                 mirrored: None,
                 active_identity: None,
@@ -191,6 +201,11 @@ mod native {
                     && !self.urls.contains_key(key)
                 {
                     self.urls.insert(key.clone(), url);
+                }
+                if let Some(canvas) = self.canvases.remove(old_key)
+                    && !self.canvases.contains_key(key)
+                {
+                    self.canvases.insert(key.clone(), canvas);
                 }
                 if self.warm.remove(old_key) {
                     self.warm.insert(key.clone());
@@ -493,7 +508,7 @@ mod native {
                     });
                     let _ = reply.try_send(Ok(PreviewReply::Json(payload)));
                 }
-                PreviewOp::Status => self.eval_json(&key, js::STATUS, reply, window, cx),
+                PreviewOp::Status => self.status(&key, reply, window, cx),
                 PreviewOp::Snapshot => self.eval_json(&key, js::SNAPSHOT, reply, window, cx),
                 PreviewOp::Evaluate { js: expr } => {
                     self.eval_json(&key, &js::evaluate(&expr), reply, window, cx)
@@ -504,8 +519,239 @@ mod native {
                 PreviewOp::Type { selector, text } => {
                     self.eval_json(&key, &js::type_text(&selector, &text), reply, window, cx)
                 }
+                PreviewOp::Resize { width, height } => {
+                    self.app_state.update(cx, |state, cx| {
+                        state.open_preview_panel_for(&session_id, cx)
+                    });
+                    let payload = match (width, height) {
+                        (Some(width), Some(height)) => {
+                            self.canvases.insert(key, (width, height));
+                            serde_json::json!({
+                                "ok": true,
+                                "mode": "fixed",
+                                "width": width,
+                                "height": height,
+                                "note": "fixed canvas is clamped to the panel if larger",
+                            })
+                        }
+                        _ => {
+                            self.canvases.remove(&key);
+                            serde_json::json!({
+                                "ok": true,
+                                "mode": "fill",
+                                "note": "preview fills the available panel",
+                            })
+                        }
+                    };
+                    self.sync_visibility(cx);
+                    cx.notify();
+                    let _ = reply.try_send(Ok(PreviewReply::Json(payload)));
+                }
+                // `key` is the routed conversation key; bind the keyboard key
+                // apart so it cannot shadow it into `eval_json`'s session slot.
+                PreviewOp::Press {
+                    key: pressed,
+                    modifiers,
+                } => self.eval_json(&key, &js::press(&pressed, &modifiers), reply, window, cx),
+                PreviewOp::Scroll {
+                    delta_x,
+                    delta_y,
+                    selector,
+                } => self.eval_json(
+                    &key,
+                    &js::scroll(delta_x, delta_y, selector.as_deref()),
+                    reply,
+                    window,
+                    cx,
+                ),
+                PreviewOp::WaitFor {
+                    selector,
+                    text,
+                    url_includes,
+                    timeout_ms,
+                } => self.wait_for(
+                    &key,
+                    selector,
+                    text,
+                    url_includes,
+                    timeout_ms,
+                    reply,
+                    window,
+                    cx,
+                ),
                 PreviewOp::Screenshot => self.screenshot(&session_id, &key, reply, window, cx),
             }
+        }
+
+        /// Add this conversation's canvas setting to the otherwise opaque page
+        /// status object returned by JavaScript.
+        fn status(
+            &mut self,
+            key: &str,
+            reply: ReplyTx,
+            window: &mut Window,
+            cx: &mut Context<Self>,
+        ) {
+            let canvas = self
+                .canvases
+                .get(key)
+                .map(|(width, height)| {
+                    serde_json::json!({
+                        "mode": "fixed",
+                        "width": width,
+                        "height": height,
+                    })
+                })
+                .unwrap_or_else(|| serde_json::json!({ "mode": "fill" }));
+            let (status_reply, status_result) = async_channel::bounded(1);
+            cx.spawn(async move |_, _| {
+                let result = match status_result.recv().await {
+                    Ok(Ok(PreviewReply::Json(mut value))) => {
+                        if let Some(object) = value.as_object_mut() {
+                            object.insert("canvas".into(), canvas);
+                            Ok(PreviewReply::Json(value))
+                        } else {
+                            Err("preview status returned a non-object value".into())
+                        }
+                    }
+                    Ok(result) => result,
+                    Err(_) => Err("preview status evaluation was dropped".into()),
+                };
+                let _ = reply.send(result).await;
+            })
+            .detach();
+            self.eval_json(key, js::STATUS, status_reply, window, cx);
+        }
+
+        /// Poll a one-shot page probe every 250ms until it matches or reaches
+        /// its deadline. Each evaluation has its own watchdog because native
+        /// WebViews can drop callbacks during navigation.
+        #[allow(clippy::too_many_arguments)]
+        fn wait_for(
+            &mut self,
+            key: &str,
+            selector: Option<String>,
+            text: Option<String>,
+            url_includes: Option<String>,
+            timeout_ms: u64,
+            reply: ReplyTx,
+            window: &mut Window,
+            cx: &mut Context<Self>,
+        ) {
+            if self.ensure_webview(key, window, cx).is_none() {
+                let err = self.webview_error.clone().unwrap_or_default();
+                let _ = reply.try_send(Err(unavailable_message(&err)));
+                return;
+            }
+            let cold = !self.warm.contains(key);
+            let key = key.to_string();
+            let probe = js::wait_for_probe(
+                selector.as_deref(),
+                text.as_deref(),
+                url_includes.as_deref(),
+            );
+            let mut pending = Vec::new();
+            if selector.is_some() {
+                pending.push("selector".to_string());
+            }
+            if text.is_some() {
+                pending.push("text".to_string());
+            }
+            if url_includes.is_some() {
+                pending.push("urlIncludes".to_string());
+            }
+            cx.spawn(async move |this, cx| {
+                let deadline = std::time::Instant::now() + Duration::from_millis(timeout_ms);
+                if cold {
+                    cx.background_executor()
+                        .timer(Duration::from_millis(700))
+                        .await;
+                    if this
+                        .update(cx, |panel, _| {
+                            panel.warm.insert(key.clone());
+                        })
+                        .is_err()
+                    {
+                        let _ = reply
+                            .send(Err("preview panel was dropped while waiting".into()))
+                            .await;
+                        return;
+                    }
+                }
+                loop {
+                    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                    if remaining.is_zero() {
+                        let _ = reply.send(Err(wait_timeout_message(&pending))).await;
+                        return;
+                    }
+                    let (probe_reply, probe_result) = async_channel::bounded(1);
+                    if this
+                        .update(cx, |panel, cx| {
+                            panel.eval_now(&key, &probe, probe_reply.clone(), cx);
+                        })
+                        .is_err()
+                    {
+                        let _ = reply
+                            .send(Err("preview panel was dropped while waiting".into()))
+                            .await;
+                        return;
+                    }
+
+                    let watchdog_delay = remaining.min(Duration::from_secs(5));
+                    let watchdog_reply = probe_reply;
+                    let watchdog_error = if remaining <= Duration::from_secs(5) {
+                        wait_timeout_message(&pending)
+                    } else {
+                        "preview wait probe evaluation timed out".into()
+                    };
+                    let watchdog_timer = cx.background_executor().timer(watchdog_delay);
+                    cx.background_executor()
+                        .spawn(async move {
+                            watchdog_timer.await;
+                            let _ = watchdog_reply.try_send(Err(watchdog_error));
+                        })
+                        .detach();
+
+                    let value = match probe_result.recv().await {
+                        Ok(Ok(PreviewReply::Json(value))) => value,
+                        Ok(Ok(PreviewReply::Image { .. })) => {
+                            let _ = reply
+                                .send(Err("preview wait probe returned an image".into()))
+                                .await;
+                            return;
+                        }
+                        Ok(Err(error)) => {
+                            let _ = reply.send(Err(error)).await;
+                            return;
+                        }
+                        Err(_) => {
+                            let _ = reply
+                                .send(Err("preview wait probe evaluation was dropped".into()))
+                                .await;
+                            return;
+                        }
+                    };
+                    if value.get("matched").and_then(serde_json::Value::as_bool) == Some(true) {
+                        let _ = reply.send(Ok(PreviewReply::Json(value))).await;
+                        return;
+                    }
+                    pending = value
+                        .get("pending")
+                        .and_then(serde_json::Value::as_array)
+                        .map(|items| {
+                            items
+                                .iter()
+                                .filter_map(serde_json::Value::as_str)
+                                .map(str::to_string)
+                                .collect()
+                        })
+                        .unwrap_or_else(|| pending.clone());
+                    cx.background_executor()
+                        .timer(Duration::from_millis(250))
+                        .await;
+                }
+            })
+            .detach();
         }
 
         /// Evaluate `script` and answer `reply` with the parsed JSON result.
@@ -695,7 +941,28 @@ mod native {
 
             let body: AnyElement = match &active {
                 Some(id) => match self.ensure_webview(id, window, cx) {
-                    Some(view) => div().flex_1().min_h_0().child(view).into_any_element(),
+                    Some(view) => {
+                        if let Some((width, height)) = self.canvases.get(id).copied() {
+                            div()
+                                .flex()
+                                .flex_1()
+                                .min_h_0()
+                                .items_center()
+                                .justify_center()
+                                .child(
+                                    div()
+                                        .flex_none()
+                                        .w(px(width as f32))
+                                        .h(px(height as f32))
+                                        .max_w_full()
+                                        .max_h_full()
+                                        .child(view),
+                                )
+                                .into_any_element()
+                        } else {
+                            div().flex_1().min_h_0().child(view).into_any_element()
+                        }
+                    }
                     None => v_flex()
                         .flex_1()
                         .gap_2()

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -675,6 +675,7 @@ preview:
   reload: "Reload"
   scan_ports: "Scan localhost dev ports"
   open_external: "Open in system browser"
+  close: "Close preview and release the page"
   unsupported_linux: "Preview is not available on Linux yet."
   unavailable: "The preview browser could not start."
   unavailable_hint: "It needs the system webview component. Everything else in tcode works without it."

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -669,6 +669,7 @@ preview:
   reload: "重新加载"
   scan_ports: "扫描本地开发端口"
   open_external: "在系统浏览器中打开"
+  close: "关闭预览并释放页面"
   unsupported_linux: "预览功能暂不支持 Linux。"
   unavailable: "预览浏览器无法启动。"
   unavailable_hint: "它需要系统的 webview 组件。tcode 的其他功能不受影响。"


### PR DESCRIPTION
## Summary

Three Preview-panel improvements toward t3code parity:

- **URL-bar drag no longer moves the window (macOS).** With the transparent titlebar, AppKit's native titlebar-region drag sat on top of the chrome row, so dragging the address bar moved the window instead of selecting text. The window now sets gpui's `app_owns_titlebar_drag`; all strips drag via `window_drag_area`, and the Diff/Plan tab strip's inert stretch gains one so it stays draggable. Bonus: titlebar clicks lose the macOS double-click-disambiguation delay.
- **Close button releases the page.** The Preview chrome gains an X that closes the tab *and* drops the conversation's WebView (webviews/urls/warm), so the page is torn down — scripts, media, sockets — rather than kept running behind a closed panel. Reopening or the next agent op recreates it on demand.
- **Agent-side MCP parity: 4 new tools.** t3code exposes 13 preview tools; tcode had 8. This ports the four a raw wry WebView (no CDP) can serve:
  - `preview_resize` — fill or fixed canvas (240..=3840, area-capped), 10 device presets with orientation; the fixed canvas centers in the panel and clamps to it (a native child view is not clipped by gpui). `preview_status` reports the canvas setting.
  - `preview_press` — keydown/keyup with modifiers; printable keys update editable targets, Enter submits the enclosing form (untrusted events have no default action).
  - `preview_scroll` — window or CSS-selected container, reports the final position.
  - `preview_wait_for` — selector / text / urlIncludes polled every 250 ms with a per-evaluation watchdog; broker timeout raised to 65 s so the 60 s wait ceiling cannot outlive it.

  t3code's `preview_recording_start/stop` are deliberately not ported: they need CDP screencast, which WKWebView cannot provide.

## Test plan

- `cargo test -p preview-mcp -p tcode-ui -p tcode-runtime` — all green (20 / 214 / runtime suites)
- `cargo clippy -p preview-mcp -p tcode-ui -p tcode-runtime -p tcode -- -D warnings` — clean
- `cargo check -p tcode` — clean
- Manual (macOS): drag the URL bar → selects text; drag strip gaps → moves window; double-click strip → zoom; X closes Preview and tears the page down

🤖 Generated with [Claude Code](https://claude.com/claude-code)