### PR TITLE
fix(sidebar): surface sessions blocked on a user-input question

### DIFF
--- a/crates/protocol/src/event.rs
+++ b/crates/protocol/src/event.rs
@@ -182,6 +182,7 @@ pub struct SessionStatus {
     pub turn_running: bool,
     pub working: bool,
     pub pending_approval: bool,
+    pub pending_user_input: bool,
     pub supports_steering: bool,
     pub provider_option_descriptors: Vec<OptionDescriptor>,
     pub provider_option_selections: Vec<OptionSelection>,

--- a/crates/protocol/src/tests.rs
+++ b/crates/protocol/src/tests.rs
@@ -142,6 +142,7 @@ fn round_trips_top_level_wire_types() {
             turn_running: true,
             working: true,
             pending_approval: false,
+            pending_user_input: true,
             supports_steering: true,
             provider_option_descriptors: Vec::new(),
             provider_option_selections: vec![agent::OptionSelection {

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -1469,6 +1469,7 @@ impl AppState {
             turn_running: session.turn_in_flight,
             working: session.has_work(),
             pending_approval,
+            pending_user_input: session.timeline.pending_user_input.is_some(),
             supports_steering: session.supports_steering(),
             provider_option_descriptors,
             provider_option_selections: meta.option_selections.clone(),
@@ -7479,6 +7480,8 @@ impl AppState {
                 | AgentEvent::RewindCompleted { .. }
                 | AgentEvent::ApprovalRequested(_)
                 | AgentEvent::ApprovalResolved { .. }
+                | AgentEvent::UserInputRequested { .. }
+                | AgentEvent::UserInputResolved { .. }
         ) {
             self.emit_session_status(session_id, cx);
         }

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -1136,6 +1136,7 @@ impl SessionsSidebar {
         let ago = humanize_ago(now_secs().saturating_sub(meta.updated_at));
         let unread = self.store.read(cx).session_unread(&session_id, cx);
         let waiting_for_approval = self.store.read(cx).pending_approval_for(&session_id, cx);
+        let waiting_for_input = self.store.read(cx).pending_user_input_for(&session_id, cx);
         let is_worktree = meta.worktree.is_some();
         let render_state = {
             let sessions = self.store.read(cx).sidebar_sessions(cx);
@@ -1212,6 +1213,12 @@ impl SessionsSidebar {
                     .build(window, cx)
             })
         })
+        .when(waiting_for_input && !waiting_for_approval, |row| {
+            row.tooltip(|window, cx| {
+                Tooltip::new(tcode_i18n::tr!("sidebar.waiting_input_tooltip").into_owned())
+                    .build(window, cx)
+            })
+        })
         .when(waiting_for_approval, |row| {
             row.child(
                 h_flex()
@@ -1228,22 +1235,41 @@ impl SessionsSidebar {
                     ),
             )
         })
-        .when(working && !waiting_for_approval, |row| {
+        .when(waiting_for_input && !waiting_for_approval, |row| {
             row.child(
                 h_flex()
                     .flex_none()
                     .items_center()
                     .gap_1()
-                    .child(div().size(px(6.)).rounded_full().bg(cx.theme().success))
+                    .child(div().size(px(6.)).rounded_full().bg(cx.theme().warning))
                     .child(
                         div()
                             .whitespace_nowrap()
                             .text_size(px(11.))
-                            .text_color(cx.theme().success)
-                            .child(tcode_i18n::tr!("sidebar.working")),
+                            .text_color(cx.theme().warning)
+                            .child(tcode_i18n::tr!("sidebar.waiting_input")),
                     ),
             )
         })
+        .when(
+            working && !waiting_for_approval && !waiting_for_input,
+            |row| {
+                row.child(
+                    h_flex()
+                        .flex_none()
+                        .items_center()
+                        .gap_1()
+                        .child(div().size(px(6.)).rounded_full().bg(cx.theme().success))
+                        .child(
+                            div()
+                                .whitespace_nowrap()
+                                .text_size(px(11.))
+                                .text_color(cx.theme().success)
+                                .child(tcode_i18n::tr!("sidebar.working")),
+                        ),
+                )
+            },
+        )
         .when(is_child, |row| {
             row.child(
                 div()

--- a/crates/ui/src/store.rs
+++ b/crates/ui/src/store.rs
@@ -45,7 +45,7 @@ pub struct WorkspaceStore {
     session_status_replica: Option<SessionStatus>,
     providers_replica: ProvidersStatus,
     git_status_replica: GitStatusStatus,
-    background_session_flags: HashMap<String, (bool, bool)>,
+    background_session_flags: HashMap<String, (bool, bool, bool)>,
     active_destination: Option<ConversationDestination>,
     native_rewind_prefills: HashMap<String, String>,
     conversation_ui: ConversationUi,
@@ -344,7 +344,11 @@ impl WorkspaceStore {
                 } else {
                     self.background_session_flags.insert(
                         session_id.clone(),
-                        (status.working, status.pending_approval),
+                        (
+                            status.working,
+                            status.pending_approval,
+                            status.pending_user_input,
+                        ),
                     );
                 }
             }
@@ -515,7 +519,7 @@ impl WorkspaceStore {
             + self
                 .background_session_flags
                 .values()
-                .filter(|(working, _)| *working)
+                .filter(|(working, _, _)| *working)
                 .count()
     }
 
@@ -889,6 +893,19 @@ impl WorkspaceStore {
                 self.background_session_flags
                     .get(session_id)
                     .map(|flags| flags.1)
+            })
+            .unwrap_or(false)
+    }
+
+    pub fn pending_user_input_for(&self, session_id: &str, _cx: &App) -> bool {
+        self.session_status_replica
+            .as_ref()
+            .filter(|status| status.session_id == session_id)
+            .map(|status| status.pending_user_input)
+            .or_else(|| {
+                self.background_session_flags
+                    .get(session_id)
+                    .map(|flags| flags.2)
             })
             .unwrap_or(false)
     }
@@ -2377,6 +2394,59 @@ mod tests {
             workspace.read_with(cx, |store, cx| store.composer_review_comments(cx)),
             replica.review_comment_drafts
         );
+
+        shutdown_test_host(&host);
+        std::fs::remove_dir_all(root).expect("remove test data");
+    }
+
+    #[gpui::test]
+    fn background_session_status_tracks_pending_user_input(cx: &mut TestAppContext) {
+        let root = std::env::temp_dir().join(format!(
+            "tcode-background-user-input-status-test-{}",
+            tcode_services::store::now_millis()
+        ));
+        let session_store = SessionStore::open_at(root.clone()).expect("open test store");
+        let meta = SessionMeta::new(ProviderKind::Codex, root.join("worktree"), None);
+        let session_id = meta.id.clone();
+        session_store.upsert_meta(&meta).expect("persist session");
+
+        let host = test_host(session_store);
+        let workspace = cx.new(|cx| WorkspaceStore::new(host.clone(), cx));
+        command(
+            &host,
+            Command::SelectSession {
+                session_id: session_id.clone(),
+            },
+        );
+        wait_until(cx, &workspace, "selected session status", |cx| {
+            workspace.read_with(cx, |store, _| {
+                store
+                    .session_status_replica
+                    .as_ref()
+                    .is_some_and(|status| status.session_id == session_id)
+            })
+        });
+
+        let background_session_id = "background-session".to_string();
+        workspace.update(cx, |store, _| {
+            let mut status = store
+                .session_status_replica
+                .clone()
+                .expect("active session status");
+            status.session_id = background_session_id.clone();
+            status.pending_user_input = true;
+            store.apply_domain_event(&EventEnvelope {
+                topic: Topic::SessionStatus {
+                    session_id: background_session_id.clone(),
+                },
+                seq: 1,
+                event: ServerEvent::SessionStatusReplaced(status),
+            });
+        });
+
+        assert!(workspace.read_with(cx, |store, cx| {
+            store.pending_user_input_for(&background_session_id, cx)
+        }));
 
         shutdown_test_host(&host);
         std::fs::remove_dir_all(root).expect("remove test data");

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -110,6 +110,8 @@ sidebar:
   child_threads: "%{count} child threads"
   waiting_approval: "Approval"
   waiting_approval_tooltip: "Waiting for approval"
+  waiting_input: "Question"
+  waiting_input_tooltip: "Waiting for your answer"
   archive: "Archive thread"
   archive_title: "Archive thread?"
   archive_description: 'Archive "%{title}" and its saved conversation? This cannot be undone.'

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -110,6 +110,8 @@ sidebar:
   child_threads: "%{count} 个子对话"
   waiting_approval: "待审批"
   waiting_approval_tooltip: "正在等待审批"
+  waiting_input: "待回答"
+  waiting_input_tooltip: "正在等待你的回答"
   archive: "归档对话"
   archive_title: "归档对话？"
   archive_description: "要归档“%{title}”及其已保存的对话吗？此操作无法撤销。"


### PR DESCRIPTION
## Problem

A session blocked on a user-input question (Claude `AskUserQuestion` / Codex `requestUserInput` / pi extension dialogs) showed **no status at all** in the sidebar thread list — a background conversation could sit stalled waiting for an answer with the user none the wiser.

Historically questions rode the approval pipeline and lit the amber "Approval" pill. Commit 62486a64 split questions into a dedicated `UserInputRequested` event (for the structured composer UI), and #189 finished routing pi dialogs onto that channel — which never had a sidebar hookup.

## Fix

Mirror the waiting-approval pipeline end to end:

- `SessionStatus` gains `pending_user_input`, read from the session's timeline (works for active and background sessions; the timeline already clears it on resolve/turn-end/close).
- `UserInputRequested`/`UserInputResolved` join the status-broadcast trigger list, so the sidebar updates the moment a question arrives.
- The UI store's background-session flags carry the new bit, with a `pending_user_input_for` accessor.
- The sidebar renders an amber **Question / 待回答** pill, precedence: approval > question > working.

## Testing

- `cargo check --workspace` — clean
- `cargo test -p tcode-ui -p tcode-protocol -p tcode-runtime -p tcode-core` — 458 passed, including a new regression test: a `SessionStatusReplaced` for a non-active session with `pending_user_input=true` makes `pending_user_input_for` return true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)