### PR TITLE
feat(pi): support the pi extension ecosystem with zero injection by default

### DIFF
--- a/crates/agent/assets/pi/tcode-permissions.ts
+++ b/crates/agent/assets/pi/tcode-permissions.ts
@@ -18,9 +18,35 @@ export default function tcodePermissions(pi: any) {
 	pi.on("tool_call", async (event: any, ctx: any) => {
 		const toolName = String(event.toolName ?? "");
 		const input = event.input ?? {};
+		const info = pi.getAllTools().find((tool: any) => tool.name === toolName)?.sourceInfo;
 
-		// Unknown extension tools never inherit blanket access. This is the
-		// fail-closed boundary if pi adds a new built-in tool in the future.
+		if (!info) {
+			return { block: true, reason: `tcode blocked tool with unknown source: ${toolName || "(unnamed)"}` };
+		}
+
+		if (info.source !== "builtin") {
+			if (mode === "read_only") {
+				return { block: true, reason: `tcode read-only mode blocked ${toolName}` };
+			}
+			if (mode === "full_access") return undefined;
+
+			const reason = "requires confirmation";
+			const payload = JSON.stringify({
+				toolName,
+				input,
+				cwd,
+				reason,
+				source: "extension",
+				extensionPath: info.path,
+				shadowsBuiltin: known.has(toolName),
+			});
+			const confirmed = await ctx.ui.confirm(`tcode:${toolName}`, payload);
+			if (!confirmed) return { block: true, reason: `tcode denied ${toolName}` };
+			return undefined;
+		}
+
+		// Built-ins unknown to this gate never inherit blanket access. This is
+		// the fail-closed boundary if pi adds a new built-in tool in the future.
 		if (!known.has(toolName)) {
 			return { block: true, reason: `tcode blocked unknown tool: ${toolName || "(unnamed)"}` };
 		}

--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -2534,6 +2534,7 @@ fn parse_ask_user_questions(input: &Value) -> Vec<UserInputQuestion> {
                 question,
                 options,
                 multi_select,
+                prefill: None,
             }
         })
         .collect()

--- a/crates/agent/src/codex.rs
+++ b/crates/agent/src/codex.rs
@@ -2104,6 +2104,7 @@ fn parse_elicitation_form(
             question: question.to_owned(),
             options,
             multi_select,
+            prefill: None,
         });
         fields.push(ElicitField {
             key: key.clone(),
@@ -2137,6 +2138,7 @@ fn parse_elicitation_url(
             elicit_option(ELICITATION_URL_CANCEL_LABEL),
         ],
         multi_select: false,
+        prefill: None,
     };
     let field = ElicitField {
         key: "url".into(),
@@ -2200,6 +2202,7 @@ fn parse_codex_user_input(params: &Value) -> Vec<UserInputQuestion> {
                 question: question.to_owned(),
                 options,
                 multi_select: false,
+                prefill: None,
             })
         })
         .collect()

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -424,6 +424,8 @@ pub struct UserInputQuestion {
     pub question: String,
     pub options: Vec<UserInputOption>,
     pub multi_select: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefill: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/agent/src/pi.rs
+++ b/crates/agent/src/pi.rs
@@ -18,7 +18,7 @@ use crate::{
     Attachment, DeltaKind, FileChange, FileChangeKind, InteractionMode, ItemContent, ItemStatus,
     LaunchEnv, ModelSpec, OptionDescriptor, OptionSelection, ProviderCommand, ProviderCommandKind,
     ProviderKind, ResumeCursor, SelectOption, SessionCommand, SessionHandle, SessionOptions,
-    ThreadItem, TokenUsage, TurnStatus,
+    ThreadItem, TokenUsage, TurnStatus, UserInputOption, UserInputQuestion,
 };
 
 const PERMISSION_EXTENSION: &str = include_str!("../assets/pi/tcode-permissions.ts");
@@ -317,6 +317,7 @@ async fn run_actor(
         next_request: 1,
         approval_mode: opts.approval_mode,
         pending_approvals: HashMap::new(),
+        pending_dialogs: HashSet::new(),
         approved_for_session: HashSet::new(),
         pending_steers: HashMap::new(),
         requested_model: opts.model.clone(),
@@ -364,7 +365,10 @@ async fn run_actor(
         })
         .await;
         match input {
-            Input::Command(Ok(SessionCommand::Shutdown)) | Input::Command(Err(_)) => break None,
+            Input::Command(Ok(SessionCommand::Shutdown)) | Input::Command(Err(_)) => {
+                let _ = actor.cancel_pending_ui();
+                break None;
+            }
             Input::Command(Ok(command)) => {
                 if let Err(err) = actor.handle_command(command).await {
                     actor
@@ -408,6 +412,7 @@ struct PiActor {
     next_request: u64,
     approval_mode: ApprovalMode,
     pending_approvals: HashMap<String, String>,
+    pending_dialogs: HashSet<String>,
     approved_for_session: HashSet<String>,
     /// Native prompt request id -> canonical steering request id. pi's prompt
     /// response is only an acceptance signal, but it is stronger than merely
@@ -492,6 +497,17 @@ impl PiActor {
                     // belongs to the mapper, not to startup.
                     if let Some(warning) = extension_warning(&message) {
                         self.emit(AgentEvent::Warning { message: warning }).await;
+                    } else if is_extension_dialog(&message)
+                        && let Some(request_id) = message.get("id").and_then(Value::as_str)
+                    {
+                        send_json(
+                            &mut self.stdin,
+                            &json!({
+                                "type":"extension_ui_response",
+                                "id":request_id,
+                                "cancelled":true
+                            }),
+                        )?;
                     }
                 }
                 Ok(ChildOutput::Error(err)) => return Err(AgentError::Protocol(err)),
@@ -541,13 +557,36 @@ impl PiActor {
             self.handle_extension_ui(&message).await;
             return;
         }
-        for event in self.mapper.on_message(&message) {
+        let events = self.mapper.on_message(&message);
+        let turn_completed = events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::TurnCompleted { .. }));
+        for event in events {
             self.emit(event).await;
+        }
+        if turn_completed {
+            let _ = self.cancel_pending_ui();
         }
     }
 
     async fn handle_extension_ui(&mut self, message: &Value) {
         let method = message.get("method").and_then(Value::as_str).unwrap_or("");
+        if matches!(method, "select" | "input" | "editor") {
+            let Some((id, question)) = extension_dialog_question(message) else {
+                self.emit(AgentEvent::Warning {
+                    message: format!("pi extension `{method}` dialog omitted its id"),
+                })
+                .await;
+                return;
+            };
+            self.pending_dialogs.insert(id.clone());
+            self.emit(AgentEvent::UserInputRequested {
+                request_id: id,
+                questions: vec![question],
+            })
+            .await;
+            return;
+        }
         if method != "confirm" {
             if let Some(warning) = extension_warning(message) {
                 self.emit(AgentEvent::Warning { message: warning }).await;
@@ -642,6 +681,7 @@ impl PiActor {
             }
             SessionCommand::Interrupt => {
                 self.mapper.interrupt_pending = true;
+                self.cancel_pending_ui()?;
                 send_json(&mut self.stdin, &json!({"type":"abort"})).map_err(|err| err.to_string())
             }
             SessionCommand::RespondApproval {
@@ -665,6 +705,7 @@ impl PiActor {
                 .map_err(|err| err.to_string())?;
                 if decision == ApprovalDecision::Cancel {
                     self.mapper.interrupt_pending = true;
+                    self.cancel_pending_ui()?;
                     send_json(&mut self.stdin, &json!({"type":"abort"}))
                         .map_err(|err| err.to_string())?;
                 }
@@ -706,11 +747,18 @@ impl PiActor {
                 }
                 Ok(())
             }
-            SessionCommand::RespondUserInput { .. } => {
-                self.emit(AgentEvent::Warning {
-                    message: "pi RPC does not expose structured user-input requests".into(),
-                })
-                .await;
+            SessionCommand::RespondUserInput {
+                request_id,
+                answers,
+            } => {
+                let Some(response) = take_extension_dialog_response(
+                    &mut self.pending_dialogs,
+                    &request_id,
+                    &answers,
+                ) else {
+                    return Ok(());
+                };
+                send_json(&mut self.stdin, &response).map_err(|err| err.to_string())?;
                 Ok(())
             }
             SessionCommand::Rewind { .. } => {
@@ -728,6 +776,18 @@ impl PiActor {
         let id = format!("tcode-{}", self.next_request);
         self.next_request += 1;
         id
+    }
+
+    fn cancel_pending_ui(&mut self) -> Result<(), String> {
+        for id in self.pending_approvals.drain().map(|(id, _)| id) {
+            send_json(
+                &mut self.stdin,
+                &json!({"type":"extension_ui_response","id":id,"confirmed":false}),
+            )
+            .map_err(|err| err.to_string())?;
+        }
+        cancel_pending_dialogs(&mut self.stdin, &mut self.pending_dialogs)
+            .map_err(|err| err.to_string())
     }
 
     async fn emit(&self, event: AgentEvent) {
@@ -997,6 +1057,35 @@ impl PiMapper {
             // prompt. pi echoes it back; mapping that echo would duplicate the
             // user bubble, as with Codex/OpenCode.
             Some("user") => Vec::new(),
+            Some("custom") if message.get("display").and_then(Value::as_bool) == Some(true) => {
+                let summary = match message.get("content") {
+                    Some(Value::String(text)) => text.clone(),
+                    Some(Value::Array(parts)) => parts
+                        .iter()
+                        .filter(|part| part.get("type").and_then(Value::as_str) == Some("text"))
+                        .filter_map(|part| part.get("text").and_then(Value::as_str))
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                    _ => String::new(),
+                };
+                if summary.trim().is_empty() {
+                    return Vec::new();
+                }
+                let provider_kind = message
+                    .get("customType")
+                    .and_then(Value::as_str)
+                    .filter(|kind| !kind.trim().is_empty())
+                    .unwrap_or("pi-extension")
+                    .to_owned();
+                vec![AgentEvent::ItemCompleted(ThreadItem {
+                    id: assistant_message_id(message),
+                    parent_item_id: None,
+                    content: ItemContent::Other {
+                        provider_kind,
+                        summary,
+                    },
+                })]
+            }
             Some("assistant") => {
                 let mut events = Vec::new();
                 let id = assistant_message_id(message);
@@ -1247,6 +1336,104 @@ fn extension_warning(message: &Value) -> Option<String> {
     (!text.is_empty()).then(|| text.to_owned())
 }
 
+fn is_extension_dialog(message: &Value) -> bool {
+    message.get("type").and_then(Value::as_str) == Some("extension_ui_request")
+        && matches!(
+            message.get("method").and_then(Value::as_str),
+            Some("select" | "input" | "editor")
+        )
+}
+
+fn extension_dialog_question(message: &Value) -> Option<(String, UserInputQuestion)> {
+    if !is_extension_dialog(message) {
+        return None;
+    }
+    let id = message.get("id")?.as_str()?.to_owned();
+    let method = message.get("method")?.as_str()?;
+    let title = message
+        .get("title")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let (question, options, prefill) = match method {
+        "select" => (
+            title.to_owned(),
+            message
+                .get("options")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+                .map(|label| UserInputOption {
+                    label: label.to_owned(),
+                    description: String::new(),
+                })
+                .collect(),
+            None,
+        ),
+        "input" => {
+            let question = match message.get("placeholder").and_then(Value::as_str) {
+                Some(placeholder) => format!("{title} ({placeholder})"),
+                None => title.to_owned(),
+            };
+            (question, Vec::new(), None)
+        }
+        "editor" => (
+            title.to_owned(),
+            Vec::new(),
+            message
+                .get("prefill")
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+        ),
+        _ => return None,
+    };
+    Some((
+        id.clone(),
+        UserInputQuestion {
+            id,
+            header: "pi".into(),
+            question,
+            options,
+            multi_select: false,
+            prefill,
+        },
+    ))
+}
+
+fn extension_dialog_response(id: &str, answer: Option<&str>) -> Value {
+    match answer {
+        Some(value) => json!({"type":"extension_ui_response","id":id,"value":value}),
+        None => json!({"type":"extension_ui_response","id":id,"cancelled":true}),
+    }
+}
+
+fn take_extension_dialog_response(
+    pending_dialogs: &mut HashSet<String>,
+    request_id: &str,
+    answers: &serde_json::Map<String, Value>,
+) -> Option<Value> {
+    if !pending_dialogs.remove(request_id) {
+        return None;
+    }
+    Some(extension_dialog_response(
+        request_id,
+        answers.get(request_id).and_then(Value::as_str),
+    ))
+}
+
+fn cancel_pending_dialogs(
+    writer: &mut impl Write,
+    pending_dialogs: &mut HashSet<String>,
+) -> Result<(), AgentError> {
+    for id in pending_dialogs.drain() {
+        send_json(
+            writer,
+            &json!({"type":"extension_ui_response","id":id,"cancelled":true}),
+        )?;
+    }
+    Ok(())
+}
+
 fn result_text(result: &Value) -> String {
     result
         .get("content")
@@ -1484,7 +1671,7 @@ fn response_error(message: &Value) -> String {
         })
 }
 
-fn send_json(writer: &mut BufWriter<ChildStdin>, value: &Value) -> Result<(), AgentError> {
+fn send_json(writer: &mut impl Write, value: &Value) -> Result<(), AgentError> {
     serde_json::to_writer(&mut *writer, value)
         .map_err(|err| AgentError::Protocol(format!("serializing pi request: {err}")))?;
     writer.write_all(b"\n")?;
@@ -1670,6 +1857,105 @@ mod tests {
     }
 
     #[test]
+    fn maps_extension_dialog_requests_to_native_user_input() {
+        let (id, select) = extension_dialog_question(&json!({
+            "type":"extension_ui_request",
+            "id":"select-id",
+            "method":"select",
+            "title":"Choose",
+            "options":["a","b"],
+            "timeout":10000
+        }))
+        .unwrap();
+        assert_eq!(id, "select-id");
+        assert_eq!(select.id, "select-id");
+        assert_eq!(select.header, "pi");
+        assert_eq!(select.question, "Choose");
+        assert!(!select.multi_select);
+        assert_eq!(select.prefill, None);
+        assert_eq!(
+            select
+                .options
+                .iter()
+                .map(|option| (option.label.clone(), option.description.clone()))
+                .collect::<Vec<_>>(),
+            vec![("a".into(), String::new()), ("b".into(), String::new())]
+        );
+
+        let (_, input) = extension_dialog_question(&json!({
+            "type":"extension_ui_request",
+            "id":"input-id",
+            "method":"input",
+            "title":"Name",
+            "placeholder":"type here"
+        }))
+        .unwrap();
+        assert_eq!(input.question, "Name (type here)");
+        assert!(input.options.is_empty());
+        assert_eq!(input.prefill, None);
+
+        let (_, editor) = extension_dialog_question(&json!({
+            "type":"extension_ui_request",
+            "id":"editor-id",
+            "method":"editor",
+            "title":"Edit",
+            "prefill":"initial text"
+        }))
+        .unwrap();
+        assert_eq!(editor.question, "Edit");
+        assert!(editor.options.is_empty());
+        assert_eq!(editor.prefill.as_deref(), Some("initial text"));
+    }
+
+    #[test]
+    fn responds_to_pending_extension_dialog_with_value_or_cancellation() {
+        let mut pending = HashSet::from(["dialog".to_owned()]);
+        let answers = serde_json::Map::from_iter([("dialog".into(), json!("custom answer"))]);
+        assert_eq!(
+            take_extension_dialog_response(&mut pending, "dialog", &answers),
+            Some(json!({
+                "type":"extension_ui_response",
+                "id":"dialog",
+                "value":"custom answer"
+            }))
+        );
+        assert!(pending.is_empty());
+
+        for answers in [
+            serde_json::Map::new(),
+            serde_json::Map::from_iter([("dialog".into(), json!(["not", "a string"]))]),
+        ] {
+            pending.insert("dialog".into());
+            assert_eq!(
+                take_extension_dialog_response(&mut pending, "dialog", &answers),
+                Some(json!({
+                    "type":"extension_ui_response",
+                    "id":"dialog",
+                    "cancelled":true
+                }))
+            );
+            assert!(pending.is_empty());
+        }
+    }
+
+    #[test]
+    fn cleanup_cancels_pending_extension_dialogs() {
+        let mut pending = HashSet::from(["dialog".to_owned()]);
+        let mut output = Vec::new();
+        cancel_pending_dialogs(&mut output, &mut pending).unwrap();
+        assert!(pending.is_empty());
+        let response: Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(
+            response,
+            json!({
+                "type":"extension_ui_response",
+                "id":"dialog",
+                "cancelled":true
+            })
+        );
+    }
+
+    #[test]
     fn map_model_uses_supported_state_thinking_level_as_default() {
         let model = json!({
             "id": "gpt-test",
@@ -1783,6 +2069,65 @@ mod tests {
                 ..
             }]
         ));
+    }
+
+    #[test]
+    fn displayed_custom_messages_become_work_log_items() {
+        let mut mapper = PiMapper::new(true);
+        let plain = mapper.on_message(&json!({
+            "type":"message_end",
+            "message":{
+                "role":"custom",
+                "customType":"my-extension",
+                "content":"plain text",
+                "display":true,
+                "timestamp":1785400000000_u64
+            }
+        }));
+        assert!(matches!(
+            plain.as_slice(),
+            [AgentEvent::ItemCompleted(ThreadItem {
+                content: ItemContent::Other { provider_kind, summary },
+                ..
+            })] if provider_kind == "my-extension" && summary == "plain text"
+        ));
+
+        let parts = mapper.on_message(&json!({
+            "type":"message_end",
+            "message":{
+                "role":"custom",
+                "content":[
+                    {"type":"text","text":"first"},
+                    {"type":"image","data":"ignored"},
+                    {"type":"text","text":"second"}
+                ],
+                "display":true,
+                "timestamp":1785400000001_u64
+            }
+        }));
+        assert!(matches!(
+            parts.as_slice(),
+            [AgentEvent::ItemCompleted(ThreadItem {
+                content: ItemContent::Other { provider_kind, summary },
+                ..
+            })] if provider_kind == "pi-extension" && summary == "first\nsecond"
+        ));
+    }
+
+    #[test]
+    fn hidden_or_empty_custom_messages_are_ignored() {
+        let mut mapper = PiMapper::new(true);
+        for message in [
+            json!({"role":"custom","content":"hidden","display":false}),
+            json!({"role":"custom","content":"implicit hidden"}),
+            json!({"role":"custom","content":[{"type":"image","data":"ignored"}],"display":true}),
+        ] {
+            assert!(
+                mapper
+                    .on_message(&json!({"type":"message_end","message":message}))
+                    .is_empty()
+            );
+        }
     }
 
     #[test]

--- a/crates/agent/src/pi.rs
+++ b/crates/agent/src/pi.rs
@@ -1163,6 +1163,29 @@ fn approval_kind(tool_name: &str, payload: &Value) -> ApprovalKind {
         .get("reason")
         .and_then(Value::as_str)
         .map(str::to_owned);
+    if payload.get("source").and_then(Value::as_str) == Some("extension") {
+        let path = payload
+            .get("extensionPath")
+            .and_then(Value::as_str)
+            .unwrap_or("(unknown path)");
+        let mut source = format!("extension tool from {path}");
+        if payload
+            .get("shadowsBuiltin")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            source.push_str(&format!(" (overrides builtin {tool_name})"));
+        }
+        let detail = match reason {
+            Some(reason) => format!("{reason}; {source}"),
+            None => source,
+        };
+        return ApprovalKind::ToolUse {
+            name: tool_name.to_owned(),
+            input,
+            detail,
+        };
+    }
     match tool_name {
         "bash" => ApprovalKind::ExecCommand {
             command: input
@@ -1541,6 +1564,81 @@ fn spawn_stderr_reader(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn extension_bash_approval_is_tool_use() {
+        let approval = approval_kind(
+            "bash",
+            &json!({
+                "toolName": "bash",
+                "source": "extension",
+                "extensionPath": "/extensions/bash.ts",
+                "input": { "command": "x" }
+            }),
+        );
+        assert!(matches!(
+            approval,
+            ApprovalKind::ToolUse { name, input, .. }
+                if name == "bash" && input == json!({ "command": "x" })
+        ));
+    }
+
+    #[test]
+    fn builtin_bash_approval_remains_exec_command() {
+        let approval = approval_kind(
+            "bash",
+            &json!({
+                "toolName": "bash",
+                "input": { "command": "x" },
+                "cwd": "/project"
+            }),
+        );
+        assert!(matches!(
+            approval,
+            ApprovalKind::ExecCommand { command, cwd, .. }
+                if command == "x" && cwd.as_deref() == Some("/project")
+        ));
+    }
+
+    #[test]
+    fn extension_tool_approval_detail_contains_path() {
+        let approval = approval_kind(
+            "hello_world",
+            &json!({
+                "toolName": "hello_world",
+                "source": "extension",
+                "extensionPath": "/extensions/hello.ts",
+                "input": {}
+            }),
+        );
+        assert!(matches!(
+            approval,
+            ApprovalKind::ToolUse { name, detail, .. }
+                if name == "hello_world" && detail.contains("/extensions/hello.ts")
+        ));
+    }
+
+    #[test]
+    fn shadowed_builtin_is_noted_in_extension_approval_detail() {
+        let approval = approval_kind(
+            "bash",
+            &json!({
+                "toolName": "bash",
+                "source": "extension",
+                "extensionPath": "/extensions/bash.ts",
+                "shadowsBuiltin": true,
+                "input": { "command": "x" },
+                "reason": "requires confirmation"
+            }),
+        );
+        assert!(matches!(
+            approval,
+            ApprovalKind::ToolUse { detail, .. }
+                if detail.contains("requires confirmation")
+                    && detail.contains("/extensions/bash.ts")
+                    && detail.contains("overrides builtin bash")
+        ));
+    }
 
     #[test]
     fn only_warning_notifications_become_session_warnings() {

--- a/crates/agent/src/pi.rs
+++ b/crates/agent/src/pi.rs
@@ -338,16 +338,15 @@ async fn run_actor(
              })
             .await;
     }
-    if opts.mcp_server.is_some()
-        || opts.orchestrate_server.is_some()
-        || opts.computer_use_server.is_some()
-    {
+    let unattached = unattached_servers(&opts);
+    if !unattached.is_empty() {
         actor
             .emit(AgentEvent::Warning {
-                message:
-                "pi RPC does not expose native MCP registration; configured tcode MCP servers were not attached"
-                    .into(),
-             })
+                message: format!(
+                    "pi has no MCP client of its own, so tcode's {} tools are unavailable in this session",
+                    unattached.join(", ")
+                ),
+            })
             .await;
     }
     if ready.send(Ok(())).await.is_err() {
@@ -487,6 +486,13 @@ impl PiActor {
                         ensure_success(&message)?;
                         return Ok(message);
                     }
+                    // Extensions load before this handshake completes, so the
+                    // one notification that explains a broken extension arrives
+                    // while we are still here. Everything else that lands early
+                    // belongs to the mapper, not to startup.
+                    if let Some(warning) = extension_warning(&message) {
+                        self.emit(AgentEvent::Warning { message: warning }).await;
+                    }
                 }
                 Ok(ChildOutput::Error(err)) => return Err(AgentError::Protocol(err)),
                 Ok(ChildOutput::Eof) | Err(_) => {
@@ -543,6 +549,10 @@ impl PiActor {
     async fn handle_extension_ui(&mut self, message: &Value) {
         let method = message.get("method").and_then(Value::as_str).unwrap_or("");
         if method != "confirm" {
+            if let Some(warning) = extension_warning(message) {
+                self.emit(AgentEvent::Warning { message: warning }).await;
+                return;
+            }
             if matches!(
                 method,
                 "notify" | "setStatus" | "setWidget" | "setTitle" | "set_editor_text"
@@ -1192,6 +1202,28 @@ fn approval_kind(tool_name: &str, payload: &Value) -> ApprovalKind {
     }
 }
 
+/// The text of a warning-or-worse `notify` from a pi extension.
+///
+/// pi's fire-and-forget UI methods expect no response, so an extension that
+/// reports trouble this way is otherwise invisible to the user — including a
+/// user's own installed extension explaining why it could not start.
+fn extension_warning(message: &Value) -> Option<String> {
+    if message.get("type").and_then(Value::as_str) != Some("extension_ui_request")
+        || message.get("method").and_then(Value::as_str) != Some("notify")
+    {
+        return None;
+    }
+    let level = message
+        .get("notifyType")
+        .and_then(Value::as_str)
+        .unwrap_or("info");
+    if !matches!(level, "warning" | "error") {
+        return None;
+    }
+    let text = message.get("message").and_then(Value::as_str)?.trim();
+    (!text.is_empty()).then(|| text.to_owned())
+}
+
 fn result_text(result: &Value) -> String {
     result
         .get("content")
@@ -1327,6 +1359,27 @@ fn pi_approval_mode(mode: ApprovalMode) -> &'static str {
         ApprovalMode::AutoAcceptEdits => "auto_accept_edits",
         ApprovalMode::FullAccess => "full_access",
     }
+}
+
+/// The tcode tool families this session does without, named the way the user
+/// knows them from Settings.
+///
+/// pi has no MCP client (its README: "No MCP"), and its RPC protocol exposes no
+/// registration hook, so every tcode MCP server stays behind. Naming them beats
+/// a blanket notice: the person reading it wants to know which tools went
+/// missing, not that a protocol lacks a feature.
+fn unattached_servers(opts: &SessionOptions) -> Vec<&'static str> {
+    let mut unattached = Vec::new();
+    if opts.mcp_server.is_some() {
+        unattached.push("preview browser");
+    }
+    if opts.orchestrate_server.is_some() {
+        unattached.push("orchestration");
+    }
+    if opts.computer_use_server.is_some() {
+        unattached.push("computer-use");
+    }
+    unattached
 }
 
 fn materialize_permission_extension() -> Result<PathBuf, AgentError> {
@@ -1488,6 +1541,35 @@ fn spawn_stderr_reader(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn only_warning_notifications_become_session_warnings() {
+        let notify = |level: &str| {
+            json!({
+                "type":"extension_ui_request",
+                "id":"1",
+                "method":"notify",
+                "message":"my-extension could not start",
+                "notifyType":level
+            })
+        };
+        assert_eq!(
+            extension_warning(&notify("warning")).as_deref(),
+            Some("my-extension could not start")
+        );
+        assert_eq!(
+            extension_warning(&notify("error")).as_deref(),
+            Some("my-extension could not start")
+        );
+        assert!(extension_warning(&notify("info")).is_none());
+        assert!(
+            extension_warning(&json!({
+                "type":"extension_ui_request","id":"1","method":"setStatus","statusText":"busy"
+            }))
+            .is_none()
+        );
+        assert!(extension_warning(&json!({"type":"agent_start"})).is_none());
+    }
 
     #[test]
     fn map_model_uses_supported_state_thinking_level_as_default() {

--- a/crates/agent/src/pi.rs
+++ b/crates/agent/src/pi.rs
@@ -224,24 +224,27 @@ async fn run_actor(
             return;
         }
     };
-    let extension = match materialize_permission_extension() {
-        Ok(path) => path,
-        Err(err) => {
-            let _ = ready.send(Err(err)).await;
-            return;
+    let extension = if gate_required(opts.approval_mode) {
+        match materialize_permission_extension() {
+            Ok(path) => Some(path),
+            Err(err) => {
+                let _ = ready.send(Err(err)).await;
+                return;
+            }
         }
+    } else {
+        None
     };
     let supports_settled =
         pi_version(&binary, &opts.launch_env).is_some_and(|version| version >= SETTLED_MIN_VERSION);
     let mut cmd = crate::process::command(&binary);
-    // Profile arguments are applied first. The transport, permission
+    // Profile arguments are applied first. The transport, optional permission
     // extension, resume target, and read-only tool set are tcode-owned and go
     // last so a profile cannot accidentally override the safety boundary.
-    cmd.args(&opts.extra_args)
-        .arg("--mode")
-        .arg("rpc")
-        .arg("--extension")
-        .arg(extension);
+    cmd.args(&opts.extra_args).arg("--mode").arg("rpc");
+    if let Some(extension) = extension {
+        cmd.arg("--extension").arg(extension);
+    }
     if let Some(thinking) = selected_thinking(&opts.option_selections) {
         cmd.arg("--thinking").arg(thinking);
     }
@@ -258,11 +261,13 @@ async fn run_actor(
     for (key, value) in opts.launch_env.pairs(ProviderKind::Pi) {
         cmd.env(key, value);
     }
-    cmd.env(
-        "TCODE_PI_APPROVAL_MODE",
-        pi_approval_mode(opts.approval_mode),
-    )
-    .env("TCODE_PI_CWD", &opts.cwd);
+    if gate_required(opts.approval_mode) {
+        cmd.env(
+            "TCODE_PI_APPROVAL_MODE",
+            pi_approval_mode(opts.approval_mode),
+        )
+        .env("TCODE_PI_CWD", &opts.cwd);
+    }
     let mut child = match cmd.spawn() {
         Ok(child) => child,
         Err(err) => {
@@ -1571,18 +1576,22 @@ fn pi_approval_mode(mode: ApprovalMode) -> &'static str {
     }
 }
 
+fn gate_required(mode: ApprovalMode) -> bool {
+    matches!(
+        mode,
+        ApprovalMode::Supervised | ApprovalMode::AutoAcceptEdits
+    )
+}
+
 /// The tcode tool families this session does without, named the way the user
 /// knows them from Settings.
 ///
 /// pi has no MCP client (its README: "No MCP"), and its RPC protocol exposes no
-/// registration hook, so every tcode MCP server stays behind. Naming them beats
-/// a blanket notice: the person reading it wants to know which tools went
-/// missing, not that a protocol lacks a feature.
+/// registration hook, so explicitly enabled tcode MCP servers stay behind.
+/// Naming them beats a blanket notice: the person reading it wants to know
+/// which opted-in tools went missing, not that a protocol lacks a feature.
 fn unattached_servers(opts: &SessionOptions) -> Vec<&'static str> {
     let mut unattached = Vec::new();
-    if opts.mcp_server.is_some() {
-        unattached.push("preview browser");
-    }
     if opts.orchestrate_server.is_some() {
         unattached.push("orchestration");
     }
@@ -1751,6 +1760,14 @@ fn spawn_stderr_reader(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn permission_gate_is_only_required_for_supervised_modes() {
+        assert!(gate_required(ApprovalMode::Supervised));
+        assert!(gate_required(ApprovalMode::AutoAcceptEdits));
+        assert!(!gate_required(ApprovalMode::FullAccess));
+        assert!(!gate_required(ApprovalMode::ReadOnly));
+    }
 
     #[test]
     fn extension_bash_approval_is_tool_use() {

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -108,6 +108,9 @@ pub struct ProviderSettings {
     /// Whether pi should trust and load the project's local `.pi` configuration.
     #[serde(default)]
     pub pi_trust_project_extensions: bool,
+    /// Whether tcode should inject its native approval extension into pi.
+    #[serde(default)]
+    pub pi_native_approvals: bool,
     /// Model slugs added by hand in the Models section.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub custom_models: Vec<String>,
@@ -136,6 +139,8 @@ pub struct ProfileConfigurationPatch {
     pub launch_args: Option<String>,
     #[serde(default)]
     pub pi_trust_project_extensions: bool,
+    #[serde(default)]
+    pub pi_native_approvals: bool,
     pub custom_models: Vec<String>,
     pub hidden_models: Vec<String>,
 }
@@ -155,6 +160,7 @@ impl Default for ProviderSettings {
             home_path: None,
             launch_args: None,
             pi_trust_project_extensions: false,
+            pi_native_approvals: false,
             custom_models: Vec::new(),
             hidden_models: Vec::new(),
         }
@@ -1014,14 +1020,17 @@ mod tests {
     fn pi_project_trust_defaults_off_and_round_trips() {
         let legacy: ProviderSettings = serde_json::from_str("{}").unwrap();
         assert!(!legacy.pi_trust_project_extensions);
+        assert!(!legacy.pi_native_approvals);
 
         let settings = ProviderSettings {
             pi_trust_project_extensions: true,
+            pi_native_approvals: true,
             ..ProviderSettings::default()
         };
         let json = serde_json::to_string(&settings).unwrap();
         let back: ProviderSettings = serde_json::from_str(&json).unwrap();
         assert!(back.pi_trust_project_extensions);
+        assert!(back.pi_native_approvals);
 
         let legacy_patch: ProfileConfigurationPatch = serde_json::from_str(
             r#"{
@@ -1037,6 +1046,7 @@ mod tests {
         )
         .unwrap();
         assert!(!legacy_patch.pi_trust_project_extensions);
+        assert!(!legacy_patch.pi_native_approvals);
     }
 
     #[test]

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -105,6 +105,9 @@ pub struct ProviderSettings {
     /// Native-provider CLI arguments appended on session start (ignored for Codex).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub launch_args: Option<String>,
+    /// Whether pi should trust and load the project's local `.pi` configuration.
+    #[serde(default)]
+    pub pi_trust_project_extensions: bool,
     /// Model slugs added by hand in the Models section.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub custom_models: Vec<String>,
@@ -131,6 +134,8 @@ pub struct ProfileConfigurationPatch {
     pub binary_path: Option<PathBuf>,
     pub home_path: Option<PathBuf>,
     pub launch_args: Option<String>,
+    #[serde(default)]
+    pub pi_trust_project_extensions: bool,
     pub custom_models: Vec<String>,
     pub hidden_models: Vec<String>,
 }
@@ -149,6 +154,7 @@ impl Default for ProviderSettings {
             binary_path: None,
             home_path: None,
             launch_args: None,
+            pi_trust_project_extensions: false,
             custom_models: Vec::new(),
             hidden_models: Vec::new(),
         }
@@ -1002,6 +1008,35 @@ mod tests {
         };
         assert_eq!(settings.extra_args(), vec!["--chrome", "--verbose"]);
         assert!(ProviderSettings::default().extra_args().is_empty());
+    }
+
+    #[test]
+    fn pi_project_trust_defaults_off_and_round_trips() {
+        let legacy: ProviderSettings = serde_json::from_str("{}").unwrap();
+        assert!(!legacy.pi_trust_project_extensions);
+
+        let settings = ProviderSettings {
+            pi_trust_project_extensions: true,
+            ..ProviderSettings::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        let back: ProviderSettings = serde_json::from_str(&json).unwrap();
+        assert!(back.pi_trust_project_extensions);
+
+        let legacy_patch: ProfileConfigurationPatch = serde_json::from_str(
+            r#"{
+                "display_name": null,
+                "accent_color": null,
+                "env": [],
+                "binary_path": null,
+                "home_path": null,
+                "launch_args": null,
+                "custom_models": [],
+                "hidden_models": []
+            }"#,
+        )
+        .unwrap();
+        assert!(!legacy_patch.pi_trust_project_extensions);
     }
 
     #[test]

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -2546,6 +2546,7 @@ impl AppState {
                 target.home_path = configuration.home_path;
                 target.launch_args = configuration.launch_args;
                 target.pi_trust_project_extensions = configuration.pi_trust_project_extensions;
+                target.pi_native_approvals = configuration.pi_native_approvals;
                 target.custom_models = configuration.custom_models;
                 target.hidden_models = configuration.hidden_models;
             }
@@ -6895,7 +6896,11 @@ impl AppState {
         self.emit_session_status(session_id, cx);
         let settings = self.settings.clone();
         let settings_store = self.settings_store.clone();
-        let preview_registration = self.preview_registration_for(&meta);
+        let preview_registration = if meta.provider == ProviderKind::Pi {
+            None
+        } else {
+            self.preview_registration_for(&meta)
+        };
         let orchestrate_registration = self.orchestrate_registration_for(&meta);
         let computer_use_registration = self.computer_use_registration.clone();
         let session_id = meta.id.clone();
@@ -8393,16 +8398,31 @@ fn session_options(
         .as_deref()
         .and_then(|id| settings.acp_agent(id))
         .cloned();
+    let approval_mode = if meta.provider == ProviderKind::Pi
+        && !provider_settings.pi_native_approvals
+    {
+        match meta.approval_mode {
+            ApprovalMode::Supervised | ApprovalMode::AutoAcceptEdits => ApprovalMode::FullAccess,
+            ApprovalMode::ReadOnly => ApprovalMode::ReadOnly,
+            ApprovalMode::FullAccess => ApprovalMode::FullAccess,
+        }
+    } else {
+        meta.approval_mode
+    };
     SessionOptions {
         cwd: meta.cwd.clone(),
         model: meta.model.clone(),
         resume: meta.resume_cursor.clone(),
         fork: meta.pending_fork,
         binary_path: provider_settings.binary_path.clone(),
-        approval_mode: meta.approval_mode,
+        approval_mode,
         option_selections: meta.option_selections.clone(),
         interaction_mode: meta.interaction_mode,
-        mcp_server,
+        mcp_server: if meta.provider == ProviderKind::Pi {
+            None
+        } else {
+            mcp_server
+        },
         orchestrate_server: if meta.orchestrate_enabled {
             orchestrate_server
         } else {
@@ -10231,6 +10251,79 @@ mod tests {
         let mcp = opts.mcp_server.expect("registration threaded through");
         assert_eq!(mcp.url, "http://127.0.0.1:7/mcp");
         assert_eq!(mcp.bearer_token, "tok");
+    }
+
+    #[test]
+    fn pi_session_options_coerce_modes_and_drop_preview_without_native_approvals() {
+        let settings = Settings::default();
+        let mut meta = SessionMeta::new(ProviderKind::Pi, PathBuf::from("/x"), None);
+        meta.approval_mode = ApprovalMode::Supervised;
+        let reg = agent::McpRegistration {
+            name: agent::McpRegistration::SERVER_NAME_PREVIEW.into(),
+            url: "http://127.0.0.1:7/mcp".into(),
+            bearer_token: "tok".into(),
+        };
+
+        let opts = session_options(
+            &meta,
+            &settings,
+            LaunchEnv::default(),
+            Some(reg),
+            None,
+            None,
+        );
+
+        assert_eq!(opts.approval_mode, ApprovalMode::FullAccess);
+        assert!(opts.mcp_server.is_none());
+        assert_eq!(meta.approval_mode, ApprovalMode::Supervised);
+
+        meta.approval_mode = ApprovalMode::AutoAcceptEdits;
+        let opts = session_options(&meta, &settings, LaunchEnv::default(), None, None, None);
+        assert_eq!(opts.approval_mode, ApprovalMode::FullAccess);
+
+        meta.approval_mode = ApprovalMode::ReadOnly;
+        let opts = session_options(&meta, &settings, LaunchEnv::default(), None, None, None);
+        assert_eq!(opts.approval_mode, ApprovalMode::ReadOnly);
+
+        meta.approval_mode = ApprovalMode::FullAccess;
+        let opts = session_options(&meta, &settings, LaunchEnv::default(), None, None, None);
+        assert_eq!(opts.approval_mode, ApprovalMode::FullAccess);
+    }
+
+    #[test]
+    fn pi_session_options_preserve_supervised_with_native_approvals() {
+        let mut settings = Settings::default();
+        settings.provider_mut(ProviderKind::Pi).pi_native_approvals = true;
+        let mut meta = SessionMeta::new(ProviderKind::Pi, PathBuf::from("/x"), None);
+        meta.approval_mode = ApprovalMode::Supervised;
+
+        let opts = session_options(&meta, &settings, LaunchEnv::default(), None, None, None);
+
+        assert_eq!(opts.approval_mode, ApprovalMode::Supervised);
+    }
+
+    #[test]
+    fn non_pi_session_options_preserve_mode_and_preview_registration() {
+        let settings = Settings::default();
+        let mut meta = SessionMeta::new(ProviderKind::ClaudeCode, PathBuf::from("/x"), None);
+        meta.approval_mode = ApprovalMode::AutoAcceptEdits;
+        let reg = agent::McpRegistration {
+            name: agent::McpRegistration::SERVER_NAME_PREVIEW.into(),
+            url: "http://127.0.0.1:7/mcp".into(),
+            bearer_token: "tok".into(),
+        };
+
+        let opts = session_options(
+            &meta,
+            &settings,
+            LaunchEnv::default(),
+            Some(reg),
+            None,
+            None,
+        );
+
+        assert_eq!(opts.approval_mode, ApprovalMode::AutoAcceptEdits);
+        assert!(opts.mcp_server.is_some());
     }
 
     #[test]

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -2545,6 +2545,7 @@ impl AppState {
                 target.binary_path = configuration.binary_path;
                 target.home_path = configuration.home_path;
                 target.launch_args = configuration.launch_args;
+                target.pi_trust_project_extensions = configuration.pi_trust_project_extensions;
                 target.custom_models = configuration.custom_models;
                 target.hidden_models = configuration.hidden_models;
             }
@@ -8416,8 +8417,13 @@ fn session_options(
         // Native providers that expose "Launch arguments" use their profile;
         // an ACP agent carries its own from the installed-agent card.
         extra_args: match meta.provider {
-            ProviderKind::ClaudeCode | ProviderKind::Pi | ProviderKind::OpenCode => {
-                provider_settings.extra_args()
+            ProviderKind::ClaudeCode | ProviderKind::OpenCode => provider_settings.extra_args(),
+            ProviderKind::Pi => {
+                let mut extra_args = provider_settings.extra_args();
+                if provider_settings.pi_trust_project_extensions {
+                    extra_args.push("--approve".into());
+                }
+                extra_args
             }
             ProviderKind::Codex => Vec::new(),
             ProviderKind::Acp => acp_agent
@@ -9950,6 +9956,8 @@ mod tests {
         claude.launch_args = Some("--chrome --verbose".into());
         let codex = settings.provider_mut(ProviderKind::Codex);
         codex.home_path = Some(PathBuf::from("/tmp/codex-shadow"));
+        let pi = settings.provider_mut(ProviderKind::Pi);
+        pi.launch_args = Some("--verbose".into());
 
         let launch_env = LaunchEnv {
             env: vec![("ANTHROPIC_BASE_URL".into(), "https://proxy.test".into())],
@@ -9981,6 +9989,17 @@ mod tests {
             opts.launch_env.pairs(ProviderKind::Codex),
             vec![("CODEX_HOME".to_string(), "/tmp/codex-shadow".to_string())]
         );
+
+        // pi project trust is opt-in and appends --approve after launch args.
+        let meta = SessionMeta::new(ProviderKind::Pi, PathBuf::from("/x"), None);
+        let opts = session_options(&meta, &settings, LaunchEnv::default(), None, None, None);
+        assert_eq!(opts.extra_args, vec!["--verbose"]);
+
+        settings
+            .provider_mut(ProviderKind::Pi)
+            .pi_trust_project_extensions = true;
+        let opts = session_options(&meta, &settings, LaunchEnv::default(), None, None, None);
+        assert_eq!(opts.extra_args, vec!["--verbose", "--approve"]);
     }
 
     /// Sensitive env rows contribute their value from `secrets.json`, never from

--- a/crates/services/src/settings.rs
+++ b/crates/services/src/settings.rs
@@ -169,6 +169,7 @@ mod tests {
                 binary_path: Some(PathBuf::from("/opt/tools/codex")),
                 home_path: Some(PathBuf::from("/tmp/codex-home")),
                 launch_args: None,
+                pi_trust_project_extensions: false,
                 custom_models: vec!["gpt-6.7-codex".into()],
                 hidden_models: vec!["gpt-5".into()],
             },

--- a/crates/services/src/settings.rs
+++ b/crates/services/src/settings.rs
@@ -170,6 +170,7 @@ mod tests {
                 home_path: Some(PathBuf::from("/tmp/codex-home")),
                 launch_args: None,
                 pi_trust_project_extensions: false,
+                pi_native_approvals: false,
                 custom_models: vec!["gpt-6.7-codex".into()],
                 hidden_models: vec!["gpt-5".into()],
             },

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -2269,14 +2269,19 @@ impl Composer {
         let current = self
             .workspace_store
             .read(cx)
-            .composer_pending_user_input(cx)
-            .map(|(id, _)| id);
-        if current != self.ui_request_id {
-            self.ui_request_id = current;
+            .composer_pending_user_input(cx);
+        let current_id = current.as_ref().map(|(id, _)| id.clone());
+        if current_id != self.ui_request_id {
+            self.ui_request_id = current_id;
             self.ui_question_index = 0;
             self.ui_selections.clear();
+            let prefill = current
+                .as_ref()
+                .and_then(|(_, questions)| questions.first())
+                .and_then(|question| question.prefill.as_deref())
+                .unwrap_or_default();
             self.user_input_custom.update(cx, |state, cx| {
-                state.set_value("", window, cx);
+                state.set_value(prefill, window, cx);
             });
         }
     }
@@ -2481,22 +2486,28 @@ impl Composer {
         let request_submit = request_id.clone();
         let mut actions = h_flex().w_full().gap_2().items_center();
         if index > 0 {
+            let questions_previous = questions.clone();
             actions = actions.child(
                 Button::new("ui-prev")
                     .ghost()
                     .small()
                     .label(tcode_i18n::tr!("userinput.previous"))
-                    .on_click(cx.listener(|this, _, _, cx| this.ui_go(-1, cx))),
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        this.ui_go(-1, &questions_previous, window, cx)
+                    })),
             );
         }
         actions = actions.child(div().flex_1());
         if !is_last {
+            let questions_next = questions.clone();
             actions = actions.child(
                 Button::new("ui-next")
                     .outline()
                     .small()
                     .label(tcode_i18n::tr!("userinput.next_question"))
-                    .on_click(cx.listener(|this, _, _, cx| this.ui_go(1, cx))),
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        this.ui_go(1, &questions_next, window, cx)
+                    })),
             );
         }
         if multi && all_answered {
@@ -2610,12 +2621,33 @@ impl Composer {
         cx.notify();
     }
 
-    fn ui_go(&mut self, delta: i32, cx: &mut Context<Self>) {
+    fn ui_go(
+        &mut self,
+        delta: i32,
+        questions: &[UserInputQuestion],
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let next = self.ui_question_index as i32 + delta;
         if next >= 0 {
             self.ui_question_index = next as usize;
+            self.seed_user_input_prefill(questions, window, cx);
             cx.notify();
         }
+    }
+
+    fn seed_user_input_prefill(
+        &mut self,
+        questions: &[UserInputQuestion],
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let prefill = questions
+            .get(self.ui_question_index)
+            .and_then(|question| question.prefill.as_deref())
+            .unwrap_or_default();
+        self.user_input_custom
+            .update(cx, |state, cx| state.set_value(prefill, window, cx));
     }
 
     /// After answering: jump to the next unanswered question, or — when the
@@ -2646,6 +2678,7 @@ impl Composer {
                     next_unanswered_question(&questions, &this.ui_selections, at)
                 {
                     this.ui_question_index = next;
+                    this.seed_user_input_prefill(&questions, window, cx);
                     cx.notify();
                 }
             });
@@ -5021,6 +5054,7 @@ mod tests {
                 description: String::new(),
             }],
             multi_select: false,
+            prefill: None,
         };
         let questions = vec![question("q1"), question("q2"), question("q3")];
         let mut selections = std::collections::HashMap::new();
@@ -5075,6 +5109,7 @@ mod tests {
                     },
                 ],
                 multi_select: false,
+                prefill: None,
             },
             UserInputQuestion {
                 id: "q2".into(),
@@ -5091,6 +5126,7 @@ mod tests {
                     },
                 ],
                 multi_select: true,
+                prefill: None,
             },
         ];
         let mut selections = std::collections::HashMap::new();

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -1610,6 +1610,10 @@ impl Composer {
     /// description, ✓ on the current one).
     fn render_permission_picker(&self, cx: &mut Context<Self>) -> AnyElement {
         let current = self.workspace_store.read(cx).composer_approval_mode(cx);
+        let native_approval_modes_enabled = self
+            .workspace_store
+            .read(cx)
+            .composer_native_approval_modes_enabled(cx);
         let (label, _, icon_path) = approval_mode_meta(current);
         let muted = cx.theme().muted_foreground;
 
@@ -1636,7 +1640,14 @@ impl Composer {
             .anchor(Anchor::BottomLeft)
             .trigger(trigger)
             .content(move |_, _, cx| {
-                render_permission_pane(current, pending_restart, &store_entity, &cx.entity(), cx)
+                render_permission_pane(
+                    current,
+                    pending_restart,
+                    native_approval_modes_enabled,
+                    &store_entity,
+                    &cx.entity(),
+                    cx,
+                )
             })
             .into_any_element()
     }
@@ -3939,6 +3950,7 @@ fn render_model_row(
 fn render_permission_pane(
     current: ApprovalMode,
     pending_restart: bool,
+    native_approval_modes_enabled: bool,
     store_entity: &Entity<WorkspaceStore>,
     popover: &Entity<PopoverState>,
     cx: &mut Context<PopoverState>,
@@ -3956,12 +3968,22 @@ fn render_permission_pane(
     for (index, (mode, label, description, icon_path)) in APPROVAL_MODES.iter().enumerate() {
         let mode = *mode;
         let is_current = mode == current;
+        let is_disabled = !native_approval_modes_enabled
+            && matches!(
+                mode,
+                ApprovalMode::Supervised | ApprovalMode::AutoAcceptEdits
+            );
         let store = store_entity.clone();
         let popover = popover.clone();
+        let disabled_hint = tcode_i18n::tr!("approval.pi_native_approvals_required");
         let accessible_label = tcode_i18n::tr!(
             "approval.mode_option",
             label = tcode_i18n::tr!(*label),
-            description = tcode_i18n::tr!(*description)
+            description = if is_disabled {
+                format!("{} {}", tcode_i18n::tr!(*description), disabled_hint)
+            } else {
+                tcode_i18n::tr!(*description).into_owned()
+            }
         )
         .into_owned();
         list = list.child(
@@ -3977,13 +3999,16 @@ fn render_permission_pane(
                 .gap_2()
                 .items_start()
                 .rounded(px(6.))
-                .cursor_pointer()
-                .hover(|s| s.bg(cx.theme().muted))
-                .on_click(move |_, window, cx| {
-                    store.update(cx, |store, cx| {
-                        store.dispatch(Command::SetActiveApprovalMode { mode }, cx)
-                    });
-                    popover.update(cx, |st, cx| st.dismiss(window, cx));
+                .when(is_disabled, |row| row.opacity(0.55))
+                .when(!is_disabled, |row| {
+                    row.cursor_pointer()
+                        .hover(|s| s.bg(cx.theme().muted))
+                        .on_click(move |_, window, cx| {
+                            store.update(cx, |store, cx| {
+                                store.dispatch(Command::SetActiveApprovalMode { mode }, cx)
+                            });
+                            popover.update(cx, |st, cx| st.dismiss(window, cx));
+                        })
                 })
                 .child(
                     Icon::empty()
@@ -4009,10 +4034,12 @@ fn render_permission_pane(
                                 }),
                         )
                         .child(
-                            div()
+                            v_flex()
+                                .gap_0p5()
                                 .text_size(px(11.))
                                 .text_color(muted)
-                                .child(tcode_i18n::tr!(*description)),
+                                .child(tcode_i18n::tr!(*description))
+                                .when(is_disabled, |text| text.child(disabled_hint)),
                         ),
                 ),
         );

--- a/crates/ui/src/provider_dialog.rs
+++ b/crates/ui/src/provider_dialog.rs
@@ -59,6 +59,7 @@ pub struct ProviderDialog {
     binary: Entity<InputState>,
     home: Entity<InputState>,
     launch_args: Entity<InputState>,
+    pi_trust_project_extensions: bool,
     custom_model: Entity<InputState>,
     slug_error: Option<String>,
     /// Draft accent (`#rrggbb`); applied on Save.
@@ -166,6 +167,7 @@ impl ProviderDialog {
             binary,
             home,
             launch_args,
+            pi_trust_project_extensions: settings.pi_trust_project_extensions,
             custom_model,
             slug_error: None,
             accent: settings.accent_color.clone(),
@@ -232,6 +234,7 @@ impl ProviderDialog {
         let binary = trimmed(&self.binary, cx);
         let home = trimmed(&self.home, cx);
         let launch = trimmed(&self.launch_args, cx);
+        let pi_trust_project_extensions = self.pi_trust_project_extensions;
         let accent = self.accent.clone();
         let custom = self.custom_models.clone();
         let hidden = self.hidden_models.clone();
@@ -257,6 +260,7 @@ impl ProviderDialog {
                                 ProviderKind::Codex => None,
                                 _ => launch,
                             },
+                            pi_trust_project_extensions,
                             custom_models: custom,
                             hidden_models: hidden,
                         }),
@@ -572,6 +576,26 @@ impl ProviderDialog {
                         .into(),
                     Input::new(&self.launch_args)
                         .rounded(crate::material::radius_input())
+                        .into_any_element(),
+                    cx,
+                ),
+            );
+        }
+        if provider == ProviderKind::Pi {
+            blocks.push(
+                self.field_block(
+                    tcode_i18n::tr!("providers.pi_trust_project_extensions")
+                        .into_owned()
+                        .into(),
+                    tcode_i18n::tr!("providers.pi_trust_project_extensions_help")
+                        .into_owned()
+                        .into(),
+                    Switch::new("pi-trust-project-extensions")
+                        .checked(self.pi_trust_project_extensions)
+                        .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                            this.pi_trust_project_extensions = *checked;
+                            cx.notify();
+                        }))
                         .into_any_element(),
                     cx,
                 ),

--- a/crates/ui/src/provider_dialog.rs
+++ b/crates/ui/src/provider_dialog.rs
@@ -60,6 +60,7 @@ pub struct ProviderDialog {
     home: Entity<InputState>,
     launch_args: Entity<InputState>,
     pi_trust_project_extensions: bool,
+    pi_native_approvals: bool,
     custom_model: Entity<InputState>,
     slug_error: Option<String>,
     /// Draft accent (`#rrggbb`); applied on Save.
@@ -168,6 +169,7 @@ impl ProviderDialog {
             home,
             launch_args,
             pi_trust_project_extensions: settings.pi_trust_project_extensions,
+            pi_native_approvals: settings.pi_native_approvals,
             custom_model,
             slug_error: None,
             accent: settings.accent_color.clone(),
@@ -235,6 +237,7 @@ impl ProviderDialog {
         let home = trimmed(&self.home, cx);
         let launch = trimmed(&self.launch_args, cx);
         let pi_trust_project_extensions = self.pi_trust_project_extensions;
+        let pi_native_approvals = self.pi_native_approvals;
         let accent = self.accent.clone();
         let custom = self.custom_models.clone();
         let hidden = self.hidden_models.clone();
@@ -261,6 +264,7 @@ impl ProviderDialog {
                                 _ => launch,
                             },
                             pi_trust_project_extensions,
+                            pi_native_approvals,
                             custom_models: custom,
                             hidden_models: hidden,
                         }),
@@ -561,6 +565,24 @@ impl ProviderDialog {
                     home_help(provider).into(),
                     Input::new(&self.home)
                         .rounded(crate::material::radius_input())
+                        .into_any_element(),
+                    cx,
+                ),
+            );
+            blocks.push(
+                self.field_block(
+                    tcode_i18n::tr!("providers.pi_native_approvals")
+                        .into_owned()
+                        .into(),
+                    tcode_i18n::tr!("providers.pi_native_approvals_help")
+                        .into_owned()
+                        .into(),
+                    Switch::new("pi-native-approvals")
+                        .checked(self.pi_native_approvals)
+                        .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                            this.pi_native_approvals = *checked;
+                            cx.notify();
+                        }))
                         .into_any_element(),
                     cx,
                 ),

--- a/crates/ui/src/store.rs
+++ b/crates/ui/src/store.rs
@@ -1720,10 +1720,40 @@ impl WorkspaceStore {
     }
 
     pub fn composer_approval_mode(&self, _cx: &App) -> agent::ApprovalMode {
-        self.session_status_replica
+        let mode = self
+            .session_status_replica
             .as_ref()
             .map(|status| status.approval_mode)
-            .unwrap_or_default()
+            .unwrap_or_default();
+        if !self.composer_native_approval_modes_enabled(_cx)
+            && matches!(
+                mode,
+                agent::ApprovalMode::Supervised | agent::ApprovalMode::AutoAcceptEdits
+            )
+        {
+            agent::ApprovalMode::FullAccess
+        } else {
+            mode
+        }
+    }
+
+    pub fn composer_native_approval_modes_enabled(&self, _cx: &App) -> bool {
+        let Some(status) = self.session_status_replica.as_ref() else {
+            return true;
+        };
+        if status.provider != agent::ProviderKind::Pi {
+            return true;
+        }
+        status
+            .requested_profile_id
+            .as_deref()
+            .and_then(|id| self.settings_replica.resolved_profile(id))
+            .map(|profile| profile.settings.pi_native_approvals)
+            .unwrap_or_else(|| {
+                self.settings_replica
+                    .provider(agent::ProviderKind::Pi)
+                    .pi_native_approvals
+            })
     }
 
     pub fn composer_approval_pending_restart(&self, _cx: &App) -> bool {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -304,7 +304,9 @@ faintest inset hairline. General: Language, Theme
 Delete confirmation, task-panel behavior, and provider update checks. The title
 model defaults to Codex `gpt-5.6-luna`; its isolated background request always
 uses `low` reasoning effort. Providers: Claude / Codex / pi / OpenCode
-configuration.
+configuration. Each pi profile includes an off-by-default "Trust project
+extensions" toggle; enabling it launches pi with `--approve` so the project's
+`.pi` extensions, settings, and skills are loaded for that session.
 
 Orchestrate begins with an explicit built-in `/orchestrate` explanation. Every
 main model is eligible: the page exposes one multiline generic identity plus

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -261,6 +261,9 @@ Approval panel (above composer): "PENDING APPROVAL" label, summary + count,
 expandable detail (command text / file list), actions Deny / Always allow /
 Approve (primary).
 
+Pi extension select, input, and editor dialogs surface through the native
+user-input panel, including editor prefill in its free-text field.
+
 ### Diff panel
 Right resizable split (default 560px, min 320px). Sidebar · chat · right panel
 are **one** resizable group: nesting a second group inside the chat panel does not

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -309,7 +309,14 @@ model defaults to Codex `gpt-5.6-luna`; its isolated background request always
 uses `low` reasoning effort. Providers: Claude / Codex / pi / OpenCode
 configuration. Each pi profile includes an off-by-default "Trust project
 extensions" toggle; enabling it launches pi with `--approve` so the project's
-`.pi` extensions, settings, and skills are loaded for that session.
+`.pi` extensions, settings, and skills are loaded for that session. pi also
+defaults to zero tcode injection: sessions run with effective Full access, no
+tcode permission extension, and no preview MCP registration. The off-by-default
+"Native approvals" toggle opts supervised and auto-accept-edits sessions into
+the tcode permission gate; without it those stored modes are effectively Full
+access while Read only remains enforced by pi's native tool filter. Because pi
+has no MCP client, its unattached-tools warning is emitted only for explicitly
+enabled orchestration or computer-use registrations.
 
 Orchestrate begins with an explicit built-in `/orchestrate` explanation. Every
 main model is eligible: the page exposes one multiline generic identity plus

--- a/docs/plans/pi-extension-support.md
+++ b/docs/plans/pi-extension-support.md
@@ -55,6 +55,21 @@
 
 验收：settings 回环/默认值测试、launch-args 测试、locale parity、全量门禁。
 
+## Module E — 默认零注入
+
+- `ProviderSettings` 增加默认关闭的 `pi_native_approvals`。关闭时不向 pi
+  注入 tcode 权限 extension 或相关环境变量；仅在 Supervised /
+  AutoAcceptEdits 且开关启用时注入权限门。ReadOnly 继续使用 pi 原生
+  `--tools read,grep,find,ls`。
+- runtime 只修改 `SessionOptions` 的有效审批模式，不改写持久化
+  `SessionMeta`：开关关闭时 Supervised / AutoAcceptEdits → FullAccess，
+  ReadOnly / FullAccess 保持不变；开关打开时全部保持原值。
+- pi 会话不再创建或传递 preview MCP registration。orchestrate 与
+  computer-use 仍是显式 opt-in，且是仅有的 unattached-MCP 警告来源。
+- composer 对关闭开关的 pi 会话将 Supervised / AutoAcceptEdits 显示为
+  禁用，并提示到 pi 提供方设置开启「原生审批」；当前高亮使用与 runtime
+  一致的有效 FullAccess，但保留存储偏好以便开启开关后恢复。
+
 ## 排期与派工
 
 前置：先提交当前未提交的 pi.rs 修复（MCP 警告措辞 + notify warning/error 冒泡），保证 clean tree。

--- a/docs/plans/pi-extension-support.md
+++ b/docs/plans/pi-extension-support.md
@@ -1,0 +1,70 @@
+# pi extension 支持 — 实施计划
+
+目标：用户安装的 pi extension 在 tcode 的 pi 会话中真正可用 —— 注册的工具能执行（经 tcode 原生审批）、UI 对话框能交互、注入的消息可见、项目级 `.pi/extensions` 可选择信任加载。
+
+前置事实（已核对到 file:line，两份调查报告为准）：
+
+- pi 的 `tool_call` 事件只有 `toolName`/`toolCallId`/`input`，无来源信息；但门 extension 可调 `pi.getAllTools()`，每条记录带 `sourceInfo { path, source, scope, origin }`，内置工具为 `source: "builtin"` / `path: "<builtin:name>"`（agent-session.js:613、source-info.d.ts:4）。注册表按名字只保留一个生效条目（agent-session.js:1954、1990），extension 覆盖内置后查询结果即实际执行的实现 —— 判定依据可靠。
+- 对话框协议（rpc-types.d.ts:384）：`select {title, options: string[], timeout?}`、`input {title, placeholder?, timeout?}`、`editor {title, prefill?}`（无 timeout）；响应 `{value}` / `{cancelled:true}`；confirm 用 `{confirmed:bool}`。pi 侧自行执行 timeout（rpc-mode.js:45），超时后迟到响应被忽略。
+- custom 消息：`message_end` 携带 `{role:"custom", customType, content: string|Array<Text|Image>, display, details?, timestamp}`（agent-session.js:1065）。
+- tcode 契约：`UserInputQuestion { id, header, question, options, multi_select }`（lib.rs:419）+ `RespondUserInput { request_id, answers }`（lib.rs:571）；composer 常驻自由文本输入框（composer.rs:2422），答案为 string 或 string[]。`ApprovalKind::ToolUse { name, input, detail }`（lib.rs:1105）；pi.rs 的 confirm 流对未知名工具已映射 ToolUse（pi.rs:1197），approve-for-session 按工具名缓存（pi.rs:654）。`ItemContent::Other` 渲染为 Work Log 单行（session.rs:1271、chat.rs:1916）。`message_end` 的 role 过滤在 pi.rs:993，`custom` 落 `_ => Vec::new()`。
+
+## Module A — 工具放行 + 内置名保护
+
+文件：`crates/agent/assets/pi/tcode-permissions.ts`、`crates/agent/src/pi.rs`
+
+- 门在 `tool_call` 时查 `pi.getAllTools().find(t => t.name === event.toolName)?.sourceInfo`：
+  - `source === "builtin"` → 现行策略不变（safe 集免确认、bash/edit/write 按模式）。
+  - 非 builtin（extension/sdk）→ `read_only`: block（`--tools` 白名单已在注册表层过滤，此为纵深防御）；`full_access`: 放行；其余模式: `ctx.ui.confirm("tcode:"+toolName, payload)`，payload 增加 `source: "extension"`、`extensionPath`、`shadowsBuiltin: bool`（name ∈ 内置七名时 true）。
+  - 查不到 sourceInfo → fail-closed block。
+- pi.rs `approval_kind`（pi.rs:1160）：payload 带 `source: "extension"` 时，即便 toolName 是 bash/edit/write 也映射为 `ToolUse`，detail 注明来源 extension 与是否覆盖内置 —— 防止 extension 代码以"普通 shell 命令"的样子出现在审批卡上。
+- approve-for-session 现有按名缓存直接适用。
+
+验收：`cargo test -p agent` 新增 approval_kind 测试（extension source → ToolUse，含 shadowed bash 用例）；脚本化 e2e（pi RPC + 最小 extension）：default 模式 hello_world → 收到 confirm 且 payload 带 source，回 confirmed:true 后工具真实执行；read_only 仍拦截；覆盖 `read` 的 extension 需审批而非免确认放行。
+
+## Module B — select/input/editor → 原生 UserInput
+
+文件：`crates/agent/src/pi.rs`、`crates/agent/src/lib.rs`、`crates/ui/src/composer.rs`
+
+- lib.rs：`UserInputQuestion` 增加 `#[serde(default)] pub prefill: Option<String>`（additive，codex/序列化不受影响）；composer 用它预填自由文本框（composer.rs:2422 一带）。
+- pi.rs `handle_extension_ui`：
+  - `select` → `UserInputRequested { request_id: id, questions: [{ id, header: "pi", question: title, options: options→{label, description:""}, multi_select: false }] }`
+  - `input` → 同上但无 options（placeholder 丢弃或并入 question 文案）
+  - `editor` → 无 options + prefill
+- `RespondUserInput` → `{"type":"extension_ui_response","id":…,"value":<string>}`；用户取消/无答案 → `{"cancelled":true}`。关联键就是顶层 `id`，照 confirm 现有 pending 模式管理；turn 结束时清理未决请求。
+- 启动握手期（`wait_response`）到达的对话框维持自动取消（彼时无 UI 可挂）。
+- 已知行为记录：select 的自由文本回答会原样传给 extension（协议 value 本就是 string）；pi 侧 timeout 过期后 tcode 的迟到回答被 pi 忽略。
+
+验收：pi.rs 单测覆盖三种方法的请求映射与响应回包（value / cancelled / turn 清理）；合入后真实 pi 手动 e2e。
+
+## Module C — custom 消息显示
+
+文件：`crates/agent/src/pi.rs`（pi.rs:993 的 role match）
+
+- `role == "custom"` 且 `display == true` → `ItemContent::Other { provider_kind: customType（缺省 "pi-extension"）, summary: 文本 content 拼接 }`；`display` false/缺省 → 丢弃；image 部分忽略（记录限制）。
+
+验收：单测 display true/false、content 为 string 与数组两种形态。
+
+## Module D — 项目信任开关（`--approve`）
+
+文件：`crates/core/src/settings.rs`、`crates/ui/src/provider_dialog.rs`、`crates/runtime/src/app.rs`、`crates/services/src/settings.rs`（测试字面量 settings.rs:153）、`locales/en.yml`、`locales/zh-CN.yml`、`docs/DESIGN.md`
+
+- `ProviderSettings` 增加 `#[serde(default)] pi_trust_project_extensions: bool`，`ProfileConfigurationPatch` 同步；provider_dialog 的 connection 区（provider_dialog.rs:536）渲染 pi-only 开关；app.rs `session_options` 为 true 时向 pi `extra_args` 追加 `"--approve"`（app.rs:8416 一带），扩展 app.rs:9946 launch-args 测试；双语 locale 同 key（parity 测试 i18n/src/lib.rs:111）；DESIGN.md 补 UI 变更。
+- 已知残留（不修，记录）：模型发现走 `pi --mode rpc --no-session` 且不带 launch args（pi.rs:65），项目 extension 注册的 provider 不会出现在模型列表。
+- 设计约束：信任决策发生在启动握手期，运行时提问会死锁，故只能做设置项。
+
+验收：settings 回环/默认值测试、launch-args 测试、locale parity、全量门禁。
+
+## 排期与派工
+
+前置：先提交当前未提交的 pi.rs 修复（MCP 警告措辞 + notify warning/error 冒泡），保证 clean tree。
+
+- Phase 1（并行，文件不相交）：Worker-A = Module A；Worker-D = Module D。均 codex/gpt-5.6-sol medium。
+- Phase 2（串行，均改 pi.rs）：Worker-BC = 先 Module C（小）再 Module B（最大块）。codex medium。
+- 每件工作：clean tree 派发 → 本人验 diff + 跑门禁（`cargo fmt --check`、`clippy --workspace --all-targets -D warnings`、`cargo test --workspace`）→ 通过即 commit。
+- 收尾：全 workspace 门禁一次 + 真实 pi e2e：一个示例 extension 走通四条链路（工具审批、select/input/editor、sendMessage 显示、项目目录信任加载）。
+
+## 范围外（记录备查）
+
+- `setStatus` / `setWidget` / `setTitle` 的 UI 落点；`notify` info 级。
+- extension 自发 turn（`sendUserMessage`/`triggerTurn`）产生的无主 `agent_start`，以及 `newSession`/`fork`/`switchSession` 造成的 pi sessionId 与 tcode resume cursor 失配 —— 真实一致性风险，实现 B 时若被触发再评估。

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -399,6 +399,8 @@ providers:
   launch_args_help: "Additional CLI arguments passed on session start."
   pi_trust_project_extensions: "Trust project extensions"
   pi_trust_project_extensions_help: "Launch pi with --approve so extensions, settings, and skills in the project's .pi directory are loaded."
+  pi_native_approvals: "Native approvals"
+  pi_native_approvals_help: "Inject a tcode permission extension into pi so supervised modes can confirm commands, edits, and extension tools natively. Off keeps pi sessions injection-free (full access)."
   models:
     title: "Models"
     count: "%{count} models available."
@@ -538,6 +540,7 @@ approval:
   auto_edits_description: "Auto-approve edits, ask before other actions."
   full_access: "Full access"
   full_access_description: "Allow commands and edits without prompts."
+  pi_native_approvals_required: "Enable Native approvals in the pi provider settings"
   command_requested: "Command approval requested"
   file_read_requested: "File-read approval requested"
   file_requested: "File-change approval requested"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -397,6 +397,8 @@ providers:
   home_help: "Custom home or data directory used by this provider instance."
   launch_args: "Launch arguments"
   launch_args_help: "Additional CLI arguments passed on session start."
+  pi_trust_project_extensions: "Trust project extensions"
+  pi_trust_project_extensions_help: "Launch pi with --approve so extensions, settings, and skills in the project's .pi directory are loaded."
   models:
     title: "Models"
     count: "%{count} models available."

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -393,6 +393,8 @@ providers:
   home_help: "该提供方实例使用的自定义主目录或数据目录。"
   launch_args: "启动参数"
   launch_args_help: "会话启动时额外传入的 CLI 参数。"
+  pi_trust_project_extensions: "信任项目扩展"
+  pi_trust_project_extensions_help: "以 --approve 启动 pi，加载项目 .pi 目录中的扩展、设置与技能。"
   models:
     title: "模型"
     count: "有 %{count} 个可用模型。"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -395,6 +395,8 @@ providers:
   launch_args_help: "会话启动时额外传入的 CLI 参数。"
   pi_trust_project_extensions: "信任项目扩展"
   pi_trust_project_extensions_help: "以 --approve 启动 pi，加载项目 .pi 目录中的扩展、设置与技能。"
+  pi_native_approvals: "原生审批"
+  pi_native_approvals_help: "向 pi 注入 tcode 权限扩展，使监督类模式可对命令、编辑与扩展工具进行原生确认。关闭则保持 pi 会话零注入（完全访问）。"
   models:
     title: "模型"
     count: "有 %{count} 个可用模型。"
@@ -532,6 +534,7 @@ approval:
   auto_edits_description: "自动批准编辑，执行其他操作前询问。"
   full_access: "完全访问"
   full_access_description: "无需提示即可执行命令和编辑。"
+  pi_native_approvals_required: "在 pi 提供方设置中开启「原生审批」后可用"
   command_requested: "请求批准执行命令"
   file_read_requested: "请求批准读取文件"
   file_requested: "请求批准修改文件"


### PR DESCRIPTION
## Summary

Makes user-installed pi extensions first-class inside tcode's pi sessions, while defaulting to **zero tcode injection** in keeping with pi's minimalism — instrumentation is something the user opts into, not something tcode imposes.

### Default experience (respects pi's philosophy)
- A pi session is now a bare `pi --mode rpc`: no injected extension, no injection env vars, no preview MCP token minting, no startup toast.
- Extension-registered tools run natively; extension `select`/`input`/`editor` dialogs surface through the native user-input panel (with editor prefill via a new optional `UserInputQuestion.prefill`); displayed `pi.sendMessage` messages appear as Work Log items; extension `notify` warnings/errors surface as session warnings.

### Opt-in toggles on the pi provider card (both off by default)
- **Native approvals** — injects the tcode permission gate for supervised / auto-accept-edits modes only. The gate resolves tool provenance via `pi.getAllTools()`: builtins keep the existing policy; extension tools go through native approval (approval card names the extension path); an extension shadowing a builtin name (`read`, `bash`, …) always requires approval and renders as ToolUse, never as a plain shell command; unresolvable provenance stays blocked fail-closed. Without the toggle, stored supervised modes are coerced to full access in SessionOptions only (the persisted preference survives), and the mode picker shows the supervised entries disabled with a pointer to the setting.
- **Trust project extensions** — launches pi with `--approve` so project-local `.pi` extensions/settings/skills load (pi's RPC mode never shows its interactive trust prompt).

### Warning policy
The "MCP tools unavailable" toast now fires only when orchestrate or computer-use were explicitly enabled but can't attach (pi has no MCP client); preview no longer triggers it.

## Test plan
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all green (new tests: gate mode matrix, approval mapping incl. shadowed builtins, dialog request/response/cleanup, custom-message display rules, session-options coercion + preview drop, settings round-trips, launch-args ordering, locale parity).
- Live pi e2e: extension tool confirmed + executed after approval; shadowed `read` gated instead of auto-allowed; denial honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)