### PR TITLE
fix: make the "Working" state self-healing instead of trusting adapter event emission

### DIFF
--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -2342,15 +2342,18 @@ impl Mapper {
                 fatal: false,
             });
         }
-        if msg.pointer("/origin/kind").and_then(Value::as_str) == Some("task-notification") {
-            // Publish the final liveness transition immediately before the
-            // follow-up TurnCompleted. A parked runtime then observes zero and
-            // finishes parking/restart decisions only after all completion
-            // output has landed.
-            events.push(AgentEvent::BackgroundTasksChanged {
-                count: self.background_tasks.len(),
-            });
-        }
+        // Publish the current background-task liveness with every result, not
+        // only task-notification-origin ones. `background_tasks_changed []`
+        // deliberately withholds the zero (see `on_background_tasks_changed`),
+        // so a result is the only place the runtime can learn the tasks are
+        // gone — and gating that on the CLI's `origin.kind` shape left the
+        // count pinned above zero (session stuck "Working") whenever the
+        // follow-up result arrived with a different origin. Re-publishing an
+        // unchanged count is harmless; a parked runtime still observes zero
+        // only after all completion output has landed.
+        events.push(AgentEvent::BackgroundTasksChanged {
+            count: self.background_tasks.len(),
+        });
         events.push(AgentEvent::TurnCompleted {
             turn_id,
             status,
@@ -3153,6 +3156,26 @@ mod tests {
         mapper.on_message(msg)
     }
 
+    /// Every `result` publishes the current background-task count immediately
+    /// before its `TurnCompleted` (the runtime's only reliable zero signal).
+    /// Assert that contract and return the completion event.
+    #[track_caller]
+    fn turn_completed_after_count(events: &[AgentEvent], count: usize) -> &AgentEvent {
+        let at = events
+            .iter()
+            .position(|event| matches!(event, AgentEvent::TurnCompleted { .. }))
+            .unwrap_or_else(|| panic!("no TurnCompleted in {events:?}"));
+        assert!(
+            at > 0
+                && matches!(
+                    &events[at - 1],
+                    AgentEvent::BackgroundTasksChanged { count: published } if *published == count
+                ),
+            "TurnCompleted must follow BackgroundTasksChanged {{ count: {count} }}, got {events:?}"
+        );
+        &events[at]
+    }
+
     #[test]
     fn replayed_user_message_exposes_native_turn_checkpoint() {
         let mut mapper = Mapper::new();
@@ -3622,7 +3645,7 @@ mod tests {
             &mut m,
             r#"{"type":"result","subtype":"success","usage":{"input_tokens":100,"output_tokens":20}}"#,
         );
-        let first = match &evs[0] {
+        let first = match turn_completed_after_count(&evs, 0) {
             AgentEvent::TurnCompleted { usage, .. } => usage.unwrap(),
             other => panic!("expected TurnCompleted, got {other:?}"),
         };
@@ -3633,7 +3656,7 @@ mod tests {
             &mut m,
             r#"{"type":"result","subtype":"success","usage":{"input_tokens":30,"output_tokens":5}}"#,
         );
-        let second = match &evs[0] {
+        let second = match turn_completed_after_count(&evs, 0) {
             AgentEvent::TurnCompleted { usage, .. } => usage.unwrap(),
             other => panic!("expected TurnCompleted, got {other:?}"),
         };
@@ -3885,7 +3908,7 @@ mod tests {
             r#"{"type":"result","subtype":"success","is_error":false}"#,
         );
         assert!(matches!(
-            &result[0],
+            turn_completed_after_count(&result, 1),
             AgentEvent::TurnCompleted {
                 turn_id: completed,
                 status: TurnStatus::Completed,
@@ -3965,7 +3988,7 @@ mod tests {
             r#"{"type":"result","subtype":"success","is_error":false,"result":"Background command launched."}"#,
         );
         assert!(matches!(
-            &first_result[0],
+            turn_completed_after_count(&first_result, 1),
             AgentEvent::TurnCompleted {
                 turn_id,
                 status: TurnStatus::Completed,
@@ -4046,6 +4069,41 @@ mod tests {
         ));
     }
 
+    /// The zero-count publication must not depend on the CLI's `origin.kind`
+    /// shape: after `background_tasks_changed []` (whose zero is deliberately
+    /// withheld), ANY later result must tell the runtime the tasks are gone —
+    /// otherwise the session sits at "Working" forever on a live idle process.
+    #[test]
+    fn any_result_publishes_zero_after_background_tasks_drain() {
+        let mut m = Mapper::new();
+        m.start_turn();
+        feed(
+            &mut m,
+            r#"{"type":"system","subtype":"background_tasks_changed","tasks":[{"task_id":"bg-1","task_type":"local_bash","description":"sleep"}]}"#,
+        );
+        let first = feed(
+            &mut m,
+            r#"{"type":"result","subtype":"success","is_error":false}"#,
+        );
+        turn_completed_after_count(&first, 1);
+
+        // The drain event withholds its zero (parking guard)...
+        assert!(
+            feed(
+                &mut m,
+                r#"{"type":"system","subtype":"background_tasks_changed","tasks":[]}"#,
+            )
+            .is_empty()
+        );
+        // ...so a later ordinary result — no `origin` at all — must publish it.
+        m.start_turn();
+        let second = feed(
+            &mut m,
+            r#"{"type":"result","subtype":"success","is_error":false}"#,
+        );
+        turn_completed_after_count(&second, 0);
+    }
+
     #[test]
     fn unknown_task_notification_without_tool_use_id_does_not_wedge_turn() {
         let mut m = Mapper::new();
@@ -4063,7 +4121,7 @@ mod tests {
             r#"{"type":"result","subtype":"success","is_error":false}"#,
         );
         assert!(matches!(
-            &result[0],
+            turn_completed_after_count(&result, 0),
             AgentEvent::TurnCompleted {
                 turn_id: completed,
                 status: TurnStatus::Completed,
@@ -4450,7 +4508,7 @@ mod tests {
             &mut m,
             r#"{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":100,"cache_read_input_tokens":50,"cache_creation_input_tokens":10,"output_tokens":20},"modelUsage":{"claude-opus-4-8[1m]":{"contextWindow":1000000}}}"#,
         );
-        match &evs[0] {
+        match turn_completed_after_count(&evs, 0) {
             AgentEvent::TurnCompleted {
                 turn_id: tid,
                 status,
@@ -4485,7 +4543,7 @@ mod tests {
                 if message == "claude turn failed (error_during_execution): provider failed"
         ));
         assert!(matches!(
-            idle_result[1],
+            turn_completed_after_count(&idle_result, 0),
             AgentEvent::TurnCompleted {
                 status: TurnStatus::Failed,
                 ..
@@ -4501,7 +4559,7 @@ mod tests {
             r#"{"type":"result","subtype":"error_during_execution","is_error":true,"result":"provider failed"}"#,
         );
         assert!(matches!(
-            attributed[0],
+            turn_completed_after_count(&attributed, 0),
             AgentEvent::TurnCompleted {
                 status: TurnStatus::Interrupted,
                 ..
@@ -4513,7 +4571,7 @@ mod tests {
             &mut m,
             r#"{"type":"result","subtype":"error_during_execution","is_error":false,"result":"Request was aborted"}"#,
         );
-        match &evs[0] {
+        match turn_completed_after_count(&evs, 0) {
             AgentEvent::TurnCompleted { status, .. } => {
                 assert_eq!(*status, TurnStatus::Interrupted)
             }
@@ -4965,11 +5023,11 @@ mod tests {
             r#"{"type":"result","subtype":"success","is_error":false,"result":"You can cancel the operation from Settings."}"#,
         );
         assert!(matches!(
-            events.as_slice(),
-            [AgentEvent::TurnCompleted {
+            turn_completed_after_count(&events, 0),
+            AgentEvent::TurnCompleted {
                 status: TurnStatus::Completed,
                 ..
-            }]
+            }
         ));
     }
 
@@ -4997,15 +5055,15 @@ mod tests {
             r#"{"type":"result","subtype":"success","is_error":false,"total_cost_usd":0.125,"duration_ms":4321,"usage":{"input_tokens":10,"output_tokens":2}}"#,
         );
         assert!(matches!(
-            events.as_slice(),
-            [AgentEvent::TurnCompleted {
+            turn_completed_after_count(&events, 0),
+            AgentEvent::TurnCompleted {
                 usage: Some(TokenUsage {
                     cost_usd: Some(cost),
                     duration_ms: Some(4321),
                     ..
                 }),
                 ..
-            }] if (*cost - 0.125).abs() < f64::EPSILON
+            } if (*cost - 0.125).abs() < f64::EPSILON
         ));
     }
 }

--- a/crates/agent/src/codex.rs
+++ b/crates/agent/src/codex.rs
@@ -1338,6 +1338,7 @@ impl Actor {
                     fatal: false,
                 })
                 .await;
+                self.fail_rejected_turn_start(pending.as_ref()).await;
             } else if value.get("result").is_none() {
                 self.emit(AgentEvent::Error {
                     message: format!(
@@ -1347,6 +1348,7 @@ impl Actor {
                     fatal: false,
                 })
                 .await;
+                self.fail_rejected_turn_start(pending.as_ref()).await;
             } else {
                 match pending {
                     Some(PendingRequest::TurnStart) => {
@@ -1363,6 +1365,24 @@ impl Actor {
                 }
             }
         }
+    }
+
+    /// A `turn/start` the runtime already accepted was rejected by the server
+    /// (JSON-RPC error or missing result): no `turn/started` will follow, so no
+    /// `turn/completed` ever arrives and the runtime's turn flag would stay set
+    /// forever. Synthesize the terminal event the protocol will never send. The
+    /// `active_turn` guard keeps a late duplicate response from failing a turn
+    /// that did start.
+    async fn fail_rejected_turn_start(&mut self, pending: Option<&PendingRequest>) {
+        if !matches!(pending, Some(PendingRequest::TurnStart)) || self.active_turn.is_some() {
+            return;
+        }
+        self.emit(AgentEvent::TurnCompleted {
+            turn_id: String::new(),
+            status: TurnStatus::Failed,
+            usage: None,
+        })
+        .await;
     }
 
     async fn handle_server_request(&mut self, value: &Value) {
@@ -2552,6 +2572,87 @@ mod tests {
             assert!(
                 events.try_recv().is_err(),
                 "RPC errors must not accept a steer"
+            );
+
+            let _ = actor.child.kill();
+            let _ = actor.child.wait();
+        });
+    }
+
+    /// A `turn/start` the runtime already accepted but the server rejects gets
+    /// a synthesized failed completion: no `turn/started` will ever follow, so
+    /// without it the runtime's turn flag (and the sidebar's "Working" state)
+    /// would stay set forever.
+    #[test]
+    fn rejected_turn_start_synthesizes_failed_completion() {
+        smol::block_on(async {
+            let (mut actor, events) = test_actor();
+            actor
+                .handle_command(SessionCommand::SendTurn {
+                    delivery_id: 7,
+                    text: "hello".into(),
+                    options: None,
+                    attachments: Vec::new(),
+                })
+                .await
+                .unwrap();
+            assert!(matches!(
+                events.recv().await.unwrap(),
+                AgentEvent::TurnAccepted { delivery_id: 7 }
+            ));
+            let ChildOutput::Line(request) = actor.lines.recv().await.unwrap() else {
+                panic!("expected echoed turn/start request")
+            };
+            let request: Value = serde_json::from_str(&request).unwrap();
+            let id = request["id"].as_i64().unwrap();
+            actor
+                .handle_line(
+                    &json!({"id": id, "error": {"code": -32000, "message": "model overloaded"}})
+                        .to_string(),
+                )
+                .await;
+            assert!(matches!(
+                events.recv().await.unwrap(),
+                AgentEvent::Error { fatal: false, .. }
+            ));
+            assert!(matches!(
+                events.recv().await.unwrap(),
+                AgentEvent::TurnCompleted {
+                    status: TurnStatus::Failed,
+                    ..
+                }
+            ));
+
+            // A rejection that races an already-started turn must not fail it.
+            actor
+                .handle_command(SessionCommand::SendTurn {
+                    delivery_id: 8,
+                    text: "again".into(),
+                    options: None,
+                    attachments: Vec::new(),
+                })
+                .await
+                .unwrap();
+            let _ = events.recv().await.unwrap(); // TurnAccepted
+            let ChildOutput::Line(request) = actor.lines.recv().await.unwrap() else {
+                panic!("expected echoed turn/start request")
+            };
+            let request: Value = serde_json::from_str(&request).unwrap();
+            let id = request["id"].as_i64().unwrap();
+            actor.active_turn = Some("turn-live".into());
+            actor
+                .handle_line(
+                    &json!({"id": id, "error": {"code": -32000, "message": "late duplicate"}})
+                        .to_string(),
+                )
+                .await;
+            assert!(matches!(
+                events.recv().await.unwrap(),
+                AgentEvent::Error { .. }
+            ));
+            assert!(
+                events.try_recv().is_err(),
+                "an active turn must not be failed by a stray turn/start rejection"
             );
 
             let _ = actor.child.kill();

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -6837,6 +6837,7 @@ impl AppState {
                         let commands = handle.commands.clone();
                         let events = handle.events.clone();
                         let pump_session = session_id.clone();
+                        let pump_commands = handle.commands.clone();
                         let pump = cx.spawn(async move |this, cx| {
                             while let Ok(event) = events.recv().await {
                                 if this
@@ -6845,9 +6846,12 @@ impl AppState {
                                     })
                                     .is_err()
                                 {
-                                    break;
+                                    return;
                                 }
                             }
+                            let _ = this.update(cx, |state, cx| {
+                                state.on_event_stream_ended(&pump_session, &pump_commands, cx);
+                            });
                         });
                         if matches_active {
                             let active = state.active.as_mut().unwrap();
@@ -6940,6 +6944,45 @@ impl AppState {
             });
         })
         .detach();
+    }
+
+    /// The provider's event stream ended without a `SessionClosed`. If the
+    /// session still owns that exact provider (same command channel, still
+    /// Live), the adapter died without announcing it — and the lifecycle flags
+    /// (`turn_in_flight`, `delivery_in_flight`, `background_task_count`) have
+    /// no other reset path, so the thread would sit at "Working" forever.
+    /// Synthesize the close so the ordinary teardown runs no matter which
+    /// adapter exit path forgot to emit it. The same-channel check keeps a
+    /// stale pump (session already closed, restarted, or shut down mid-event)
+    /// from tearing down a successor provider.
+    fn on_event_stream_ended(
+        &mut self,
+        session_id: &str,
+        pump_commands: &async_channel::Sender<SessionCommand>,
+        cx: &mut Context<Self>,
+    ) {
+        let still_owned = self
+            .active
+            .as_ref()
+            .filter(|active| active.meta.id == session_id)
+            .or_else(|| self.background.get(session_id))
+            .is_some_and(|session| match &session.runtime {
+                Runtime::Live(current) => current.same_channel(pump_commands),
+                _ => false,
+            });
+        if !still_owned {
+            return;
+        }
+        log::warn!(
+            "provider event stream for {session_id} ended without SessionClosed; synthesizing close"
+        );
+        self.on_event(
+            session_id,
+            AgentEvent::SessionClosed {
+                reason: Some("provider event stream ended without a close".into()),
+            },
+            cx,
+        );
     }
 
     /// Handle one canonical event from the live provider.
@@ -12512,6 +12555,126 @@ mod tests {
         });
 
         let _ = std::fs::remove_dir_all(&cwd);
+        let _ = std::fs::remove_dir_all(&data);
+    }
+
+    /// The T-"stuck Working" family: an adapter whose event stream dies without
+    /// a `SessionClosed` must not leave the lifecycle flags set forever. The
+    /// pump synthesizes the close, which runs the ordinary teardown.
+    #[gpui::test]
+    fn dead_event_stream_without_close_clears_working_flags(cx: &mut gpui::TestAppContext) {
+        let data =
+            std::env::temp_dir().join(format!("tcode-dead-stream-test-{}", uuid::Uuid::new_v4()));
+        let store = SessionStore::open_at(data.clone()).unwrap();
+        let state = cx.new(|_| AppState::new(store));
+        let (commands, _receiver) = async_channel::unbounded();
+
+        let id = state.update(cx, |state, cx| {
+            let mut active = live_session(ProviderKind::ClaudeCode, commands.clone());
+            active.turn_in_flight = true;
+            active.background_task_count = 2;
+            let id = active.meta.id.clone();
+            state.store.upsert_meta(&active.meta).unwrap();
+            state.sessions = state.store.load_index();
+            state.active = Some(active);
+            assert!(state.turn_running_for(&id));
+
+            state.on_event_stream_ended(&id, &commands, cx);
+
+            assert!(
+                !state.turn_running_for(&id),
+                "a dead event stream must not pin the session at Working"
+            );
+            let active = state.active.as_ref().unwrap();
+            assert!(matches!(active.runtime, Runtime::Idle));
+            id
+        });
+        cx.run_until_parked();
+        state.update(cx, |state, _| {
+            // The synthesized close is durable evidence in the session log.
+            let replayed = state.store.read_events(&id);
+            assert!(
+                replayed
+                    .iter()
+                    .any(|stored| matches!(stored.event, AgentEvent::SessionClosed { .. })),
+                "the synthesized SessionClosed must be persisted"
+            );
+        });
+
+        let _ = std::fs::remove_dir_all(&data);
+    }
+
+    /// Same leak, parked variant: the flags of a backgrounded session must
+    /// reset too (and the dead resident entry is released).
+    #[gpui::test]
+    fn dead_event_stream_clears_parked_working_flags(cx: &mut gpui::TestAppContext) {
+        let data = std::env::temp_dir().join(format!(
+            "tcode-dead-parked-stream-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let store = SessionStore::open_at(data.clone()).unwrap();
+        let state = cx.new(|_| AppState::new(store));
+        let (commands, _receiver) = async_channel::unbounded();
+
+        state.update(cx, |state, cx| {
+            let mut parked = live_session(ProviderKind::ClaudeCode, commands.clone());
+            parked.turn_in_flight = true;
+            parked.background_task_count = 1;
+            let id = parked.meta.id.clone();
+            state.store.upsert_meta(&parked.meta).unwrap();
+            state.sessions = state.store.load_index();
+            state.background.insert(id.clone(), parked);
+            assert!(state.turn_running_for(&id));
+
+            state.on_event_stream_ended(&id, &commands, cx);
+
+            assert!(
+                !state.turn_running_for(&id),
+                "a dead event stream must not pin a parked session at Working"
+            );
+        });
+
+        let _ = std::fs::remove_dir_all(&data);
+    }
+
+    /// A stale pump (the session was already closed, restarted, or handed to a
+    /// new provider process) must not tear down the successor runtime when its
+    /// old event channel drains.
+    #[gpui::test]
+    fn stale_pump_close_leaves_successor_runtime_alone(cx: &mut gpui::TestAppContext) {
+        let data =
+            std::env::temp_dir().join(format!("tcode-stale-pump-test-{}", uuid::Uuid::new_v4()));
+        let store = SessionStore::open_at(data.clone()).unwrap();
+        let state = cx.new(|_| AppState::new(store));
+        let (old_commands, _old_receiver) = async_channel::unbounded();
+        let (new_commands, _new_receiver) = async_channel::unbounded();
+
+        state.update(cx, |state, cx| {
+            let mut active = live_session(ProviderKind::ClaudeCode, new_commands);
+            active.turn_in_flight = true;
+            let id = active.meta.id.clone();
+            state.store.upsert_meta(&active.meta).unwrap();
+            state.sessions = state.store.load_index();
+            state.active = Some(active);
+
+            // The old pump drains after the session moved to a new provider.
+            state.on_event_stream_ended(&id, &old_commands, cx);
+
+            let active = state.active.as_ref().unwrap();
+            assert!(
+                matches!(active.runtime, Runtime::Live(_)),
+                "a stale pump must not tear down the successor provider"
+            );
+            assert!(active.turn_in_flight);
+            assert!(state.turn_running_for(&id));
+
+            // And an idle session ignores stream-end noise entirely.
+            state.active.as_mut().unwrap().runtime = Runtime::Idle;
+            state.active.as_mut().unwrap().turn_in_flight = false;
+            state.on_event_stream_ended(&id, &old_commands, cx);
+            assert!(!state.turn_running_for(&id));
+        });
+
         let _ = std::fs::remove_dir_all(&data);
     }
 


### PR DESCRIPTION
## The recurring bug

"Ended conversations stuck at Working" has been patched ~10 times (#75, #104, #161, …) and kept coming back. Root cause: the badge folds four hand-kept flags (`turn_in_flight`, `delivery_in_flight`, queue, `background_task_count`), and every reset depends on the right adapter event arriving. Any adapter missing one emission on one exit path leaks a flag forever — and the surface of such paths grows with every provider and feature. Prior fixes each closed one path; this PR closes the class.

## Changes

**Runtime chokepoint backstop** — the event pump used to exit silently when an adapter dropped its channel without `SessionClosed`, leaving the flags with no reset path. It now synthesizes the close, running the ordinary teardown. A same-channel ownership check makes a stale pump (session closed, restarted, or shut down mid-event) a no-op, so it can never tear down a successor provider. This covers every adapter's current and future missed exit paths.

**Claude: origin-shape-proof zero publication** — `background_tasks_changed []` deliberately withholds its zero (parking guard), so a `result` is the only place the runtime learns the tasks are gone. That publication was gated on `origin.kind == "task-notification"`; any CLI shape drift pinned the count > 0 on a live idle process. Every result now publishes the current count (audit ranked this the most likely live leak).

**Codex: rejected `turn/start` closes the turn** — acceptance sets the runtime's turn flag before the server answers; a JSON-RPC rejection (or missing result) emitted only a nonfatal `Error`, and nothing else could ever clear the flag. The adapter now synthesizes a Failed `TurnCompleted`, guarded so a stray rejection can't fail a turn that actually started.

## Verification

- 5 new regression tests (dead stream active/parked, stale-pump no-op, Claude zero-after-drain, Codex rejected turn/start incl. the guard case)
- `cargo test --workspace` green (153 agent + 95 runtime + rest), `cargo fmt --check` clean, `cargo clippy --workspace --all-targets` clean
- A static audit of all five adapters' lifecycle-event guarantees informed the fix ranking; remaining lower-likelihood paths (OpenCode `session.error` without idle, pi missing `agent_settled`, ACP cancel against a non-compliant agent) are now all backstopped by the pump synthesis whenever the process actually dies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)