### PR TITLE
feat: promote compaction, orchestrate, and callback rows to centered dividers

### DIFF
--- a/crates/ui/src/chat/components/activity.rs
+++ b/crates/ui/src/chat/components/activity.rs
@@ -113,20 +113,6 @@ pub(crate) fn activity_row(
                 )
             }
         }
-        EntryContent::ContextCompacted => {
-            let summary = div()
-                .min_w_0()
-                .overflow_hidden()
-                .text_ellipsis()
-                .text_color(muted)
-                .child(crate::tr!("chat.context_compacted"))
-                .into_any_element();
-            (
-                ItemStatus::Completed,
-                Icon::new(IconName::Minimize),
-                summary,
-            )
-        }
         _ => (
             ItemStatus::Completed,
             Icon::new(IconName::Info),

--- a/crates/ui/src/chat/components/disclosure.rs
+++ b/crates/ui/src/chat/components/disclosure.rs
@@ -52,9 +52,10 @@ pub(crate) fn callback_row(
     )
 }
 
-/// A naked disclosure row with a height-capped verbatim body: a hugging,
-/// left-aligned header led by a chevron, so it reads as an expandable row of
-/// the flow rather than an ambient divider.
+/// A centered disclosure notification with a height-capped verbatim body: the
+/// divider grammar's stub–label–stub row, with the label clickable to expand.
+/// Orchestrate context and child-thread results read as ambient notifications
+/// of the flow — the same standing as a relay or model-change divider.
 pub(crate) fn disclosure(
     key: &str,
     label: SharedString,
@@ -64,7 +65,7 @@ pub(crate) fn disclosure(
     cx: &App,
 ) -> AnyElement {
     let muted = cx.theme().muted_foreground;
-    let row = crate::material::accessible_clickable(
+    let toggle = crate::material::accessible_clickable(
         h_flex(),
         SharedString::from(format!("disclosure-{key}")),
         Role::Button,
@@ -72,19 +73,28 @@ pub(crate) fn disclosure(
         cx,
     )
     .aria_expanded(expanded)
-    .self_start()
-    .h(px(28.))
+    .flex_none()
+    .h(px(24.))
     .px_1p5()
     .gap_1p5()
     .items_center()
     .rounded(crate::material::radius_button())
-    .text_size(px(12.5))
+    .text_size(px(11.))
     .text_color(muted)
     .cursor_pointer()
     .hover(|row| row.bg(cx.theme().accent))
     .on_click(on_toggle)
     .child(Icon::new(chevron(expanded)).size(px(12.)).text_color(muted))
     .child(label);
+
+    let row = h_flex()
+        .w_full()
+        .items_center()
+        .justify_center()
+        .gap_2()
+        .child(super::dividers::divider_stub(cx))
+        .child(toggle)
+        .child(super::dividers::divider_stub(cx));
 
     let mut block = v_flex().w_full().gap_1().child(row);
     if expanded {

--- a/crates/ui/src/chat/components/dividers.rs
+++ b/crates/ui/src/chat/components/dividers.rs
@@ -1,7 +1,7 @@
 use crate::theme::ActiveTheme as _;
 use agent::ProviderKind;
 use gpui::{
-    AnyElement, App, Hsla, InteractiveElement as _, IntoElement as _, ParentElement as _,
+    AnyElement, App, Div, Hsla, InteractiveElement as _, IntoElement as _, ParentElement as _,
     SharedString, Styled as _, div, px,
 };
 use gpui_base::h_flex;
@@ -10,11 +10,17 @@ use gpui_base::h_flex;
 /// full-width rule would cut the flow in two, and these events only annotate it.
 const STUB_WIDTH: f32 = 24.;
 
+/// One hairline stub of the divider grammar, shared with the centered
+/// disclosure rows so every ambient notification flanks its label identically.
+pub(crate) fn divider_stub(cx: &App) -> Div {
+    div().h(px(1.)).w(px(STUB_WIDTH)).bg(cx.theme().border)
+}
+
 /// The one divider grammar: a centered 11px label between two hairline stubs.
 /// `tint` colors the label alone — the rules stay border-quiet no matter what
 /// the event is, so no divider can shout louder than another.
 fn divider(id: SharedString, label: String, tint: Hsla, cx: &App) -> AnyElement {
-    let stub = || div().h(px(1.)).w(px(STUB_WIDTH)).bg(cx.theme().border);
+    let stub = || divider_stub(cx);
     h_flex()
         .id(id)
         .w_full()
@@ -72,6 +78,17 @@ pub(crate) fn model_change_divider(
     divider(
         SharedString::from(format!("model-change-{id}")),
         label,
+        cx.theme().warning,
+        cx,
+    )
+}
+
+/// Context compaction rewrites what the model remembers, so it announces
+/// itself at model-swap prominence rather than hiding in the work log.
+pub(crate) fn context_compacted_divider(id: &str, cx: &App) -> AnyElement {
+    divider(
+        SharedString::from(format!("context-compacted-{id}")),
+        crate::tr!("chat.context_compacted").into_owned(),
         cx.theme().warning,
         cx,
     )

--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -309,6 +309,12 @@ impl ChatView {
                         cx,
                     ));
                 }
+                Segment::ContextCompacted(entry) => {
+                    column = column.child(components::dividers::context_compacted_divider(
+                        &entry.id,
+                        cx,
+                    ));
+                }
                 Segment::ActivityRun(activities) => {
                     let segment_id = activities[0].id.as_str();
                     column = column.child(self.compose_work_log(

--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -311,8 +311,7 @@ impl ChatView {
                 }
                 Segment::ContextCompacted(entry) => {
                     column = column.child(components::dividers::context_compacted_divider(
-                        &entry.id,
-                        cx,
+                        &entry.id, cx,
                     ));
                 }
                 Segment::ActivityRun(activities) => {

--- a/crates/ui/src/chat/model.rs
+++ b/crates/ui/src/chat/model.rs
@@ -26,6 +26,7 @@ pub(crate) enum Segment<'a> {
     ActivityRun(Vec<&'a TimelineEntry>),
     Relay(&'a TimelineEntry),
     ModelChange(&'a TimelineEntry),
+    ContextCompacted(&'a TimelineEntry),
     User(&'a TimelineEntry),
     Assistant(&'a TimelineEntry),
     Error(&'a TimelineEntry),
@@ -132,7 +133,6 @@ pub(crate) fn segment_entries<'a>(
             | EntryContent::Item(ItemContent::Subagent { .. })
             | EntryContent::Item(ItemContent::WebSearch { .. })
             | EntryContent::Item(ItemContent::Other { .. })
-            | EntryContent::ContextCompacted
             | EntryContent::Item(ItemContent::FileChange { .. }) => activities.push(entry),
             EntryContent::Item(ItemContent::Reasoning { .. }) => activities.push(entry),
             EntryContent::Item(ItemContent::UserMessage { .. }) | EntryContent::Steer { .. } => {
@@ -146,6 +146,10 @@ pub(crate) fn segment_entries<'a>(
             EntryContent::ModelChanged { .. } => {
                 flush_activities(&mut segments, &mut activities);
                 segments.push(Segment::ModelChange(entry));
+            }
+            EntryContent::ContextCompacted => {
+                flush_activities(&mut segments, &mut activities);
+                segments.push(Segment::ContextCompacted(entry));
             }
             EntryContent::Item(ItemContent::AssistantMessage { .. }) => {
                 flush_activities(&mut segments, &mut activities);
@@ -183,7 +187,6 @@ pub(crate) struct WorkLogCounts {
     pub(crate) files: usize,
     pub(crate) tools: usize,
     pub(crate) subagents: usize,
-    pub(crate) compactions: usize,
 }
 
 pub(crate) fn work_log_counts(entries: &[&TimelineEntry]) -> WorkLogCounts {
@@ -200,8 +203,8 @@ pub(crate) fn work_log_counts(entries: &[&TimelineEntry]) -> WorkLogCounts {
             | EntryContent::Item(ItemContent::WebSearch { .. })
             | EntryContent::Item(ItemContent::Other { .. }) => counts.tools += 1,
             EntryContent::Item(ItemContent::Subagent { .. }) => counts.subagents += 1,
-            EntryContent::ContextCompacted => counts.compactions += 1,
-            EntryContent::Steer { .. }
+            EntryContent::ContextCompacted
+            | EntryContent::Steer { .. }
             | EntryContent::Item(ItemContent::UserMessage { .. })
             | EntryContent::Item(ItemContent::AssistantMessage { .. })
             | EntryContent::Item(ItemContent::Reasoning { .. })
@@ -1579,7 +1582,6 @@ mod tests {
             files: 3,
             tools: 1,
             subagents: 2,
-            compactions: 1,
         };
 
         crate::set_locale(crate::LANGUAGE_ENGLISH);


### PR DESCRIPTION
## Summary
- Context compaction is now a first-class centered divider (warning tint, model-change prominence) via a new `Segment::ContextCompacted`, instead of folding into the work log's activity rows
- The orchestrate-skill context row and child-thread callback result rows adopt the same stub–label–stub divider grammar: a centered clickable label that still expands to the verbatim body
- Removed the now-unused `compactions` work-log count (it was tallied but never rendered)

## Test plan
- `cargo test -p tcode-ui` — 254 tests pass
- `cargo check -p tcode-ui --examples` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)