### PR TITLE
fix(ui): make the hide-model icon mirror state, not action

### DIFF
--- a/crates/ui/src/provider_dialog.rs
+++ b/crates/ui/src/provider_dialog.rs
@@ -829,10 +829,13 @@ impl ProviderDialog {
                 Button::new(("model-hide", index))
                     .ghost()
                     .xsmall()
+                    // Like the star beside it, the icon mirrors the model's
+                    // current state (slashed eye = hidden); the tooltip names
+                    // the action.
                     .icon(if hidden {
-                        IconName::Eye
-                    } else {
                         IconName::EyeOff
+                    } else {
+                        IconName::Eye
                     })
                     .tooltip(if hidden {
                         tcode_i18n::tr!("providers.models.show")


### PR DESCRIPTION
The hide-model button showed the slashed eye on visible models and the open eye on hidden ones (icon-as-action), while the neighboring favorite star shows current state — so the row read as inverted. Flip the icon to the state convention: slashed eye = hidden. Tooltips already name the action and are unchanged.

Reported by a user via feedback on the providers dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)