### PR TITLE
fix(ui): make work log capsules honest about their contents

### DIFF
--- a/crates/ui/src/chat/components/work_log.rs
+++ b/crates/ui/src/chat/components/work_log.rs
@@ -10,7 +10,6 @@ use gpui::{
 };
 use gpui_base::{StyledExt as _, h_flex, v_flex};
 
-use super::super::model::WorkLogCounts;
 use tcode_core::session::{TimelineEntry, TurnMeta};
 
 pub(crate) type WorkLogArgs<'a> = (
@@ -19,7 +18,6 @@ pub(crate) type WorkLogArgs<'a> = (
     &'a TurnMeta,
     &'a Path,
     &'a [&'a TimelineEntry],
-    &'a WorkLogCounts,
     bool,
 );
 

--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -257,6 +257,14 @@ impl ChatView {
         cx.notify();
     }
 
+    fn promote_auto_expanded(&mut self, turn: usize, key: &str, cx: &mut Context<Self>) {
+        self.expanded.insert(manual_override_key(key));
+        self.expanded.insert(key.to_string());
+        self.sync_markdown_states(cx);
+        self.list_state.remeasure_items(turn..turn + 1);
+        cx.notify();
+    }
+
     // -- turn rendering -----------------------------------------------------
 
     /// Render one turn as chronological messages, errors, and Work Log runs.
@@ -275,8 +283,6 @@ impl ChatView {
 
         let segmented = segment_entries(entries, turn.running);
         let segments = &segmented.flow;
-        let turn_entries: Vec<&TimelineEntry> = entries.iter().map(AsRef::as_ref).collect();
-        let turn_counts = work_log_counts(&turn_entries);
         let last_activity_segment = live_activity_segment(segments, turn.running);
 
         for (segment_index, segment) in segments.iter().enumerate() {
@@ -318,7 +324,6 @@ impl ChatView {
                             turn,
                             cwd,
                             activities,
-                            &turn_counts,
                             last_activity_segment == Some(segment_index),
                         ),
                         cx,
@@ -659,7 +664,7 @@ impl ChatView {
         args: components::work_log::WorkLogArgs<'_>,
         cx: &mut Context<Self>,
     ) -> AnyElement {
-        let (index, segment_id, turn, cwd, activities, turn_counts, is_last) = args;
+        let (index, segment_id, turn, cwd, activities, is_last) = args;
         let section_key = format!("worklog-{index}-{segment_id}");
         let running = is_last && turn.running;
         let automatic = work_log_auto_expands(activities, turn.running, is_last);
@@ -667,12 +672,7 @@ impl ChatView {
         let manually_expanded =
             expanded && (self.expanded.contains(&manual_override_key(&section_key)) || !automatic);
         let segment_counts = work_log_counts(activities);
-        let counts = if is_last {
-            turn_counts
-        } else {
-            &segment_counts
-        };
-        let mut capsule_label = work_log_capsule_label(counts, activities.len());
+        let mut capsule_label = work_log_capsule_label(&segment_counts, activities.len());
         if capsule_label.is_empty() {
             capsule_label = crate::tr!("chat.work_log").into_owned();
         }
@@ -709,6 +709,7 @@ impl ChatView {
         }
 
         let toggle_section_key = section_key;
+        let ticker_expanded = expanded && !manually_expanded;
         components::work_log::work_log(
             components::work_log::WorkLogData {
                 index,
@@ -721,7 +722,11 @@ impl ChatView {
                 rows,
             },
             cx.listener(move |this, _, _, cx| {
-                this.toggle_auto_expanded(index, &toggle_section_key, automatic, cx);
+                if ticker_expanded {
+                    this.promote_auto_expanded(index, &toggle_section_key, cx);
+                } else {
+                    this.toggle_auto_expanded(index, &toggle_section_key, automatic, cx);
+                }
             }),
             cx,
         )

--- a/crates/ui/src/chat/model.rs
+++ b/crates/ui/src/chat/model.rs
@@ -165,7 +165,7 @@ pub(crate) fn segment_entries<'a>(
 }
 
 /// Which segment, if any, is the turn's *live* work log — the one that opens on
-/// its own and reports the turn's totals.
+/// its own while the turn is running.
 ///
 /// A running turn whose last segment is prose has none: liveness is carried by
 /// the turn-level working indicator standing bare after every segment, so every
@@ -1498,7 +1498,7 @@ mod tests {
         // to host it, and the earlier run has already settled.
         assert_eq!(segments.len(), 2);
         assert_eq!(live_activity_segment(&segments, true), None);
-        // Once the turn ends, that same run carries the turn's snapshot.
+        // Once the turn ends, that same run is the final settled work log.
         assert_eq!(live_activity_segment(&segments, false), Some(0));
 
         let activity_tail = [entry("assistant", assistant("answer")), command("cmd")];
@@ -1763,14 +1763,14 @@ mod tests {
     }
 
     #[test]
-    fn finished_activity_runs_show_nonzero_segment_counts() {
+    fn finished_activity_runs_use_segment_scoped_counts() {
         let _locale_guard = crate::settings::TestLocaleGuard::acquire();
         let entries = [
             command("command-1"),
             file_change("files-1", &["src/shared.rs"]),
             entry("assistant", assistant("intermediate output")),
             command("command-2"),
-            file_change("files-2", &["src/shared.rs"]),
+            command("command-3"),
         ];
         let segments = segment_entries(&entries, false).flow;
         let activity_indexes: Vec<usize> = segments
@@ -1783,7 +1783,7 @@ mod tests {
         assert_eq!(activity_indexes.len(), 2);
 
         let counts = work_log_counts(&refs(&entries));
-        assert_eq!(counts.commands, 2);
+        assert_eq!(counts.commands, 3);
         assert_eq!(counts.files, 1);
 
         let labels = || {
@@ -1799,9 +1799,9 @@ mod tests {
                 .collect::<Vec<_>>()
         };
         crate::set_locale(crate::LANGUAGE_ENGLISH);
-        assert_eq!(labels(), ["1 edit · 1 command", "1 edit · 1 command"]);
+        assert_eq!(labels(), ["1 edit · 1 command", "2 commands"]);
         crate::set_locale(crate::LANGUAGE_SIMPLIFIED_CHINESE);
-        assert_eq!(labels(), ["1 处编辑 · 1 条命令", "1 处编辑 · 1 条命令"]);
+        assert_eq!(labels(), ["1 处编辑 · 1 条命令", "2 条命令"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Users saw work log capsules claiming many activities while expanding revealed only one, with no apparent way to reach the rest. Two causes, both fixed:

- **Segment-scoped capsule labels**: the last activity segment of a turn labeled its capsule with whole-turn counts (`turn_counts`) while its body only rendered that segment's own rows — the header claimed activities the fold could never reveal. Labels now always use the segment's own counts, and the unused turn-counts plumbing is removed.
- **Ticker click promotes instead of collapsing**: a running turn's live work log auto-expands as a two-row ticker (often one real activity plus the live thinking row). Its chevron already read "expanded", and clicking it collapsed the capsule; a second click was needed to see everything. The first click on a ticker now promotes it to full manual expansion. Subagent rows keep their existing toggle semantics.

An audit replaying 10 real session logs through `Timeline::fold_events` + the fold pipeline confirmed no third bug: across 380+ activity segments, manual expansion always renders exactly the segment's entries, and every raw-vs-timeline count difference was benign cross-turn lifecycle attribution (`gone=[]` everywhere).

## Test plan
- `cargo fmt --all --check` — clean
- `cargo test -p tcode-ui` — 253 + 1 tests pass (including updated segment-count label tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)