### PR TITLE
perf: throttle inactive main window to ~2 FPS

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -322,6 +322,10 @@ fn main() {
                 // Persistent windows use the platform's system material:
                 // macOS blur, Windows Acrylic, or an opaque fallback.
                 window_background: main_window_background(),
+                // Throttle background redraws (spinners, streaming output) to
+                // ~2 FPS while the window is inactive; gpui lifts the cap the
+                // moment the window is active or receiving high-rate input.
+                inactive_frame_interval: Some(Duration::from_millis(500)),
                 ..Default::default()
             };
 


### PR DESCRIPTION
## Summary

gpui rev `30f7370` (already our locked rev) added `WindowOptions.inactive_frame_interval`: when a window is inactive and not receiving high-rate input, redraws are capped at the given interval; full frame rate is restored the moment the window becomes active. Set 500 ms on the main window so background spinners and streaming-output redraws stop burning CPU/GPU while tcode is unfocused.

Mirrors longbridge/gpui-component#2749 — the useful part of that PR is the upstream gpui API, so we benefit directly despite using `gpui-base`.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo check -p tcode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)