### PR TITLE
chore: drop dev-profile opt-level override for dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,6 @@ members = [
 resolver = "3"
 default-members = ["crates/app"]
 
-# Debug FPS: gpui/taffy layout+paint are unusable at opt-level 0, and taffy's
-# generics are instantiated inside gpui, so deps must be optimized wholesale.
-# Workspace crates stay at opt-level 0 for debugging.
-[profile.dev.package."*"]
-opt-level = 2
-
 [profile.release]
 opt-level = 3
 lto = "fat"


### PR DESCRIPTION
Removes the `[profile.dev.package."*"] opt-level = 2` block from the workspace manifest. Compiling every dependency at opt-level 2 made CI's dev-profile jobs (clippy, workspace tests) substantially slower than necessary.

Trade-off: the override existed for debug-run FPS (gpui/taffy layout+paint are slow at opt-level 0). If local debug runs become unusable, the fix is a narrower override targeting just gpui/taffy rather than every dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)