### PR TITLE
feat(agent): capture served model, stop reasons, cost/duration, real diffs; surface model fallback

### DIFF
--- a/crates/agent/src/acp.rs
+++ b/crates/agent/src/acp.rs
@@ -1431,6 +1431,8 @@ async fn finish_turn(
                 used_tokens: None,
                 context_window: None,
                 total_processed_tokens: Some(usage.total_tokens),
+                cost_usd: None,
+                duration_ms: None,
             });
             let (status, message) = stop_reason_status(response.stop_reason);
             (status, message, usage)
@@ -1961,6 +1963,11 @@ impl State {
                 let usage = TokenUsage {
                     used_tokens: Some(usage.used),
                     context_window: Some(usage.size),
+                    cost_usd: usage
+                        .cost
+                        .as_ref()
+                        .filter(|cost| cost.currency.eq_ignore_ascii_case("USD"))
+                        .map(|cost| cost.amount),
                     ..Default::default()
                 };
                 self.usage = Some(usage);

--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -1044,6 +1044,12 @@ pub(crate) struct Mapper {
     /// Native rewind control requests awaiting Claude's correlated response.
     pending_rewinds: HashMap<String, PendingRewind>,
     native_rewind: bool,
+    /// Last assistant model published to the canonical event stream.
+    last_served_model: Option<String>,
+    /// Latest structured stop reason for the active turn.
+    stop_reason: Option<String>,
+    /// Warning-bearing stop reason already emitted for this occurrence.
+    warned_stop_reason: Option<String>,
 }
 
 impl Mapper {
@@ -1078,6 +1084,9 @@ impl Mapper {
             background_task_history: HashSet::new(),
             pending_rewinds: HashMap::new(),
             native_rewind: false,
+            last_served_model: None,
+            stop_reason: None,
+            warned_stop_reason: None,
         }
     }
 
@@ -1106,6 +1115,8 @@ impl Mapper {
         self.current_turn_id = Some(id.clone());
         self.awaiting_turn_checkpoint = self.native_rewind;
         self.exit_plan_captured = false;
+        self.stop_reason = None;
+        self.warned_stop_reason = None;
         id
     }
 
@@ -1116,6 +1127,8 @@ impl Mapper {
         let id = format!("turn-{}", self.turn_counter);
         self.current_turn_id = Some(id.clone());
         self.exit_plan_captured = false;
+        self.stop_reason = None;
+        self.warned_stop_reason = None;
         id
     }
 
@@ -1661,12 +1674,15 @@ impl Mapper {
                 }]
             }
             Some("message_delta") => {
+                let mut events = self.observe_stop_reason(
+                    event.pointer("/delta/stop_reason").and_then(Value::as_str),
+                );
                 // Live usage growth; nice-to-have for token display.
                 if let Some(usage) = event.get("usage") {
                     let tu = map_usage(usage, None);
-                    return vec![AgentEvent::TokenUsage(tu)];
+                    events.push(AgentEvent::TokenUsage(tu));
                 }
-                Vec::new()
+                events
             }
             _ => Vec::new(),
         }
@@ -1684,6 +1700,17 @@ impl Mapper {
             Some(m) => m,
             None => return Vec::new(),
         };
+        let mut out = Vec::new();
+        if let Some(model) = message.get("model").and_then(Value::as_str)
+            && self.last_served_model.as_deref() != Some(model)
+        {
+            self.last_served_model = Some(model.to_owned());
+            out.push(AgentEvent::ServedModel {
+                model: model.to_owned(),
+                reason: None,
+            });
+        }
+        out.extend(self.observe_stop_reason(message.get("stop_reason").and_then(Value::as_str)));
         let msg_id = message
             .get("id")
             .and_then(Value::as_str)
