### PR TITLE
fix(ui): pin input typography instead of inheriting window defaults

### DIFF
--- a/crates/ui/src/composer/components/user_input.rs
+++ b/crates/ui/src/composer/components/user_input.rs
@@ -181,10 +181,12 @@ impl Composer {
             .border_color(cx.theme().input)
             .bg(cx.theme().popover)
             .child(
-                div()
-                    .flex_1()
-                    .min_w_0()
-                    .child(Textarea::new(&self.user_input_custom).appearance(false)),
+                div().flex_1().min_w_0().child(
+                    Textarea::new(&self.user_input_custom)
+                        .appearance(false)
+                        // Match the 13px option rows around it.
+                        .text_size(px(13.)),
+                ),
             )
             .child(
                 crate::material::accessible_clickable(

--- a/crates/ui/src/composer/mod.rs
+++ b/crates/ui/src/composer/mod.rs
@@ -919,7 +919,14 @@ impl Render for Composer {
             })
             .when(has_terminal_contexts, |this| this.child(context_chips))
             .when(has_review_comments, |this| this.child(review_chips))
-            .child(Textarea::new(&self.input).appearance(false))
+            // Prose typography per the Beautiful UI spec (13.5px / 21px), so
+            // text reads the same while typed as it does once sent.
+            .child(
+                Textarea::new(&self.input)
+                    .appearance(false)
+                    .text_size(px(13.5))
+                    .line_height(px(21.)),
+            )
             .children(self.render_image_strip(cx))
             .child(control_row);
 

--- a/crates/ui/src/widgets/input.rs
+++ b/crates/ui/src/widgets/input.rs
@@ -5,7 +5,7 @@ use crate::{
 use gpui::{
     App, DefiniteLength, Edges, Entity, Focusable as _, IntoElement, ParentElement as _,
     RenderOnce, SharedString, StyleRefinement, Styled, TextAlign, Window,
-    prelude::FluentBuilder as _, px, relative,
+    prelude::FluentBuilder as _, px, rems,
 };
 use gpui_base::StyledExt as _;
 use gpui_base::{InputBase, RoleOverride};
@@ -141,7 +141,17 @@ impl RenderOnce for Input {
             .flex()
             .size_full()
             .items_center()
-            .line_height(relative(1.25))
+            // The editor inherits the ambient text style, so typography must
+            // be pinned here (upstream gpui-component convention): explicit
+            // per-size font size and a fixed line height, not one relative to
+            // whatever font size happens to cascade in.
+            .line_height(rems(1.25))
+            .map(|this| match self.size {
+                Size::XSmall => this.text_xs(),
+                Size::Small | Size::Medium => this.text_sm(),
+                Size::Large => this.text_base(),
+                Size::Size(v) => this.text_size(v * 0.875),
+            })
             .when(!multi_line, |this| match self.size {
                 Size::XSmall => this.h_5().px_1(),
                 Size::Small => this.h_6().px_2(),
@@ -149,9 +159,10 @@ impl RenderOnce for Input {
                 Size::Size(v) => this.h(v).px(v * 0.2),
                 Size::Medium => this.h_8().px_2p5(),
             })
+            // Multi-line insets come from the editor paddings above; padding
+            // the container as well doubles them.
             .when(multi_line, |this| {
                 this.h_auto()
-                    .p_2()
                     .when_some(self.height, |this, height| this.h(height))
             })
             .when(self.appearance, |this| {


### PR DESCRIPTION
## Problem

The composer input's text didn't match the surrounding UI. The Input/Textarea wrapper (`crates/ui/src/widgets/input.rs`, introduced in #212) reuses gpui_base's editor machinery but dropped the typography conventions of the upstream styled wrapper:

- No font size was ever set, and nothing in the ancestor chain sets one, so inputs inherited gpui's default window text style: 16px system font — while chat bubbles render at 13px and the Beautiful UI spec calls for 13.5px body prose.
- `line_height(relative(1.25))` only produced the intended 20px because of that inherited 16px; fixing the font size alone would have collapsed it to ~17px.
- Multi-line inputs were inset twice: 8px editor paddings **and** a `p_2()` on the container.

## Fix

- Wrapper now pins typography per the upstream gpui-component convention: explicit per-size text size (xs/sm/sm/base), fixed `rems(1.25)` line height, and container padding only for single-line inputs.
- The composer prompt overrides to the Beautiful UI prose spec (13.5px / 21px) so text reads the same while typed as it does once sent; the user-input custom answer matches its 13px option rows.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)