### PR TITLE
fix(ui): show copy action only on a turn's final assistant message

### DIFF
--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -284,6 +284,11 @@ impl ChatView {
         let segmented = segment_entries(entries, turn.running);
         let segments = &segmented.flow;
         let last_activity_segment = live_activity_segment(segments, turn.running);
+        // Only the turn's final assistant text is the deliverable; interim
+        // notes between tool runs carry no action row.
+        let last_assistant_segment = segments
+            .iter()
+            .rposition(|segment| matches!(segment, Segment::Assistant(_)));
 
         for (segment_index, segment) in segments.iter().enumerate() {
             match segment {
@@ -383,7 +388,8 @@ impl ChatView {
                             cwd,
                             markdown,
                             pinned: pinned.1 == Some(entry.id.as_str()),
-                            show_actions: !turn.running,
+                            show_actions: !turn.running
+                                && last_assistant_segment == Some(segment_index),
                             copied,
                         },
                         cx.listener(move |this, _, _, cx| {


### PR DESCRIPTION
Every assistant text segment in a finished turn rendered its own hover copy button because `show_actions` only checked `!turn.running`. Interim notes between tool runs are not deliverables; now only the turn's last assistant segment carries the action row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)