### PR TITLE
Refill composer when removing a queued message

### DIFF
--- a/crates/ui/src/composer/components/queue_strip.rs
+++ b/crates/ui/src/composer/components/queue_strip.rs
@@ -63,6 +63,7 @@ impl Composer {
 
         for (index, message) in queued.into_iter().enumerate() {
             let id = message.id;
+            let text = message.text.clone();
             let scheduled = message.fire_at_unix_secs.is_some();
             let steer_tooltip = if scheduled {
                 crate::tr!("composer.send_now").into_owned()
@@ -127,9 +128,8 @@ impl Composer {
                             .xsmall()
                             .icon(IconName::Close)
                             .tooltip(crate::tr!("composer.drop_queued"))
-                            .on_click(cx.listener(move |this, _, _, cx| {
-                                this.workspace_store
-                                    .update(cx, |store, _cx| store.drop_queued(id));
+                            .on_click(cx.listener(move |this, _, window, cx| {
+                                this.drop_queued_and_refill(id, text.clone(), window, cx);
                             })),
                     ),
             );

--- a/crates/ui/src/composer/mod.rs
+++ b/crates/ui/src/composer/mod.rs
@@ -317,6 +317,29 @@ impl Composer {
         self.recompute_trigger(cx);
     }
 
+    /// Remove a queued message and return its text to the composer for editing.
+    /// Selecting the replacement lets the user discard it with one keystroke,
+    /// while queued attachments are deliberately ignored.
+    fn drop_queued_and_refill(
+        &mut self,
+        id: u64,
+        text: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.workspace_store
+            .update(cx, |store, _cx| store.drop_queued(id));
+        let selection = 0..text.len();
+        self.input.update(cx, |state, cx| {
+            state.set_value(text, window, cx);
+            state
+                .base_state()
+                .update(cx, |state, cx| state.set_selected_range(selection, cx));
+            state.focus(window, cx);
+        });
+        self.recompute_trigger(cx);
+    }
+
     /// Whether `submit` has anything to send. Keep the primary-action choice on
     /// this same predicate so attachment/context-only drafts never masquerade
     /// as an empty plan that Enter would implement.

--- a/crates/ui/src/composer/mod.rs
+++ b/crates/ui/src/composer/mod.rs
@@ -332,9 +332,7 @@ impl Composer {
         let selection = 0..text.len();
         self.input.update(cx, |state, cx| {
             state.set_value(text, window, cx);
-            state
-                .base_state()
-                .update(cx, |state, cx| state.set_selected_range(selection, cx));
+            state.set_selected_range(selection, cx);
             state.focus(window, cx);
         });
         self.recompute_trigger(cx);


### PR DESCRIPTION
## Summary

- remove the selected queued message as before
- replace the composer draft with the queued message text
- select all restored text and focus the composer input
- ignore queued attachments when refilling

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p tcode-ui --all-targets --locked -- -D warnings`
- `cargo test -p tcode-ui --locked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)