### PR TITLE
chore(deps): bump agent-client-protocol from 1.2.0 to 2.0.0 (audited)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,17 +140,19 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882b815ffa67b023e1b40e7ea3bab3f05869654e8565d6811870c5545285e1d3"
+checksum = "6d87bc7769eba641753ba5dc52f73ec3765d51022c6753bf040967125ddc86a8"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
+ "async-io",
  "async-process",
  "blocking",
  "futures",
  "futures-concurrency",
  "rustc-hash 2.1.3",
+ "rustix 1.1.4",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -162,19 +164,19 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5ca63f112bd2459bcaf9eda0683b9ba95fc3b5e5fdd9036ca941c6a09345b1"
+checksum = "3abd4080f51e4f24f5042beb7fb7a66ede29a2dc1c2582c329532e1c27264ddc"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06679e1542356341f4550ccfb16338b64f37f6af70de2105446ef6fbb078234c"
+checksum = "d5c231915b4ab578c722eca2d1bd7df4d300bfd6cac3b8e9f0d1e3ddc95b187c"
 dependencies = [
  "anyhow",
  "derive_more 2.1.1",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-agent-client-protocol = { version = "1.2", features = [
+agent-client-protocol = { version = "2.0", features = [
     "unstable_auth_methods",
     "unstable_end_turn_token_usage",
 ] }


### PR DESCRIPTION
Supersedes #166 with an audited upgrade of the ACP SDK to 2.0.0.

## Why a separate PR

The 2.0 release keeps the stable ACP v1 wire schema unchanged but makes coordinated breaking changes to the Rust SDK APIs and low-level transport boundary ([release notes](https://github.com/agentclientprotocol/rust-sdk/releases/tag/v2.0.0), [migration guide](https://agentclientprotocol.github.io/rust-sdk/migration_v2.0.html)). The bump compiles cleanly, so the risk was silent semantic drift rather than build breakage. Each risk area was audited against both SDK sources (1.2.0 vs 2.0.0, schema 1.4.0 vs 1.5.0):

| Risk area | Verdict |
|---|---|
| `ObservedWriter` line-sniffing of `session/prompt` delivery | Holds — v2 still writes one newline-terminated JSON object per typed request (`write_line`: single `\n`, `write_all` + `flush`); batching applies to incoming acceptance and relays only |
| New ordered-dispatch barrier for response callbacks | Not engaged — all responses consumed via `block_task`, which never calls `mark_ordered` |
| Incoming dispatch concurrency (`on_receive_request!`/`on_receive_notification!`) | Macros textually identical across versions; handlers spawn their work, so permission requests still interleave with a pending prompt |
| Double-response suppression | `Responder` was already `FnOnce`-consumed in 1.2; no tcode path responds twice |
| Cancellation (`session/cancel`) | Wire type byte-identical; prompt's `block_task` still resolves from the agent's response, as the code expects |
| Initialize/negotiation | `ProtocolVersion::LATEST` still resolves to V1 without `unstable_protocol_v2`; the negotiation changes live in the feature-gated multi-protocol router |
| `unstable_auth_methods` / `unstable_end_turn_token_usage` | Same feature gates, byte-identical schema definitions |
| MCP-over-ACP removal | Not used — tcode declares real HTTPS `McpServer::Http` servers; the removed thing was the synthetic `acp:` URL transport |

One behavioral change does apply and is an improvement: transport EOF now promptly fails any pending `block_task` instead of leaving it hanging, complementing the existing `ObservedReader` EOF path.

## Verification

- `cargo build -p agent` — clean, zero warnings
- `cargo clippy -p agent` — clean
- `cargo test -p agent` — 153 passed, 0 failed

Closes #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)