@@ -1691,7 +1718,7 @@ impl Mapper {
             .to_string();
         let content = match message.get("content").and_then(Value::as_array) {
             Some(c) => c,
-            None => return Vec::new(),
+            None => return out,
         };
         // Continue the stream's block numbering across the CLI's split
         // `assistant` lines (see `assistant_blocks_seen`).
@@ -1702,7 +1729,6 @@ impl Mapper {
         let first_index = *seen;
         *seen += content.len();
 
-        let mut out = Vec::new();
         for (offset, block) in content.iter().enumerate() {
             let index = first_index + offset;
             match block.get("type").and_then(Value::as_str) {
@@ -1742,6 +1768,25 @@ impl Mapper {
             }
         }
         out
+    }
+
+    fn observe_stop_reason(&mut self, reason: Option<&str>) -> Vec<AgentEvent> {
+        let Some(reason) = reason.filter(|reason| !reason.is_empty()) else {
+            return Vec::new();
+        };
+        self.stop_reason = Some(reason.to_owned());
+        let message = match reason {
+            "refusal" => Some("Request declined by safety classifiers (stop_reason: refusal)"),
+            "max_tokens" => Some("Response truncated: max_tokens limit reached"),
+            _ => None,
+        };
+        if message.is_none() || self.warned_stop_reason.as_deref() == Some(reason) {
+            return Vec::new();
+        }
+        self.warned_stop_reason = Some(reason.to_owned());
+        vec![AgentEvent::Warning {
+            message: message.unwrap().to_owned(),
+        }]
     }
 
     fn on_tool_use(&mut self, block: &Value) -> Vec<AgentEvent> {
@@ -1937,7 +1982,22 @@ impl Mapper {
                     exit_code: if is_error { Some(1) } else { Some(0) },
                     status,
                 },
-                ToolItem::File { changes } => ItemContent::FileChange { changes, status },
+                ToolItem::File { mut changes } => {
+                    if let Some(structured_patch) = msg.pointer("/tool_use_result/structuredPatch")
+                    {
+                        let diff = render_structured_patch(structured_patch);
+                        let path = msg
+                            .pointer("/tool_use_result/filePath")
+                            .and_then(Value::as_str);
+                        for change in &mut changes {
+                            if let Some(path) = path {
+                                change.path = path.to_owned();
+                            }
+                            change.diff = diff.clone();
+                        }
+                    }
+                    ItemContent::FileChange { changes, status }
+                }
                 ToolItem::Tool { name, input } => ItemContent::ToolCall {
                     name,
                     input,
@@ -2244,13 +2304,14 @@ impl Mapper {
 
     fn on_result(&mut self, msg: &Value) -> Vec<AgentEvent> {
         self.awaiting_turn_checkpoint = false;
+        let mut events = self.observe_stop_reason(msg.get("stop_reason").and_then(Value::as_str));
         let turn_id = self
             .current_turn_id
             .take()
             .unwrap_or_else(|| format!("turn-{}", self.turn_counter.max(1)));
         // No message outlives its turn, so the block counters can go.
         self.assistant_blocks_seen.clear();
-        let mut status = result_status(msg);
+        let mut status = result_status(msg, self.stop_reason.as_deref());
         if std::mem::take(&mut self.interrupt_pending) && status != TurnStatus::Completed {
             status = TurnStatus::Interrupted;
         }
@@ -2259,9 +2320,10 @@ impl Mapper {
             // Accumulate this turn's processed tokens into the session total.
             self.cumulative_processed += usage.used_tokens.unwrap_or(0);
             usage.total_processed_tokens = Some(self.cumulative_processed);
+            usage.cost_usd = msg.get("total_cost_usd").and_then(Value::as_f64);
+            usage.duration_ms = msg.get("duration_ms").and_then(Value::as_u64);
             usage
         });
-        let mut events = Vec::new();
         if status == TurnStatus::Failed {
             // The `result` field carries the CLI's own error text (API errors,
             // crashes); a bare "failed" turn marker would discard it.
@@ -2533,6 +2595,29 @@ fn file_changes(name: &str, input: &Value) -> Vec<FileChange> {
     }
 }
 
+/// Render Claude's structured edit hunks as a unified diff body.
+fn render_structured_patch(value: &Value) -> Option<String> {
+    let hunks = value.as_array()?;
+    let mut rendered = Vec::new();
+    for hunk in hunks {
+        let old_start = hunk.get("oldStart").and_then(Value::as_u64)?;
+        let old_lines = hunk.get("oldLines").and_then(Value::as_u64)?;
+        let new_start = hunk.get("newStart").and_then(Value::as_u64)?;
+        let new_lines = hunk.get("newLines").and_then(Value::as_u64)?;
+        rendered.push(format!(
+            "@@ -{old_start},{old_lines} +{new_start},{new_lines} @@"
+        ));
+        rendered.extend(
+            hunk.get("lines")
+                .and_then(Value::as_array)?
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_owned),
+        );
+    }
+    (!rendered.is_empty()).then(|| rendered.join("\n"))
+}
+
 /// Flatten a `tool_result` content field (string or block array) into text.
 fn tool_result_text(content: Option<&Value>) -> String {
     match content {
@@ -2555,12 +2640,24 @@ fn tool_result_text(content: Option<&Value>) -> String {
     }
 }
 
-fn result_status(msg: &Value) -> TurnStatus {
-    if msg.get("subtype").and_then(Value::as_str) == Some("success") {
+fn result_status(msg: &Value, stop_reason: Option<&str>) -> TurnStatus {
+    let subtype = msg.get("subtype").and_then(Value::as_str);
+    let is_error = msg.get("is_error").and_then(Value::as_bool);
+    if subtype == Some("success") && is_error != Some(true) {
         return TurnStatus::Completed;
     }
-    // Distinguish user-triggered interrupts from genuine failures by scanning the
-    // result text / error markers, matching the SDK's interrupted heuristic.
+    if matches!(
+        subtype,
+        Some("interrupted" | "interrupt" | "cancelled" | "canceled" | "aborted")
+    ) || matches!(
+        stop_reason,
+        Some("interrupted" | "interrupt" | "cancelled" | "canceled" | "aborted")
+    ) {
+        return TurnStatus::Interrupted;
+    }
+    // Older CLI error results have no structured interrupt marker. Restrict the
+    // legacy prose heuristic to those non-success results so ordinary answers
+    // mentioning cancellation cannot be misclassified.
     let haystack = format!(
         "{} {}",
         msg.get("result")
@@ -2606,6 +2703,8 @@ fn map_usage(usage: &Value, model_usage: Option<&Value>) -> TokenUsage {
         // Session-cumulative total is stamped by the caller (`on_result`); the
         // streaming/partial usage path leaves it unset.
         total_processed_tokens: None,
+        cost_usd: None,
+        duration_ms: None,
     }
 }
 
@@ -4823,5 +4922,90 @@ mod tests {
         );
         assert!(accepted_request_ids(&events).is_empty());
         assert_eq!(mapper.pending_steers.len(), 1);
+    }
+
+    #[test]
+    fn assistant_served_model_is_emitted_once_per_change() {
+        let mut mapper = Mapper::new();
+        let line = r#"{"type":"assistant","message":{"model":"claude-sonnet-4","id":"msg-1","content":[]}}"#;
+        let first = feed(&mut mapper, line);
+        let repeat = feed(&mut mapper, line);
+        assert!(matches!(
+            first.as_slice(),
+            [AgentEvent::ServedModel { model, reason: None }] if model == "claude-sonnet-4"
+        ));
+        assert!(repeat.is_empty());
+    }
+
+    #[test]
+    fn refusal_stop_reason_warns_once_across_delta_and_assistant() {
+        let mut mapper = Mapper::new();
+        let delta = feed(
+            &mut mapper,
+            r#"{"type":"stream_event","event":{"type":"message_delta","delta":{"stop_reason":"refusal"}}}"#,
+        );
+        let assistant = feed(
+            &mut mapper,
+            r#"{"type":"assistant","message":{"id":"msg-1","stop_reason":"refusal","content":[]}}"#,
+        );
+        assert!(matches!(
+            delta.as_slice(),
+            [AgentEvent::Warning { message }]
+                if message == "Request declined by safety classifiers (stop_reason: refusal)"
+        ));
+        assert!(assistant.is_empty());
+    }
+
+    #[test]
+    fn successful_result_that_mentions_cancel_is_completed() {
+        let mut mapper = Mapper::new();
+        mapper.start_turn();
+        let events = feed(
+            &mut mapper,
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"You can cancel the operation from Settings."}"#,
+        );
+        assert!(matches!(
+            events.as_slice(),
+            [AgentEvent::TurnCompleted {
+                status: TurnStatus::Completed,
+                ..
+            }]
+        ));
+    }
+
+    #[test]
+    fn structured_patch_renders_unified_diff() {
+        let patch = json!([{
+            "oldStart": 3,
+            "oldLines": 2,
+            "newStart": 3,
+            "newLines": 2,
+            "lines": [" keep", "-old", "+new"]
+        }]);
+        assert_eq!(
+            render_structured_patch(&patch).as_deref(),
+            Some("@@ -3,2 +3,2 @@\n keep\n-old\n+new")
+        );
+    }
+
+    #[test]
+    fn result_cost_and_duration_land_in_completed_usage() {
+        let mut mapper = Mapper::new();
+        mapper.start_turn();
+        let events = feed(
+            &mut mapper,
+            r#"{"type":"result","subtype":"success","is_error":false,"total_cost_usd":0.125,"duration_ms":4321,"usage":{"input_tokens":10,"output_tokens":2}}"#,
+        );
+        assert!(matches!(
+            events.as_slice(),
+            [AgentEvent::TurnCompleted {
+                usage: Some(TokenUsage {
+                    cost_usd: Some(cost),
+                    duration_ms: Some(4321),
+                    ..
+                }),
+                ..
+            }] if (*cost - 0.125).abs() < f64::EPSILON
+        ));
     }
 }

--- a/crates/agent/src/codex.rs
+++ b/crates/agent/src/codex.rs
@@ -1690,6 +1690,11 @@ impl Actor {
                     self.emit(AgentEvent::TokenUsage(usage)).await;
                 }
             }
+            "model/rerouted" => {
+                if let Some((model, reason)) = model_reroute(params) {
+                    self.emit(AgentEvent::ServedModel { model, reason }).await;
+                }
+            }
             "error" => {
                 // No message field → show the raw notification: a summary like
                 // "unknown error" leaves nothing to diagnose with.
@@ -2379,7 +2384,28 @@ fn map_usage(value: &Value) -> Option<TokenUsage> {
         used_tokens: last.get("totalTokens").and_then(Value::as_u64),
         context_window: value.get("modelContextWindow").and_then(Value::as_u64),
         total_processed_tokens,
+        cost_usd: None,
+        duration_ms: None,
     })
+}
+
+fn model_reroute(params: &Value) -> Option<(String, Option<String>)> {
+    // Read both spellings while app-server versions transition between Rust
+    // protocol names and JSON camelCase.
+    let _from = params
+        .get("fromModel")
+        .or_else(|| params.get("from_model"))
+        .and_then(Value::as_str);
+    let to = params
+        .get("toModel")
+        .or_else(|| params.get("to_model"))
+        .and_then(Value::as_str)?
+        .to_owned();
+    let reason = params
+        .get("reason")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    Some((to, reason))
 }
 
 #[cfg(test)]
@@ -2817,6 +2843,30 @@ mod tests {
         assert_eq!(usage.used_tokens, Some(120));
         assert_eq!(usage.total_processed_tokens, Some(5000));
         assert_eq!(usage.context_window, Some(200000));
+    }
+
+    #[test]
+    fn model_rerouted_notification_maps_served_model_with_reason() {
+        smol::block_on(async {
+            let (mut actor, events) = test_actor();
+            actor
+                .handle_notification(
+                    "model/rerouted",
+                    &json!({
+                        "from_model": "gpt-5",
+                        "toModel": "gpt-5-mini",
+                        "reason": "capacity"
+                    }),
+                )
+                .await;
+            assert!(matches!(
+                events.recv().await.unwrap(),
+                AgentEvent::ServedModel { model, reason }
+                    if model == "gpt-5-mini" && reason.as_deref() == Some("capacity")
+            ));
+            let _ = actor.child.kill();
+            let _ = actor.child.wait();
+        });
     }
 
     #[test]

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -681,6 +681,12 @@ pub enum AgentEvent {
         resume: ResumeCursor,
         model: Option<String>,
     },
+    /// The model that actually served the response. Providers may reroute away
+    /// from the model selected when the session started.
+    ServedModel {
+        model: String,
+        reason: Option<String>,
+    },
     TurnStarted {
         turn_id: String,
     },
@@ -1138,6 +1144,7 @@ pub enum ApprovalDecision {
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(default)]
 pub struct TokenUsage {
     pub input_tokens: Option<u64>,
     pub cached_input_tokens: Option<u64>,
@@ -1149,6 +1156,10 @@ pub struct TokenUsage {
     /// `thread/tokenUsage` running total; Claude accumulated per-turn usage).
     /// Shown as "Total processed" in the context-meter popover.
     pub total_processed_tokens: Option<u64>,
+    /// Provider-reported cost for this turn/message, in US dollars.
+    pub cost_usd: Option<f64>,
+    /// Provider-reported turn duration, in milliseconds.
+    pub duration_ms: Option<u64>,
 }
 
 #[cfg(test)]

--- a/crates/agent/src/opencode.rs
+++ b/crates/agent/src/opencode.rs
@@ -485,6 +485,7 @@ pub(crate) struct OpenCodeMapper {
     cumulative_processed: u64,
     turn_failed: bool,
     interrupted: bool,
+    last_served_model: Option<String>,
 }
 
 impl OpenCodeMapper {
@@ -502,6 +503,7 @@ impl OpenCodeMapper {
             cumulative_processed: 0,
             turn_failed: false,
             interrupted: false,
+            last_served_model: None,
         }
     }
 
@@ -591,6 +593,18 @@ impl OpenCodeMapper {
                     return mapped;
                 }
                 if info.get("role").and_then(Value::as_str) == Some("assistant") {
+                    if let Some(model) = info
+                        .get("modelID")
+                        .or_else(|| info.get("model_id"))
+                        .and_then(Value::as_str)
+                        && self.last_served_model.as_deref() != Some(model)
+                    {
+                        self.last_served_model = Some(model.to_owned());
+                        mapped.events.push(AgentEvent::ServedModel {
+                            model: model.to_owned(),
+                            reason: None,
+                        });
+                    }
                     if let Some(error) = info.get("error") {
                         self.turn_failed = true;
                         mapped.events.push(AgentEvent::Error {
@@ -599,8 +613,9 @@ impl OpenCodeMapper {
                         });
                     }
                     if info.pointer("/time/completed").is_some()
-                        && let Some(usage) = usage_from_tokens(info.get("tokens"))
+                        && let Some(mut usage) = usage_from_tokens(info.get("tokens"))
                     {
+                        usage.cost_usd = info.get("cost").and_then(Value::as_f64);
                         let key = info
                             .get("id")
                             .and_then(Value::as_str)
@@ -728,7 +743,11 @@ impl OpenCodeMapper {
             }
             Some("tool") => self.tool_updated(part),
             Some("step-finish") => {
-                if let Some(usage) = usage_from_tokens(part.get("tokens")) {
+                if let Some(mut usage) = usage_from_tokens(part.get("tokens")) {
+                    // The step-finish snapshot and completed message carry the
+                    // same cumulative per-message cost. Recording it here lets
+                    // the later reconciliation coalesce exactly.
+                    usage.cost_usd = part.get("cost").and_then(Value::as_f64);
                     let mut events = Vec::new();
                     let key = part
                         .get("messageID")
@@ -800,7 +819,8 @@ impl OpenCodeMapper {
             }
             _ => (ItemStatus::InProgress, None),
         };
-        let item = open_code_tool_item(&call_id, &name, input, output, status);
+        let exit_code = state.pointer("/metadata/exit").and_then(json_i32);
+        let item = open_code_tool_item(&call_id, &name, input, output, exit_code, status);
         vec![match state.get("status").and_then(Value::as_str) {
             Some("pending") => AgentEvent::ItemStarted(item),
             Some("completed" | "error") => AgentEvent::ItemCompleted(item),
@@ -849,6 +869,8 @@ fn same_token_usage(left: TokenUsage, right: TokenUsage) -> bool {
         && left.used_tokens == right.used_tokens
         && left.context_window == right.context_window
         && left.total_processed_tokens == right.total_processed_tokens
+        && left.cost_usd == right.cost_usd
+        && left.duration_ms == right.duration_ms
 }
 
 fn processed_tokens(usage: TokenUsage) -> u64 {
@@ -871,6 +893,14 @@ fn merge_token_usage(total: &mut TokenUsage, usage: TokenUsage) {
         (Some(left), Some(right)) => Some(left.max(right)),
         (left, right) => left.or(right),
     };
+    total.cost_usd = match (total.cost_usd, usage.cost_usd) {
+        (None, None) => None,
+        (left, right) => Some(left.unwrap_or(0.0) + right.unwrap_or(0.0)),
+    };
+    total.duration_ms = match (total.duration_ms, usage.duration_ms) {
+        (Some(left), Some(right)) => Some(left.saturating_add(right)),
+        (left, right) => left.or(right),
+    };
 }
 
 fn add_token_counts(left: Option<u64>, right: Option<u64>) -> Option<u64> {
@@ -885,6 +915,7 @@ fn open_code_tool_item(
     name: &str,
     input: Value,
     output: Option<String>,
+    exit_code: Option<i32>,
     status: ItemStatus,
 ) -> ThreadItem {
     let content = if name == "bash" {
@@ -895,7 +926,7 @@ fn open_code_tool_item(
                 .unwrap_or("")
                 .to_owned(),
             output: output.unwrap_or_default(),
-            exit_code: None,
+            exit_code,
             status,
         }
     } else {
@@ -1001,7 +1032,16 @@ fn usage_from_tokens(tokens: Option<&Value>) -> Option<TokenUsage> {
             .and_then(|total| total.checked_add(cache_write)),
         context_window: None,
         total_processed_tokens: None,
+        cost_usd: None,
+        duration_ms: None,
     })
+}
+
+fn json_i32(value: &Value) -> Option<i32> {
+    value
+        .as_i64()
+        .and_then(|number| i32::try_from(number).ok())
+        .or_else(|| value.as_str()?.parse().ok())
 }
 
 fn json_number(value: Option<&Value>) -> Option<u64> {
@@ -1714,6 +1754,7 @@ mod tests {
                     input_tokens: Some(10),
                     output_tokens: Some(5),
                     total_processed_tokens: Some(19),
+                    cost_usd: Some(0.1),
                     ..
                 }),
                 ..
@@ -1834,5 +1875,56 @@ mod tests {
             "Custom"
         );
         assert_eq!(configured["default"]["openai"], "gpt-test");
+    }
+
+    #[test]
+    fn assistant_model_change_is_emitted_once() {
+        let mut mapper = OpenCodeMapper::new("ses".into());
+        let event = json!({
+            "type": "message.updated",
+            "properties": {
+                "sessionID": "ses",
+                "info": {"role": "assistant", "id": "msg", "modelID": "gpt-5"}
+            }
+        });
+        let first = mapper.on_event(&event).events;
+        let repeat = mapper.on_event(&event).events;
+        assert!(matches!(
+            first.as_slice(),
+            [AgentEvent::ServedModel { model, reason: None }] if model == "gpt-5"
+        ));
+        assert!(repeat.is_empty());
+    }
+
+    #[test]
+    fn bash_metadata_exit_populates_exit_code() {
+        let mut mapper = OpenCodeMapper::new("ses".into());
+        let event = json!({
+            "type": "message.part.updated",
+            "properties": {
+                "sessionID": "ses",
+                "part": {
+                    "type": "tool",
+                    "callID": "call",
+                    "tool": "bash",
+                    "state": {
+                        "status": "completed",
+                        "input": {"command": "false"},
+                        "output": "",
+                        "metadata": {"exit": 7}
+                    }
+                }
+            }
+        });
+        assert!(matches!(
+            mapper.on_event(&event).events.as_slice(),
+            [AgentEvent::ItemCompleted(ThreadItem {
+                content: ItemContent::CommandExecution {
+                    exit_code: Some(7),
+                    ..
+                },
+                ..
+            })]
+        ));
     }
 }

--- a/crates/agent/src/pi.rs
+++ b/crates/agent/src/pi.rs
@@ -1216,6 +1216,8 @@ fn map_usage(usage: Option<&Value>) -> Option<TokenUsage> {
         used_tokens: number(usage.get("totalTokens")),
         context_window: None,
         total_processed_tokens: None,
+        cost_usd: None,
+        duration_ms: None,
     })
 }
 

--- a/crates/core/src/relay.rs
+++ b/crates/core/src/relay.rs
@@ -246,6 +246,7 @@ fn render_turn(number: usize, entries: &[&TimelineEntry], timeline: &Timeline) -
             EntryContent::ContextCompacted => {
                 activity(&mut body, "context", "provider", "compacted")
             }
+            EntryContent::ModelChanged { .. } => {}
             EntryContent::Reasoning { .. } => {}
         }
     }

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -183,6 +183,12 @@ pub struct TurnMeta {
     /// turn's end — a missing or untrustworthy timestamp yields no breakdown
     /// rather than an invented one.
     pub timing: Option<TurnTiming>,
+    /// Model that actually served this turn, when reported by the provider.
+    pub served_model: Option<String>,
+    /// Provider-reported cost for this turn, in US dollars.
+    pub cost_usd: Option<f64>,
+    /// Provider-reported duration, distinct from tcode's observed wall clock.
+    pub provider_duration_ms: Option<u64>,
 }
 
 impl TurnMeta {
@@ -474,6 +480,12 @@ pub enum EntryContent {
         to_provider: agent::ProviderKind,
         to_model: Option<String>,
     },
+    /// The provider changed the model actually serving this session.
+    ModelChanged {
+        from: Option<String>,
+        to: String,
+        reason: Option<String>,
+    },
     /// The provider compacted its context window (a "Context compacted" work-log row).
     ContextCompacted,
 }
@@ -533,6 +545,8 @@ pub struct Timeline {
     pub resume: Option<ResumeCursor>,
     pub provider_session_id: Option<String>,
     pub model: Option<String>,
+    /// Latest model reported by the serving provider. Seeded from `model`.
+    last_served_model: Option<String>,
     pub last_turn_status: Option<TurnStatus>,
     /// The turn currently accumulating entries, if any.
     current_turn: Option<usize>,
@@ -642,6 +656,26 @@ impl Timeline {
                 if model.is_some() {
                     self.model = model.clone();
                 }
+                self.last_served_model = self.model.clone();
+            }
+            AgentEvent::ServedModel { model, reason } => {
+                let turn = self.ensure_turn(ts);
+                self.turns[turn].served_model = Some(model.clone());
+                if self.last_served_model.as_deref() != Some(model.as_str()) {
+                    let from = self.last_served_model.clone();
+                    let id = self.synthetic_id("model");
+                    self.entries.push(Arc::new(TimelineEntry {
+                        id,
+                        content: EntryContent::ModelChanged {
+                            from,
+                            to: model.clone(),
+                            reason: reason.clone(),
+                        },
+                        ts,
+                        turn,
+                    }));
+                    self.last_served_model = Some(model.clone());
+                }
             }
             AgentEvent::TurnStarted { turn_id } => {
                 // Reuse the open turn (typically opened by the user message);
@@ -714,6 +748,10 @@ impl Timeline {
                     }
                     self.turns[turn].status = Some(*status);
                     self.turns[turn].running = false;
+                    if let Some(usage) = usage {
+                        self.turns[turn].cost_usd = usage.cost_usd;
+                        self.turns[turn].provider_duration_ms = usage.duration_ms;
+                    }
                     let clock = std::mem::take(&mut self.tool_clock);
                     // A repeated completion finds an already-spent clock; it
                     // must not erase the breakdown the first one derived.
@@ -948,6 +986,9 @@ impl Timeline {
             running: false,
             changes: None,
             timing: None,
+            served_model: None,
+            cost_usd: None,
+            provider_duration_ms: None,
         });
         let idx = self.turns.len() - 1;
         self.current_turn = Some(idx);
@@ -3279,5 +3320,39 @@ mod tests {
             (clamped_secs.total, clamped_secs.ai, clamped_secs.tools),
             (1, 0, 1)
         );
+    }
+
+    #[test]
+    fn served_model_change_sets_turn_meta_and_adds_one_divider() {
+        let timeline = Timeline::fold_events([
+            AgentEvent::SessionStarted {
+                provider_session_id: "session".into(),
+                resume: ResumeCursor(json!({})),
+                model: Some("requested".into()),
+            },
+            user_msg("user", "hello"),
+            AgentEvent::ServedModel {
+                model: "served".into(),
+                reason: Some("capacity".into()),
+            },
+            AgentEvent::ServedModel {
+                model: "served".into(),
+                reason: Some("capacity".into()),
+            },
+        ]);
+        assert_eq!(timeline.turns[0].served_model.as_deref(), Some("served"));
+        let changes = timeline
+            .entries
+            .iter()
+            .filter(|entry| matches!(entry.content, EntryContent::ModelChanged { .. }))
+            .collect::<Vec<_>>();
+        assert_eq!(changes.len(), 1);
+        assert!(matches!(
+            &changes[0].content,
+            EntryContent::ModelChanged { from, to, reason }
+                if from.as_deref() == Some("requested")
+                    && to == "served"
+                    && reason.as_deref() == Some("capacity")
+        ));
     }
 }

--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -187,6 +187,7 @@ fn plain_text_as_markdown(text: &str) -> String {
 enum Segment<'a> {
     ActivityRun(Vec<&'a TimelineEntry>),
     Relay(&'a TimelineEntry),
+    ModelChange(&'a TimelineEntry),
     User(&'a TimelineEntry),
     Assistant(&'a TimelineEntry),
     Error(&'a TimelineEntry),
@@ -272,6 +273,10 @@ fn segment_entries<'a>(
                 flush_activities(&mut segments, &mut activities);
                 segments.push(Segment::Relay(entry));
             }
+            EntryContent::ModelChanged { .. } => {
+                flush_activities(&mut segments, &mut activities);
+                segments.push(Segment::ModelChange(entry));
+            }
             EntryContent::Assistant { .. } => {
                 flush_activities(&mut segments, &mut activities);
                 segments.push(Segment::Assistant(entry));
@@ -315,8 +320,9 @@ fn work_log_counts(entries: &[&TimelineEntry]) -> WorkLogCounts {
             | EntryContent::Assistant { .. }
             | EntryContent::Reasoning { .. }
             | EntryContent::Error { .. }
-            | EntryContent::ProviderStartError { .. } => {}
-            EntryContent::ProviderRelay { .. } => {}
+            | EntryContent::ProviderStartError { .. }
+            | EntryContent::ProviderRelay { .. }
+            | EntryContent::ModelChanged { .. } => {}
         }
     }
     counts.files = files.len();
@@ -473,6 +479,8 @@ fn index_turns(
                 turn.running.hash(&mut content);
                 // The finished bottom row renders the turn's breakdown.
                 turn.timing.hash(&mut content);
+                turn.served_model.hash(&mut content);
+                turn.cost_usd.map(f64::to_bits).hash(&mut content);
                 turn.status
                     .as_ref()
                     .map(std::mem::discriminant)
@@ -578,6 +586,11 @@ fn hash_entry_shape(content: &EntryContent, hash: &mut DefaultHasher) {
         } => {
             from_provider.hash(hash);
             to_provider.hash(hash);
+        }
+        EntryContent::ModelChanged { from, to, reason } => {
+            from.hash(hash);
+            to.hash(hash);
+            reason.hash(hash);
         }
         EntryContent::ContextCompacted => {}
     }
@@ -865,6 +878,18 @@ impl ChatView {
                         cx,
                     ));
                 }
+                Segment::ModelChange(entry) => {
+                    let EntryContent::ModelChanged { from, to, reason } = &entry.content else {
+                        unreachable!();
+                    };
+                    column = column.child(self.render_model_change_divider(
+                        &entry.id,
+                        from.as_deref(),
+                        to,
+                        reason.as_deref(),
+                        cx,
+                    ));
+                }
                 Segment::ActivityRun(activities) => {
                     let segment_id = activities[0].id.as_str();
                     column = column.child(self.render_work_log(
@@ -991,7 +1016,7 @@ impl ChatView {
         if !turn.running
             && let Some(ts) = turn.end_ts.or(entries.last().and_then(|e| e.ts))
         {
-            column = column.child(self.render_timestamp(ts, turn.timing, cx));
+            column = column.child(self.render_timestamp(ts, turn, cx));
         }
 
         // Pending steers float below every live transcript/work-log element.
@@ -1056,6 +1081,46 @@ impl ChatView {
                     )),
             )
             .child(div().h(px(1.)).flex_1().bg(border))
+            .into_any_element()
+    }
+
+    fn render_model_change_divider(
+        &self,
+        id: &str,
+        from: Option<&str>,
+        to: &str,
+        reason: Option<&str>,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let warning = cx.theme().warning;
+        let label = match from {
+            Some(from) => tcode_i18n::tr!("chat.model_changed", from = from, to = to).into_owned(),
+            None => tcode_i18n::tr!("chat.model_changed_to", to = to).into_owned(),
+        };
+        let label = match reason {
+            Some(reason) if !reason.is_empty() => format!("{label} ({reason})"),
+            _ => label,
+        };
+
+        h_flex()
+            .id(SharedString::from(format!("model-change-{id}")))
+            .w_full()
+            .items_center()
+            .gap_3()
+            .child(div().h(px(1.)).flex_1().bg(warning.opacity(0.45)))
+            .child(
+                div()
+                    .flex_none()
+                    .px_2()
+                    .py_0p5()
+                    .rounded_full()
+                    .border_1()
+                    .border_color(warning.opacity(0.55))
+                    .text_size(px(11.))
+                    .text_color(warning)
+                    .child(label),
+            )
+            .child(div().h(px(1.)).flex_1().bg(warning.opacity(0.45)))
             .into_any_element()
     }
 
@@ -1749,6 +1814,15 @@ impl ChatView {
                 .start_ts
                 .map(|start| now_millis().saturating_sub(start) / 1000)
                 .unwrap_or(0);
+            let requested_model = self
+                .app_state
+                .read(cx)
+                .active
+                .as_ref()
+                .and_then(|active| active.meta.model.clone());
+            let served_model =
+                divergent_served_model(turn.served_model.as_deref(), requested_model.as_deref())
+                    .map(str::to_owned);
             section = section.child(
                 h_flex()
                     .gap_2()
@@ -1759,7 +1833,14 @@ impl ChatView {
                     .child(tcode_i18n::tr!(
                         "chat.working_for",
                         duration = format_duration(secs)
-                    )),
+                    ))
+                    .when_some(served_model, |row, served| {
+                        row.child(
+                            div()
+                                .text_color(cx.theme().warning)
+                                .child(format!("⚠ {served}")),
+                        )
+                    }),
             );
         } else if let Some(label) = finished_work_log_label(is_last, &segment_counts, turn_counts) {
             section = section.child(
@@ -2390,15 +2471,23 @@ impl ChatView {
 
     /// The finished turn's bottom row: the local completion clock, followed by
     /// the wall-clock breakdown when the turn's events supported deriving one.
-    fn render_timestamp(
-        &self,
-        ts: u64,
-        timing: Option<TurnTiming>,
-        cx: &mut Context<Self>,
-    ) -> AnyElement {
+    fn render_timestamp(&self, ts: u64, turn: &TurnMeta, cx: &mut Context<Self>) -> AnyElement {
+        let requested_model = self
+            .app_state
+            .read(cx)
+            .active
+            .as_ref()
+            .and_then(|active| active.meta.model.as_deref());
         turn_time_footer(
-            turn_time_parts(format_local_time(ts), timing),
+            turn_time_clauses(
+                format_local_time(ts),
+                turn.timing,
+                turn.cost_usd,
+                turn.served_model.as_deref(),
+                requested_model,
+            ),
             cx.theme().muted_foreground,
+            cx.theme().warning,
         )
         .into_any_element()
     }
@@ -3261,6 +3350,31 @@ fn format_span(secs: u64) -> String {
     }
 }
 
+fn divergent_served_model<'a>(
+    served_model: Option<&'a str>,
+    requested_model: Option<&str>,
+) -> Option<&'a str> {
+    match (served_model, requested_model) {
+        (Some(served), Some(requested)) if served != requested => Some(served),
+        _ => None,
+    }
+}
+
+fn format_cost_usd(cost: f64) -> String {
+    if cost.abs() >= 0.01 {
+        return format!("${cost:.2}");
+    }
+
+    let decimals = if (cost * 1_000.).round() != 0. { 3 } else { 4 };
+    let formatted = format!("{cost:.decimals$}");
+    let trimmed = formatted.trim_end_matches('0').trim_end_matches('.');
+    if trimmed == "0" || trimmed == "-0" {
+        "$0.0000".to_string()
+    } else {
+        format!("${trimmed}")
+    }
+}
+
 /// A finished turn's bottom row, one clause per renderable unit: the completion
 /// clock, plus the turn's wall-clock breakdown when one was derivable. Legacy
 /// sessions without timestamps keep exactly the clock they showed before.
@@ -3280,21 +3394,59 @@ fn turn_time_parts(clock: String, timing: Option<TurnTiming>) -> Vec<String> {
     ]
 }
 
-/// The finished turn's bottom row, laid out from [`turn_time_parts`]. Each
-/// clause is its own item in a wrapping flow rather than one long string, so a
-/// narrow chat column (a diff panel is open, say) reflows the row at the middle
-/// dots instead of clipping the last clause at the divider. On a comfortable
-/// width the items pack onto one line and the row reads exactly as before.
-fn turn_time_footer(clauses: Vec<String>, muted: Hsla) -> Div {
-    /// Layout handles for the clauses, in render order (the last three only
-    /// exist when the turn had a derivable breakdown).
-    const SELECTORS: [&str; 4] = [
+#[derive(Clone)]
+struct TurnTimeClause {
+    text: String,
+    selector: &'static str,
+    warning: bool,
+}
+
+fn turn_time_clauses(
+    clock: String,
+    timing: Option<TurnTiming>,
+    cost_usd: Option<f64>,
+    served_model: Option<&str>,
+    requested_model: Option<&str>,
+) -> Vec<TurnTimeClause> {
+    const TIMING_SELECTORS: [&str; 4] = [
         "turn-time-clock",
         "turn-time-total",
         "turn-time-ai",
         "turn-time-tools",
     ];
 
+    let mut clauses = turn_time_parts(clock, timing)
+        .into_iter()
+        .zip(TIMING_SELECTORS)
+        .map(|(text, selector)| TurnTimeClause {
+            text,
+            selector,
+            warning: false,
+        })
+        .collect::<Vec<_>>();
+    if let Some(cost) = cost_usd {
+        clauses.push(TurnTimeClause {
+            text: format_cost_usd(cost),
+            selector: "turn-time-cost",
+            warning: false,
+        });
+    }
+    if let Some(served) = divergent_served_model(served_model, requested_model) {
+        clauses.push(TurnTimeClause {
+            text: format!("⚠ {served}"),
+            selector: "turn-time-model",
+            warning: true,
+        });
+    }
+    clauses
+}
+
+/// The finished turn's bottom row, laid out from [`turn_time_parts`]. Each
+/// clause is its own item in a wrapping flow rather than one long string, so a
+/// narrow chat column (a diff panel is open, say) reflows the row at the middle
+/// dots instead of clipping the last clause at the divider. On a comfortable
+/// width the items pack onto one line and the row reads exactly as before.
+fn turn_time_footer(clauses: Vec<TurnTimeClause>, muted: Hsla, warning: Hsla) -> Div {
     let last = clauses.len().saturating_sub(1);
     h_flex()
         .w_full()
@@ -3325,14 +3477,15 @@ fn turn_time_footer(clauses: Vec<String>, muted: Hsla) -> Div {
                     // break never strands a separator at the start of the next
                     // line. `min_w_0` lets a clause too wide for a line of its
                     // own wrap inside itself instead of spilling out of the row.
-                    let selector = SELECTORS.get(ix).copied().unwrap_or("turn-time-clause");
+                    let selector = clause.selector;
                     div()
                         .min_w_0()
                         .debug_selector(move || selector.into())
+                        .when(clause.warning, |element| element.text_color(warning))
                         .child(if ix == last {
-                            clause
+                            clause.text
                         } else {
-                            format!("{clause} ·")
+                            format!("{} ·", clause.text)
                         })
                 })),
         )
@@ -3573,8 +3726,9 @@ mod tests {
         copy_payload, diff_stats, displayed_error_text, file_edit_row, finished_work_log_label,
         format_duration, format_span, index_turns, list_sync, live_edit_counts, live_edit_rows,
         md_sync, plain_text_as_markdown, previous_logs_toggle_label, segment_entries,
-        timeline_overdraw, turn_time_footer, turn_time_parts, turn_work_log_summary,
-        work_log_auto_expands, work_log_counts, work_log_row_entries, work_log_summary,
+        timeline_overdraw, turn_time_clauses, turn_time_footer, turn_time_parts,
+        turn_work_log_summary, work_log_auto_expands, work_log_counts, work_log_row_entries,
+        work_log_summary,
     };
     use crate::markdown::MarkdownState;
     use agent::{FileChange, FileChangeKind, ItemStatus};
@@ -4952,7 +5106,7 @@ This begins after the hard break."#;
     /// Renders the production footer builder itself, so this layout test cannot
     /// drift from what a finished turn actually paints.
     struct TurnTimeFooterProbe {
-        clauses: Vec<String>,
+        clauses: Vec<super::TurnTimeClause>,
     }
 
     impl gpui::Render for TurnTimeFooterProbe {
@@ -4969,6 +5123,7 @@ This begins after the hard break."#;
             gpui_component::v_flex().size_full().child(turn_time_footer(
                 self.clauses.clone(),
                 cx.theme().muted_foreground,
+                cx.theme().warning,
             ))
         }
     }
@@ -4981,7 +5136,13 @@ This begins after the hard break."#;
 
         let _locale_guard = crate::settings::TestLocaleGuard::acquire();
         tcode_i18n::set_locale(tcode_i18n::LANGUAGE_ENGLISH);
-        let clauses = turn_time_parts("10:18 AM".into(), Some(TurnTiming::new(99_000, 0)));
+        let clauses = turn_time_clauses(
+            "10:18 AM".into(),
+            Some(TurnTiming::new(99_000, 0)),
+            None,
+            None,
+            None,
+        );
         // The footer's clauses, in render order (mirrors `turn_time_footer`).
         let selectors = [
             "turn-time-clock",
@@ -5050,6 +5211,53 @@ This begins after the hard break."#;
             wrapped,
             "the row never reflowed onto a second line, so a narrow column must be clipping it"
         );
+    }
+
+    #[test]
+    fn finished_time_clauses_format_cost_and_only_show_a_divergent_served_model() {
+        let _locale_guard = crate::settings::TestLocaleGuard::acquire();
+        tcode_i18n::set_locale(tcode_i18n::LANGUAGE_ENGLISH);
+
+        let clauses = turn_time_clauses(
+            "3:04 PM".into(),
+            Some(TurnTiming::new(80_000, 35_000)),
+            Some(0.12),
+            Some("claude-opus-5"),
+            Some("claude-fable-5"),
+        );
+        assert_eq!(
+            clauses
+                .iter()
+                .map(|clause| (clause.selector, clause.text.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("turn-time-clock", "3:04 PM"),
+                ("turn-time-total", "Total 1m 20s"),
+                ("turn-time-ai", "AI thinking & response 45s"),
+                ("turn-time-tools", "Tool calls 35s"),
+                ("turn-time-cost", "$0.12"),
+                ("turn-time-model", "⚠ claude-opus-5"),
+            ]
+        );
+
+        let sub_cent = turn_time_clauses(
+            "3:04 PM".into(),
+            None,
+            Some(0.004),
+            Some("claude-fable-5"),
+            Some("claude-fable-5"),
+        );
+        assert_eq!(
+            sub_cent
+                .iter()
+                .map(|clause| (clause.selector, clause.text.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("turn-time-clock", "3:04 PM"), ("turn-time-cost", "$0.004"),]
+        );
+
+        let missing_requested =
+            turn_time_clauses("3:04 PM".into(), None, None, Some("served"), None);
+        assert_eq!(missing_requested.len(), 1);
     }
 
     #[test]

--- a/docs/provider-data-gaps.md
+++ b/docs/provider-data-gaps.md
@@ -1,0 +1,179 @@
+# Provider data gaps
+
+Inventory of data that provider CLIs/protocols put on the wire but tcode does not yet
+capture. Compiled from a full audit of the adapter parsers in `crates/agent/src/`
+(claude, codex, opencode, pi, acp) against recorded fixtures and protocol schemas.
+
+Already captured as of this document's introduction (see `feat/provider-data-capture`):
+per-message/turn served model + model-change events (claude, codex, opencode), claude
+structured stop reasons, cost (claude/opencode/acp) and provider-reported turn duration
+(claude), claude `structuredPatch` real diffs, opencode exit codes.
+
+Legend: **slot exists** = a field on `AgentEvent`/`TokenUsage`/`ItemContent`/`TurnMeta`
+could hold it today; **new plumbing** = needs a new event variant or field.
+
+## Cross-cutting themes
+
+| Theme | Providers offering it | Status |
+|---|---|---|
+| Rate limits / quota (`resetsAt`, used %, plan type, credits) | claude (`rate_limit_event`), codex (`account/rateLimits/updated`) | Entirely dropped; no representation anywhere. Largest new-plumbing item. |
+| Reasoning-token split (`thinking_tokens`, `reasoningOutputTokens`, `tokens.reasoning`) | claude, codex, opencode | Dropped or folded into `output_tokens`; needs a `TokenUsage` field. |
+| Cache-write token split | claude (`cache_creation.ephemeral_{5m,1h}`), codex (`cacheWriteInputTokens`), pi (`cacheWrite`) | Only flat `cache_creation_input_tokens` survives (claude); others dropped. |
+| Provider-reported per-item timing | codex (`startedAtMs`/`completedAtMs`), opencode (`state.time.*`, `part.time.*`) | Dropped; `TurnTiming` is reconstructed from tcode's own clock. |
+| stdout/stderr split for shell tools | claude (`tool_use_result.stdout/stderr`), codex (`stdout`/`stderr` alongside `aggregatedOutput`) | Collapsed into one output string; `ItemContent::CommandExecution` has a single `output`. |
+| Structured stop/finish reasons | pi (`stopReason`), opencode (`step-finish.reason`), acp (`StopReason`) | Collapsed to Completed/Failed; claude now captured, others still dropped. |
+
+## claude (`crates/agent/src/claude.rs`)
+
+### Whole events dropped
+
+- `rate_limit_event` — status, `resetsAt`, overage state. New plumbing.
+- `content_block_start` / `content_block_stop` — earliest tool-call start signal
+  (tool cards currently appear only when the full `assistant` line arrives) and block
+  boundaries. New plumbing in the stream path.
+
+### `system/init`
+
+- `tools` (enabled tool list), `mcp_servers` (incl. connection **status** — tcode never
+  learns whether Claude actually connected its MCP servers), `agents` (subagent types),
+  `permissionMode` (actual effective mode), `plugins`, `capabilities`, `apiKeySource`,
+  `output_style`, `cwd`, `fast_mode_state`.
+- `claude_code_version` — currently obtained via a redundant `claude --version`
+  subprocess even though the init line carries it.
+
+### Stream / assistant events
+
+- `message_start.message.usage` — prompt-size reading at turn start (context gauge could
+  update before the turn ends). `ttft_ms` — time to first token.
+- `message_delta.usage.output_tokens_details.thinking_tokens`, `usage.iterations[]`.
+- Live usage has no denominator: the `message_delta` path passes `context_window: None`;
+  only `result.modelUsage.contextWindow` fills it at turn end.
+- Content blocks: `redacted_thinking` (silently skipped — renders as a gap),
+  `server_tool_use` / `web_search_tool_result` (web search results vanish entirely),
+  `document`, `image`. `tool_use` blocks' `caller.type`.
+- `request_id` (for support escalation).
+
+### Tool results (`user` events)
+
+- `tool_use_result.originalFile` (pre-edit content — exact before/after diffing,
+  rewind previews), `filePath` (authoritative resolved path), `userModified`.
+- Bash: `stdout`/`stderr` split, `interrupted` flag. `exit_code` is currently
+  fabricated from `is_error` (0/1).
+- `MultiEdit.edits[]` / `NotebookEdit` — only path-level FileChange, no diff.
+- TodoWrite `activeForm` — present-tense label Claude's own UI uses for the running step.
+
+### `result` (turn end)
+
+- `modelUsage.<model>.*` per-model breakdown (tokens, `costUSD`, `maxOutputTokens`,
+  `webSearchRequests`) — only `contextWindow` is read.
+- `num_turns`, `api_error_status`, `terminal_reason`, `ttft_ms`, `usage.service_tier`,
+  `usage.speed`, `permission_denials` (which tools were denied this turn — natural
+  Warning/work-log row).
+
+### Approvals / control
+
+- `control_request.tool_use_id` — supplied by the CLI but dropped in the general path,
+  so approval prompts can't be linked to their timeline tool card.
+- `control_request.display_name`, `permission_suggestions` (stored verbatim, never shown).
+
+### Subagents (`subagent_tail.rs`)
+
+- Child `message.model`, `usage`, `stop_reason`, `tool_use_result` payloads, and the
+  entire child `result` line (per-subagent usage/cost) are dropped.
+- `task_notification.usage` (`duration_ms`, `tool_uses`, `total_tokens`) — per-subagent
+  cost; `ItemContent::Subagent` has no slot.
+- `compact_boundary.compact_metadata` (`trigger`, `pre_tokens`, `post_tokens`) — the
+  "context compacted" row can't say how much was compacted.
+
+## codex (`crates/agent/src/codex.rs`)
+
+### Never-handled notifications (dropped at the `_ =>` arm)
+
+`account/rateLimits/updated` (windows, `usedPercent`, `resetsAt`, credits, `planType`,
+`spendControlReached`), `model/safetyBuffering/updated`, `model/verification`,
+`thread/compacted` (token deltas), `thread/name|goal|settings/updated`,
+`turn/moderationMetadata`, `item/mcpToolCall/progress`, `item/reasoning/summaryPartAdded`,
+`item/autoApprovalReview/*`, `mcpServer/startupStatus/updated`, `skills/changed`,
+`account/updated`.
+
+### Turn / usage
+
+- `turn.error` on `turn/completed` — a failed turn's reason never reaches the UI
+  (any unrecognized status silently maps to Completed).
+- `turn.durationMs`, `turn.startedAt`/`completedAt`, per-item `startedAtMs`/`completedAtMs`.
+- `TokenUsage` gaps: `reasoningOutputTokens`, `cacheWriteInputTokens`, and the whole
+  `total.*` breakdown (only `total.totalTokens` survives).
+- Typed error taxonomy on `error` notifications (`errorType`, `failureStage`,
+  `httpStatusCode` — `contextWindowExceeded`, `usageLimitExceeded`, …) — only
+  `message` + `willRetry` are read.
+
+### Items
+
+- `commandExecution`: `stdout`/`stderr` split, `parsedCmd` (friendly rendering codex's
+  own TUI uses), `cwd`, `processId`.
+- `fileChange`: rename destination `movePath` is used only as a presence test — the
+  target path itself is thrown away; `autoApproved` flag.
+- `webSearch.results` — only the query is kept.
+- `mcpToolCall`: `connectorId`, `appName`, `actionName`; error collapsed to
+  `error.message`.
+- `dynamicToolCall`: `namespace` (same-name tools collide), `callId`, `success`/`error`.
+- `reasoning`: summary vs raw content flattened into one string; delta
+  `summaryIndex`/`contentIndex` section boundaries dropped (sections run together).
+- Unmapped item types render as raw JSON via `ItemContent::Other` — notably
+  `enteredReviewMode`/`exitedReviewMode` with full structured code-review findings
+  (`reviewOutput`, `overallCorrectness`, per-finding fields).
+
+### Requests / responses
+
+- Approval requests: server-supplied `decisions` list is ignored (options hardcoded);
+  `approvalId` dropped (multiple approvals can share one `itemId` — misrouting risk);
+  `parsedCmd`, `grantRoot`, `environmentId`.
+- `thread/start` response: `serviceTier`, `approvalPolicy`, `sandbox`,
+  `activePermissionProfile`, `ThreadSettings` (effort, collaborationMode, …),
+  `ThreadStatus.activeFlags` (`usageLimited`, `budgetLimited`, `blocked`, `paused`).
+- `model/list`: `inputModalities` (image support never checked), `upgradeInfo`.
+- Known dead code: the `turn/start` response is read at `/result/turn/id` but the real
+  shape is `{turnId}` — the read never matches (benign; `turn/started` fills it).
+
+## opencode (`crates/agent/src/opencode.rs`)
+
+- `message.updated`: `info.time.created/completed` (timestamps used only as booleans),
+  `info.parentID`, `info.mode`, `info.agent`, `info.path.*`; `info.error` flattened
+  (loses `error.name`/`data`).
+- `step-finish`: `reason` (finish reason), `tokens.reasoning` (folded into output),
+  `tokens.cache.write` (only summed into `used`).
+- Tool parts: `state.metadata` beyond `exit` (stdout/stderr split, description),
+  `state.title`, `state.time.start/end` (per-tool duration on the wire, unread).
+- `patch` parts: kind forced to Modify, `diff: None`, `part.hash` dropped.
+- `session.diff`: `additions`/`deletions` counts.
+- `session.status` retry: `attempt` flattened into a warning string.
+- Permissions: `always[]` options, `time`.
+- Whole part kinds: `step-start`, `snapshot`, `file`, `agent`, `todo`. Whole events:
+  `message.removed`, `message.part.removed`, `session.updated/deleted`, `file.edited`,
+  LSP events.
+
+## pi (`crates/agent/src/pi.rs`)
+
+- `usage.cacheWrite`; `stopReason` (only `"error"` is distinguished).
+- `turn_end.toolResults[]`, `agent_end.messages[]`.
+- Tool results: exit code hardcoded `None`; non-text result parts dropped; edit old/new
+  strings present in args but only `path` is read (`diff: None`).
+- Retry/compaction/extension events flattened into free-text warnings
+  (`attempt`/`maxAttempts`/`delayMs` lose structure).
+- `message_update` types other than text/thinking deltas (`toolcall_start`,
+  `toolcall_delta`) silently dropped.
+- `get_state.data` fields beyond `sessionId`/`sessionFile`/`model` never enumerated.
+
+## acp (`crates/agent/src/acp.rs`)
+
+- `usage.thought_tokens`, `usage.cached_write_tokens`.
+- `stopReason` discriminant (Refusal / MaxTokens / MaxTurnRequests collapse to Failed
+  plus prose).
+- `session_info_update` — entire variant ignored (agent-supplied session title,
+  `updatedAt`).
+- `TerminalExitStatus.signal` — signal-killed commands render with no exit info.
+- `locations[].line` (no follow-along cursor); image/audio tool content replaced with
+  `"[image]"`/`"[audio]"` markers.
+- `PlanEntry.priority`; `AvailableCommand.input` (argument hint).
+- Mid-session model change via `config_option_update` re-emits options only — the
+  recorded session model goes stale.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,6 +2,8 @@ app:
   name: "tcode"
 chat:
   relayed: "Relayed from %{from} to %{to}"
+  model_changed: "Model changed: %{from} → %{to}"
+  model_changed_to: "Model changed to %{to}"
   new_thread: "New thread"
   no_active_thread: "No active thread"
   work_log: "Work Log"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -2,6 +2,8 @@ app:
   name: "tcode"
 chat:
   relayed: "已从 %{from} 接力至 %{to}"
+  model_changed: "模型已切换：%{from} → %{to}"
+  model_changed_to: "模型已切换至 %{to}"
   new_thread: "新建对话"
   no_active_thread: "没有活动对话"
   work_log: "工作日志"


### PR DESCRIPTION
## Summary

A full audit of the provider adapters (claude / codex / opencode / pi / acp) found substantial wire data being parsed and discarded. This PR captures the high-value subset and surfaces model fallback in the UI; the remaining gaps are documented as a roadmap.

### Captured
- **Served model (cross-provider)**: claude per-message `message.model`, codex `model/rerouted` (from/to/reason), opencode `info.modelID` → `TurnMeta.served_model` + deduplicated `ModelChanged` timeline entries
- **Model fallback UI** (e.g. Fable 5 safety-classifier fallback to Opus, codex reroutes):
  - warning divider in the timeline at the switch point
  - "⚠ model" tag to the right of the live *Working for…* timer while the diverged turn runs
  - served-model + cost clauses at the right end of the finished-turn time row
- **claude structured stop reasons**: refusal / max_tokens warnings; result classification now prefers structured `is_error`/`subtype` — fixes prose-scan misclassifying answers that merely contain "cancel"
- **claude `structuredPatch`**: file cards show the actually-applied unified diff instead of one fabricated from tool input
- **Cost & provider duration**: claude `total_cost_usd`/`duration_ms`, opencode `info.cost`, acp `UsageUpdate.cost` (USD)
- **opencode bash exit codes** from `state.metadata`

### Documented for later
`docs/provider-data-gaps.md` — remaining uncaptured fields per provider (rate limits, stdout/stderr split, reasoning-token split, early tool-card signal, web-search results, codex review findings, subagent usage, …).

## Testing
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets --locked -- -D warnings` ✅
- `TCODE_LIVE_TESTS=0 cargo test --workspace` ✅ (agent 151, core 123, ui 215, all green; new regression tests for model dedupe, reroute parsing, stop-reason classification, structuredPatch rendering, cost mapping, exit codes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)