### PR TITLE
refactor(ui): inline the activity row argument, chevron right after the text

### DIFF
--- a/crates/ui/src/chat/components/activity.rs
+++ b/crates/ui/src/chat/components/activity.rs
@@ -109,7 +109,6 @@ pub(crate) fn activity_row(
             } else {
                 let summary = div()
                     .min_w_0()
-                    .flex_1()
                     .overflow_hidden()
                     .text_ellipsis()
                     .child(crate::tr!("chat.thinking_done"))
@@ -120,7 +119,6 @@ pub(crate) fn activity_row(
         EntryContent::ContextCompacted => {
             let summary = div()
                 .min_w_0()
-                .flex_1()
                 .overflow_hidden()
                 .text_ellipsis()
                 .text_color(muted)
@@ -188,7 +186,8 @@ pub(crate) fn activity_row(
 }
 
 /// A row summary in the tool-chips grammar: the bare verb, then its argument
-/// in the row's one and only surface — a 22px chip.
+/// as plain inline text. No surface of its own — the row packs left so the
+/// chevron sits right after the words, and only the argument shrinks.
 fn activity_summary(
     primary: impl IntoElement,
     argument: Option<AnyElement>,
@@ -197,7 +196,6 @@ fn activity_summary(
 ) -> AnyElement {
     h_flex()
         .min_w_0()
-        .flex_1()
         .gap_2()
         .overflow_hidden()
         .child(
@@ -209,27 +207,16 @@ fn activity_summary(
         )
         .when_some(argument, |row, argument| {
             row.child(
-                h_flex()
+                div()
                     .min_w_0()
-                    .flex_1()
-                    .h(px(22.))
-                    .px_1p5()
-                    .items_center()
                     .overflow_hidden()
-                    .rounded(crate::material::radius_chip())
-                    .bg(cx.theme().muted)
+                    .text_ellipsis()
                     .text_size(px(11.5))
                     .text_color(cx.theme().muted_foreground)
-                    .when(monospace, |chip| {
-                        chip.font_family(cx.theme().mono_font_family.clone())
+                    .when(monospace, |text| {
+                        text.font_family(cx.theme().mono_font_family.clone())
                     })
-                    .child(
-                        div()
-                            .min_w_0()
-                            .overflow_hidden()
-                            .text_ellipsis()
-                            .child(argument),
-                    ),
+                    .child(argument),
             )
         })
         .into_any_element()


### PR DESCRIPTION
Layout-only change to the Work Log activity row (`crates/ui/src/chat/components/activity.rs`).

## Before

`[status icon] [primary word] [ argument in a gray 22px rounded chip ] ..................... [chevron]`

The argument sat in its own surface (`radius_chip()` + `theme().muted`, fixed 22px height), and the summary container was `flex_1`, so it stretched across the row and pushed the expand chevron to the far right edge — far from the text it belongs to.

## After

`[status icon] [primary word] [argument] [chevron]` — everything packs left, empty space is to the right of the chevron.

- The argument renders as plain inline text: `muted_foreground`, `text_size(px(11.5))`, mono font when the `monospace` flag is set, single line with `text_ellipsis`.
- The summary container no longer grows (`min_w_0`, default shrink), so the chevron sits immediately after the content. The argument is the only part that shrinks and it still truncates cleanly at narrow widths; the chevron is `flex_shrink_0` and can never be pushed out of view.
- Same `flex_1` removal applied to the two inline summaries (reasoning-done, context-compacted) so those rows pack left too.

Unchanged: the in-progress spinner, danger coloring for failed rows, hover pill + `accessible_clickable` wiring, `aria_expanded`, the expanded detail section, and which entries are expandable. `CommandExecution`'s break-marker highlighting still passes through.

## Checks

- `cargo fmt --all --check` — pass
- `cargo clippy -p tcode-ui --all-targets --locked -- -D warnings` — pass
- `cargo test -p tcode-ui --locked` — pass (251 + 1 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)