### PR TITLE
fix(ui): make image paste intercept the editor's Paste action

### DIFF
--- a/crates/ui/src/composer/components/images.rs
+++ b/crates/ui/src/composer/components/images.rs
@@ -208,11 +208,12 @@ impl Composer {
     }
 
     /// Pull an image off the clipboard (⌘V with image content), if present.
+    /// Returns whether an image was accepted.
     pub(in super::super) fn paste_clipboard_image(
         &mut self,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) {
+    ) -> bool {
         let mut accepted_image = false;
         if let Some(item) = cx.read_from_clipboard() {
             for entry in &item.entries {
@@ -240,8 +241,10 @@ impl Composer {
             }
         }
         if !accepted_image && let Some((mime, bytes)) = crate::pasteboard::read_pasteboard_image() {
-            self.add_image_bytes("pasted-image".to_string(), mime, bytes, window, cx);
+            accepted_image =
+                self.add_image_bytes("pasted-image".to_string(), mime, bytes, window, cx);
         }
+        accepted_image
     }
 
     pub(in super::super) fn remove_image(&mut self, index: usize, cx: &mut Context<Self>) {

--- a/crates/ui/src/composer/mod.rs
+++ b/crates/ui/src/composer/mod.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use crate::overlay::{DialogButtons, Notification, OverlayExt as _};
 use crate::theme::ActiveTheme as _;
 use crate::widgets::button::{Button, ButtonVariants as _};
-use crate::widgets::input::{Input, InputEvent, InputState, Textarea, TextareaState};
+use crate::widgets::input::{Input, InputEvent, InputState, Paste, Textarea, TextareaState};
 use crate::widgets::spinner::Spinner;
 use crate::{
     icon::{Icon, IconName},
@@ -883,14 +883,19 @@ impl Render for Composer {
             // token would render as a murky translucent wash here.
             .bg(cx.theme().popover)
             .shadow_md()
-            // Secondary+V with image clipboard content, and arrow/Escape trigger-menu
-            // navigation (fires after the input's own key actions).
+            // The editor binds Secondary+V to Paste, which consumes the keystroke
+            // before any key-down listener runs — so image paste must intercept
+            // the Paste *action* in the capture phase. Swallow it only when the
+            // clipboard held an image; text paste propagates to the editor.
+            .capture_action(cx.listener(|this, _: &Paste, window, cx| {
+                if this.paste_clipboard_image(window, cx) {
+                    cx.stop_propagation();
+                }
+            }))
+            // Arrow/Escape trigger-menu navigation (fires after the input's own
+            // key actions).
             .capture_key_down(cx.listener(|this, ev: &gpui::KeyDownEvent, window, cx| {
                 let key = ev.keystroke.key.as_str();
-                if key == "v" && ev.keystroke.modifiers.secondary() {
-                    this.paste_clipboard_image(window, cx);
-                    return;
-                }
                 if this.handle_user_input_digit(ev, window, cx) {
                     cx.stop_propagation();
                     return;

--- a/crates/ui/src/widgets/input.rs
+++ b/crates/ui/src/widgets/input.rs
@@ -10,7 +10,7 @@ use gpui::{
 use gpui_base::StyledExt as _;
 use gpui_base::{InputBase, RoleOverride};
 
-pub use gpui_base::input::{Copy, InputEvent, InputState, SelectAll, TextareaState};
+pub use gpui_base::input::{Copy, InputEvent, InputState, Paste, SelectAll, TextareaState};
 
 enum State {
     Input(Entity<InputState>),


### PR DESCRIPTION
## Problem

Pasting an image from the clipboard (⌘V) into the composer did nothing.

## Root cause

The editor core (gpui-base) binds Secondary+V to the `Paste` action. In gpui's key dispatch, a keystroke that matches an action binding dispatches the action and returns early — the `KeyDownEvent` never reaches element key listeners. The composer's `capture_key_down` branch that pulled images off the clipboard was therefore dead code whenever the input was focused, i.e. in the only state a user actually pastes from.

## Fix

- Intercept the `Paste` **action** in the capture phase on the composer card, which runs before the editor's bubble-phase paste handler. If the clipboard holds an image, attach it and stop propagation (so the editor doesn't paste the empty text form over a selection); otherwise propagate so text paste works unchanged.
- `paste_clipboard_image` now returns whether an image was accepted, including the macOS pasteboard fallback path.
- Re-export `Paste` from the input widget module.

Known limit: the context-menu Paste item calls the editor's paste directly, bypassing action dispatch, so right-click paste still ignores images — only keyboard ⌘V (the reported scenario) is fixed.

## Verification

Manually verified in the dev build: with a PNG on the clipboard, ⌘V in the composer attaches the image; text paste unaffected. `cargo check -p tcode-ui` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)