### PR TITLE
Float the scroll-to-end button

### DIFF
--- a/crates/ui/src/chat.rs
+++ b/crates/ui/src/chat.rs
@@ -2992,11 +2992,10 @@ impl ChatView {
     }
 
     fn render_scroll_pill(&self, cx: &mut Context<Self>) -> AnyElement {
-        h_flex()
-            .flex_shrink_0()
-            .w_full()
-            .justify_center()
-            .pb_1()
+        div()
+            .absolute()
+            .bottom(px(12.))
+            .mx_auto()
             .child(
                 Button::new("scroll-to-end")
                     .outline()
@@ -3145,11 +3144,12 @@ impl Render for ChatView {
                     .flex_col()
                     .flex_1()
                     .min_h_0()
-                    .child(timeline),
-            )
-            .when(
-                self.list_state.is_scrolled_to_end() == Some(false),
-                |this| this.child(self.render_scroll_pill(cx)),
+                    .relative()
+                    .child(timeline)
+                    .when(
+                        self.list_state.is_scrolled_to_end() == Some(false),
+                        |this| this.child(self.render_scroll_pill(cx)),
+                    ),
             )
             .child(self.composer.clone());
 


### PR DESCRIPTION
## What changed

- render the “Scroll to end” pill as an absolute overlay inside the timeline
- keep the timeline in normal continuous flow behind the pill
- preserve the existing follow-tail click behavior

## Why

The pill previously lived as a full-width child in the main vertical layout. Its wrapper reserved an entire horizontal row, visually interrupting the conversation stream.

## Impact

When the conversation is scrolled away from the end, the control now floats above the composer without consuming timeline space. Clicking it still returns to the end and hides the control.

## Validation

- `cargo fmt --check`
- `cargo check -p tcode-ui`
- `cargo build -p tcode`
- verified in an isolated native GPUI window by scrolling away from the end, inspecting the overlay, clicking it, and confirming it disappeared at the tail
