### PR TITLE
fix(providers): surface the pi/OpenCode thinking selector and probe their auth

### DIFF
--- a/crates/agent/src/opencode.rs
+++ b/crates/agent/src/opencode.rs
@@ -1107,10 +1107,22 @@ fn map_models(catalog: &Value) -> Vec<ModelSpec> {
                 && !variants.is_empty()
             {
                 let mut variants: Vec<_> = variants.keys().cloned().collect();
-                variants.sort();
+                const EFFORT_ORDER: &[&str] =
+                    &["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+                variants.sort_by(|left, right| {
+                    let left_order = EFFORT_ORDER
+                        .iter()
+                        .position(|effort| effort == left)
+                        .unwrap_or(usize::MAX);
+                    let right_order = EFFORT_ORDER
+                        .iter()
+                        .position(|effort| effort == right)
+                        .unwrap_or(usize::MAX);
+                    left_order.cmp(&right_order).then_with(|| left.cmp(right))
+                });
                 options.push(OptionDescriptor::Select {
-                    id: "variant".into(),
-                    label: "Variant".into(),
+                    id: "reasoningEffort".into(),
+                    label: "Thinking".into(),
                     options: variants
                         .into_iter()
                         .map(|variant| SelectOption {
@@ -1843,13 +1855,34 @@ mod tests {
         let models = map_models(&json!({
             "default":{"openai":"gpt-test"},
             "providers":[{"id":"openai","models":{"gpt-test":{
-                "name":"GPT Test","status":"active","variants":{"high":{}}
+                "name":"GPT Test","status":"active","variants":{
+                    "alpha":{},"high":{},"low":{},"max":{},"medium":{},
+                    "minimal":{},"none":{},"xhigh":{},"zeta":{}
+                }
             }}}]
         }));
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "openai/gpt-test");
         assert!(models[0].is_default);
-        assert_eq!(models[0].options.len(), 1);
+        let [
+            OptionDescriptor::Select {
+                id, label, options, ..
+            },
+        ] = models[0].options.as_slice()
+        else {
+            panic!("expected one select descriptor");
+        };
+        assert_eq!(id, "reasoningEffort");
+        assert_eq!(label, "Thinking");
+        assert_eq!(
+            options
+                .iter()
+                .map(|option| option.value.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "none", "minimal", "low", "medium", "high", "xhigh", "max", "alpha", "zeta"
+            ]
+        );
     }
 
     #[test]

--- a/crates/agent/src/pi.rs
+++ b/crates/agent/src/pi.rs
@@ -97,6 +97,7 @@ fn list_models_blocking(
     )?;
 
     let mut current = None;
+    let mut thinking_level = None;
     let mut catalog = None;
     let mut reader = BufReader::new(stdout);
     while current.is_none() || catalog.is_none() {
@@ -109,6 +110,10 @@ fn list_models_blocking(
             Some("state") => {
                 ensure_success(&message)?;
                 current = Some(model_wire_id(message.pointer("/data/model")));
+                thinking_level = message
+                    .pointer("/data/thinkingLevel")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned);
             }
             Some("models") => {
                 ensure_success(&message)?;
@@ -129,11 +134,15 @@ fn list_models_blocking(
     Ok(catalog
         .unwrap_or_default()
         .iter()
-        .filter_map(|model| map_model(model, current.as_deref()))
+        .filter_map(|model| map_model(model, current.as_deref(), thinking_level.as_deref()))
         .collect())
 }
 
-fn map_model(model: &Value, current: Option<&str>) -> Option<ModelSpec> {
+fn map_model(
+    model: &Value,
+    current: Option<&str>,
+    thinking_level: Option<&str>,
+) -> Option<ModelSpec> {
     let id = model.get("id")?.as_str()?;
     let provider = model.get("provider")?.as_str()?;
     let wire_id = format!("{provider}/{id}");
@@ -151,6 +160,9 @@ fn map_model(model: &Value, current: Option<&str>) -> Option<ModelSpec> {
         {
             levels.push("max");
         }
+        let default_value = thinking_level
+            .filter(|level| levels.contains(level))
+            .map(str::to_owned);
         options.push(OptionDescriptor::Select {
             id: "reasoningEffort".into(),
             label: "Thinking".into(),
@@ -162,7 +174,7 @@ fn map_model(model: &Value, current: Option<&str>) -> Option<ModelSpec> {
                     description: None,
                 })
                 .collect(),
-            default_value: None,
+            default_value,
         });
     }
     Some(ModelSpec {
@@ -1476,6 +1488,32 @@ fn spawn_stderr_reader(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn map_model_uses_supported_state_thinking_level_as_default() {
+        let model = json!({
+            "id": "gpt-test",
+            "provider": "openai",
+            "reasoning": true
+        });
+        let mapped = map_model(&model, None, Some("xhigh")).unwrap();
+        assert!(matches!(
+            mapped.options.as_slice(),
+            [OptionDescriptor::Select {
+                default_value: Some(level),
+                ..
+            }] if level == "xhigh"
+        ));
+
+        let mapped = map_model(&model, None, Some("unsupported")).unwrap();
+        assert!(matches!(
+            mapped.options.as_slice(),
+            [OptionDescriptor::Select {
+                default_value: None,
+                ..
+            }]
+        ));
+    }
 
     #[test]
     fn maps_recorded_rpc_fixture() {

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -562,8 +562,8 @@ impl ActiveSession {
 
     /// Whether a launch-time option (reasoning effort for Claude, context
     /// window, fast mode, thinking, …) changed while the provider is live, so
-    /// the next turn must restart it. Codex's reasoning effort is excluded: it
-    /// is applied per turn via [`TurnOptions`] and needs no restart.
+    /// the next turn must restart it. Codex and OpenCode reasoning effort is
+    /// excluded: it is applied per turn via [`TurnOptions`] and needs no restart.
     fn options_changed_while_live(&self) -> bool {
         if !matches!(self.runtime, Runtime::Live(_)) {
             return false;
@@ -573,7 +573,10 @@ impl ActiveSession {
         if self.meta.provider == ProviderKind::Acp {
             return false;
         }
-        let ignore_effort = self.meta.provider == ProviderKind::Codex;
+        let ignore_effort = matches!(
+            self.meta.provider,
+            ProviderKind::Codex | ProviderKind::OpenCode
+        );
         normalized_selections(&self.meta.option_selections, ignore_effort)
             != normalized_selections(&self.live_option_selections, ignore_effort)
     }
@@ -591,11 +594,14 @@ impl ActiveSession {
             && (self.background_task_count > 0 || self.delivery_in_flight.is_some())
     }
 
-    /// Per-turn overrides derived from the session's persisted state: Codex
-    /// reasoning effort (applied per turn) and the Build/Plan interaction mode.
+    /// Per-turn overrides derived from the session's persisted state: Codex and
+    /// OpenCode reasoning effort, plus the Build/Plan interaction mode.
     fn turn_options(&self) -> TurnOptions {
-        let effort = if self.meta.provider == ProviderKind::Codex {
-            codex_effort_selection(&self.meta.option_selections)
+        let effort = if matches!(
+            self.meta.provider,
+            ProviderKind::Codex | ProviderKind::OpenCode
+        ) {
+            effort_selection(&self.meta.option_selections)
         } else {
             None
         };
@@ -6295,10 +6301,10 @@ impl AppState {
         if id == "reasoningEffort" {
             active.pending_ultrathink = false;
         }
-        // ACP agents apply option changes live: route the choice back to the
-        // agent (`session/set_mode` / `set_model` / `set_config_option`) instead
-        // of waiting for a restart.
-        if active.meta.provider == ProviderKind::Acp
+        // ACP agents apply every option change live; pi applies its thinking
+        // level live. Route those choices back instead of waiting for a restart.
+        if (active.meta.provider == ProviderKind::Acp
+            || (active.meta.provider == ProviderKind::Pi && id == "reasoningEffort"))
             && let Runtime::Live(commands) = &active.runtime
             && let Some(selection) = active.meta.option_selections.iter().find(|s| s.id == id)
         {
@@ -8262,8 +8268,8 @@ fn sanitize_filename(name: &str) -> String {
     out.chars().take(80).collect()
 }
 
-/// The reasoning-effort selection value, if any (Codex applies it per turn).
-fn codex_effort_selection(selections: &[OptionSelection]) -> Option<String> {
+/// The reasoning-effort selection value, if any.
+fn effort_selection(selections: &[OptionSelection]) -> Option<String> {
     selections
         .iter()
         .find(|s| s.id == "reasoningEffort")
@@ -8271,8 +8277,8 @@ fn codex_effort_selection(selections: &[OptionSelection]) -> Option<String> {
 }
 
 /// Selections sorted by id for order-independent comparison, optionally dropping
-/// the reasoning-effort entry (which, for Codex, applies per turn and never
-/// forces a restart).
+/// the reasoning-effort entry (which, for per-turn providers, never forces a
+/// restart).
 fn normalized_selections(
     selections: &[OptionSelection],
     ignore_effort: bool,
@@ -11236,6 +11242,18 @@ mod tests {
             terminal_workspace: TerminalWorkspace::default(),
             _pump: None,
         }
+    }
+
+    #[test]
+    fn opencode_effort_is_applied_per_turn_without_restart() {
+        let mut active = live_session(ProviderKind::OpenCode, async_channel::unbounded().0);
+        active.meta.option_selections.push(OptionSelection {
+            id: "reasoningEffort".into(),
+            value: serde_json::json!("high"),
+        });
+
+        assert_eq!(active.turn_options().effort.as_deref(), Some("high"));
+        assert!(!active.options_changed_while_live());
     }
 
     #[test]

--- a/crates/services/src/provider_auth.rs
+++ b/crates/services/src/provider_auth.rs
@@ -176,6 +176,41 @@ fn decode_jwt_claims(token: &str) -> Option<serde_json::Value> {
     serde_json::from_slice(&bytes).ok()
 }
 
+/// Parse the shared `auth.json` shape used by pi and OpenCode. Each top-level
+/// key names an upstream provider whose object carries a non-empty `type`.
+///
+/// An empty or unreadable credential set remains indeterminate because either
+/// CLI may also authenticate through environment variables.
+pub fn parse_aggregator_auth(json: &str) -> Option<ProviderAuth> {
+    let value: serde_json::Value = serde_json::from_str(json).ok()?;
+    let object = value.as_object()?;
+    let mut providers: Vec<_> = object
+        .iter()
+        .filter_map(|(provider, credential)| {
+            credential
+                .as_object()?
+                .get("type")
+                .and_then(|value| value.as_str())
+                .filter(|kind| !kind.trim().is_empty())
+                .map(|_| provider.as_str())
+        })
+        .collect();
+    if providers.is_empty() {
+        return None;
+    }
+    providers.sort_unstable();
+    let overflow = providers.len().saturating_sub(3);
+    let mut label = providers.into_iter().take(3).collect::<Vec<_>>().join(", ");
+    if overflow > 0 {
+        label.push_str(&format!(" +{overflow}"));
+    }
+    Some(ProviderAuth {
+        status: AuthStatus::Authenticated,
+        label: Some(label),
+        email: None,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -272,5 +307,29 @@ mod tests {
         }
         // An unknown plan degrades to the generic label rather than inventing one.
         assert_eq!(normalize_chatgpt_plan("mystery"), None);
+    }
+
+    #[test]
+    fn parses_aggregator_auth_json() {
+        let auth =
+            parse_aggregator_auth(r#"{"zai":{"type":"oauth"},"anthropic":{"type":"oauth"}}"#)
+                .unwrap();
+        assert_eq!(auth.status, AuthStatus::Authenticated);
+        assert_eq!(auth.label.as_deref(), Some("anthropic, zai"));
+        assert_eq!(auth.email, None);
+
+        let auth = parse_aggregator_auth(r#"{"openai":{"type":"api","key":"sk-x"}}"#).unwrap();
+        assert_eq!(auth.status, AuthStatus::Authenticated);
+        assert_eq!(auth.label.as_deref(), Some("openai"));
+
+        assert!(parse_aggregator_auth("{}").is_none());
+        assert!(parse_aggregator_auth("not json").is_none());
+
+        let auth = parse_aggregator_auth(
+            r#"{"zeta":{"type":"api"},"beta":{"type":"oauth"},"delta":{"type":"api"},
+                "alpha":{"type":"oauth"},"gamma":{"type":"oauth"}}"#,
+        )
+        .unwrap();
+        assert_eq!(auth.label.as_deref(), Some("alpha, beta, delta +2"));
     }
 }

--- a/crates/services/src/provider_probe.rs
+++ b/crates/services/src/provider_probe.rs
@@ -7,7 +7,7 @@ use tcode_core::provider_status::{
     AuthStatus, ProviderAuth, ProviderProbeDiagnostic, ProviderSnapshot, ProviderStatusKind,
 };
 
-use crate::provider_auth::{parse_claude_auth, parse_codex_auth};
+use crate::provider_auth::{parse_aggregator_auth, parse_claude_auth, parse_codex_auth};
 
 /// The bare command name for a provider (fallback when no path resolves).
 pub fn default_program(provider: ProviderKind) -> String {
@@ -109,10 +109,30 @@ pub async fn probe_provider(
             let json = path.and_then(|path| std::fs::read_to_string(path).ok());
             json.as_deref().and_then(parse_codex_auth)
         }
-        // Both CLIs can aggregate credentials for several upstream model
-        // providers. Installation/version are definitive; auth remains
-        // indeterminate until a session/model query succeeds.
-        ProviderKind::Pi | ProviderKind::OpenCode => None,
+        ProviderKind::Pi => {
+            let home = launch_env
+                .home
+                .or_else(|| dirs::home_dir().map(|home| home.join(".pi/agent")));
+            let path = home.map(|home| home.join("auth.json"));
+            // This is a small local JSON file; keep the direct read used by the
+            // app rather than introducing a thread-pool hop.
+            let json = path.and_then(|path| std::fs::read_to_string(path).ok());
+            json.as_deref().and_then(parse_aggregator_auth)
+        }
+        ProviderKind::OpenCode => {
+            let xdg_data = env
+                .iter()
+                .rev()
+                .find(|(key, _)| key == "XDG_DATA_HOME")
+                .map(|(_, value)| PathBuf::from(value))
+                .or_else(|| std::env::var_os("XDG_DATA_HOME").map(PathBuf::from))
+                .or_else(|| dirs::home_dir().map(|home| home.join(".local/share")));
+            let path = xdg_data.map(|home| home.join("opencode/auth.json"));
+            // This is a small local JSON file; keep the direct read used by the
+            // app rather than introducing a thread-pool hop.
+            let json = path.and_then(|path| std::fs::read_to_string(path).ok());
+            json.as_deref().and_then(parse_aggregator_auth)
+        }
         // ACP authentication is surfaced by its session protocol.
         ProviderKind::Acp => None,
     };

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -4484,9 +4484,9 @@ fn traits_chip_label(
         match descriptor {
             OptionDescriptor::Select {
                 id,
+                label,
                 options,
                 default_value,
-                ..
             } => {
                 // An armed Ultrathink shows in the reasoning segment (it is not
                 // persisted, so it does not resolve as an ordinary selection).
@@ -4497,11 +4497,11 @@ fn traits_chip_label(
                     parts.push(o.label.clone());
                     continue;
                 }
-                if let Some(value) = resolved_select_value(id, options, default_value, selections)
-                    && let Some(o) = options.iter().find(|o| o.value == value)
-                {
-                    parts.push(o.label.clone());
-                }
+                let part = resolved_select_value(id, options, default_value, selections)
+                    .and_then(|value| options.iter().find(|o| o.value == value))
+                    .map(|option| option.label.clone())
+                    .unwrap_or_else(|| label.clone());
+                parts.push(part);
             }
             OptionDescriptor::Boolean {
                 id,
@@ -4980,6 +4980,25 @@ mod tests {
         assert_eq!(
             traits_chip_label(&thinking, &[], false),
             Some("Thinking Off".into())
+        );
+        let unresolved = agent::ModelSpec {
+            id: "u".into(),
+            display_name: "u".into(),
+            is_default: false,
+            options: vec![agent::OptionDescriptor::Select {
+                id: "reasoningEffort".into(),
+                label: "Thinking".into(),
+                options: vec![agent::SelectOption {
+                    value: "high".into(),
+                    label: "High".into(),
+                    description: None,
+                }],
+                default_value: None,
+            }],
+        };
+        assert_eq!(
+            traits_chip_label(&unresolved, &[], false),
+            Some("Thinking".into())
         );
         // A model with no descriptors has no chip.
         let bare = agent::ModelSpec {


### PR DESCRIPTION
## Problem

Two user-reported issues with the pi and OpenCode providers:

1. **The thinking-level selector never appeared.** The composer traits chip only renders when a select descriptor resolves a current value. Claude/Codex catalogs always ship a `default_value`, but pi and OpenCode shipped `default_value: None` — so on a fresh session the chip label came up empty and the only entry point to the thinking picker was hidden. The adapters themselves (pi `--thinking`/`set_thinking_level`, OpenCode per-turn `variant`) were already wired.
2. **A false "cannot verify authentication" warning.** `probe_provider` hardcoded `auth = None` for both CLIs, so even a logged-in Codex-subscription user saw the indeterminate-auth warning permanently.

## Fix

- The traits chip now falls back to the descriptor's label when no value resolves, so the picker is always reachable.
- pi model discovery seeds `default_value` from the CLI's persisted `thinkingLevel` (read from the same `get_state` response it already consumes).
- OpenCode's variant select becomes the canonical `reasoningEffort` id with a "Thinking" label and canonical effort ordering (none → low → medium → high → xhigh → max) instead of alphabetical; the adapter keeps accepting the old `variant` id from persisted sessions.
- OpenCode effort now applies per turn like Codex, and a live pi session takes thinking changes over `set_thinking_level` — neither prompts for a session restart anymore.
- Auth probing reads pi's `$PI_CODING_AGENT_DIR/auth.json` and OpenCode's `$XDG_DATA_HOME/opencode/auth.json` and reports the connected upstream providers as the auth label. Missing or empty files keep the indeterminate path, since both CLIs also accept environment-variable credentials.

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all pass.
- Live probes against pi 0.82.1 and opencode 1.18.9: `probe --list-models pi` now shows `default_value: xhigh` on every reasoning model; `--list-models opencode` shows `reasoningEffort` / "Thinking" with canonical ordering.
- New unit tests cover the chip fallback, the pi default plumbing, the OpenCode descriptor shape/ordering, per-turn OpenCode effort, and the aggregator auth parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)