### PR TITLE
feat(voice): live dictation via macOS 26 SpeechAnalyzer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           command_new_violations="$(
             grep -rn "Command::new(" crates --include="*.rs" \
               | grep -v -e "crates/services/src/process.rs:" -e "crates/agent/src/process.rs:" \
+              -e "crates/voice/build.rs:" \
               | grep -v '^[^:]*:[0-9]*:[[:space:]]*//' \
               || true
           )"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,8 @@ jobs:
             <key>LSApplicationCategoryType</key><string>public.app-category.developer-tools</string>
             <key>LSMinimumSystemVersion</key><string>12.0</string>
             <key>NSHighResolutionCapable</key><true/>
+            <key>NSMicrophoneUsageDescription</key><string>Tcode uses the microphone for voice input in the message composer.</string>
+            <key>NSSpeechRecognitionUsageDescription</key><string>Tcode transcribes your speech on-device to type messages by voice.</string>
           </dict></plist>
           PLIST
           plutil -lint "$app/Contents/Info.plist"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8433,7 +8433,15 @@ dependencies = [
  "tcode-protocol",
  "tcode-runtime",
  "tcode-services",
+ "tcode-voice",
  "term",
+]
+
+[[package]]
+name = "tcode-voice"
+version = "0.1.0"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/orchestrate-mcp",
     "crates/computer-use-mcp",
     "crates/ui",
+    "crates/voice",
     "crates/app",
 ]
 resolver = "3"

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -9,6 +9,7 @@ tcode-core = { path = "../core" }
 tcode-protocol = { path = "../protocol" }
 tcode-runtime = { path = "../runtime" }
 tcode-services = { path = "../services" }
+tcode-voice = { path = "../voice" }
 term = { path = "../term" }
 preview-mcp = { path = "../preview-mcp" }
 computer-use-mcp = { path = "../computer-use-mcp" }

--- a/crates/ui/src/assets.rs
+++ b/crates/ui/src/assets.rs
@@ -81,7 +81,12 @@ const EXTRA_ICONS: &[(&str, &[u8])] = &[
         "icons/sparkles.svg",
         include_bytes!("../../../assets/icons/sparkles.svg"),
     ),
+    ("icons/mic.svg", MIC_SVG.as_bytes()),
 ];
+
+/// Lucide `mic`, inlined rather than shipped as a file: it is the composer
+/// dictation button's only asset and the feature is macOS-only.
+const MIC_SVG: &str = r#"<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-mic"><path d="M12 19v3"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><rect x="9" y="2" width="6" height="13" rx="3"/></svg>"#;
 
 /// App assets layered over gpui-component's built-in icon assets.
 pub struct Assets;

--- a/crates/ui/src/composer/components/mod.rs
+++ b/crates/ui/src/composer/components/mod.rs
@@ -6,3 +6,7 @@ mod plan;
 mod queue_strip;
 mod trigger_menu;
 mod user_input;
+/// Dictation exists only where the engine does, so the whole component —
+/// button included — compiles out elsewhere.
+#[cfg(target_os = "macos")]
+pub(super) mod voice;

--- a/crates/ui/src/composer/components/voice.rs
+++ b/crates/ui/src/composer/components/voice.rs
@@ -34,6 +34,9 @@ struct Dictation {
     /// False between `start` and the engine's `Ready` — the first session may
     /// still be downloading speech assets, so the button shows a busy state.
     ready: bool,
+    /// Smoothed microphone level (`0.0..=1.0`) shown as a glow behind the mic
+    /// icon so the user can see their speech is being picked up.
+    level: f32,
     /// Cursor offset (UTF-8 bytes) captured when dictation started.
     anchor: usize,
     committed_len: usize,
@@ -98,11 +101,21 @@ impl Composer {
                 .child(if preparing {
                     Spinner::new().small().color(color).into_any_element()
                 } else {
-                    Icon::empty()
+                    let icon = Icon::empty()
                         .path("icons/mic.svg")
                         .small()
-                        .text_color(color)
-                        .into_any_element()
+                        .text_color(color);
+                    match dictation {
+                        // While recording, a glow behind the glyph tracks the
+                        // live input level: visible proof the mic hears you.
+                        Some(d) => div()
+                            .rounded_full()
+                            .p(px(2.))
+                            .bg(cx.theme().danger.opacity(0.08 + d.level * 0.42))
+                            .child(icon)
+                            .into_any_element(),
+                        None => icon.into_any_element(),
+                    }
                 })
                 .on_click(cx.listener(|this, _, window, cx| this.toggle_dictation(window, cx)))
                 .into_any_element(),
@@ -159,6 +172,7 @@ impl Composer {
         self.voice.session = Some(Dictation {
             session,
             ready: false,
+            level: 0.0,
             anchor,
             committed_len: 0,
             volatile_len: 0,
@@ -204,6 +218,14 @@ impl Composer {
             DictationEvent::Ready => {
                 if let Some(dictation) = self.voice.session.as_mut() {
                     dictation.ready = true;
+                    cx.notify();
+                }
+            }
+            DictationEvent::Level(level) => {
+                if let Some(dictation) = self.voice.session.as_mut() {
+                    // Fast attack, slow decay: peaks register instantly and
+                    // fade out instead of flickering at the callback rate.
+                    dictation.level = level.max(dictation.level * 0.8);
                     cx.notify();
                 }
             }

--- a/crates/ui/src/composer/components/voice.rs
+++ b/crates/ui/src/composer/components/voice.rs
@@ -1,0 +1,288 @@
+//! Live dictation in the composer: the mic toggle button plus the transcript
+//! insertion state machine that keeps rewriting the engine's hypothesis in
+//! place. macOS only — see `crates/voice` for the engine side.
+
+use super::super::*;
+
+use gpui::SharedString;
+use tcode_voice::{DictationEvent, DictationSession};
+
+/// The composer's dictation state.
+pub(in super::super) struct Voice {
+    /// `tcode_voice::is_supported()`, sampled once per composer: the answer
+    /// cannot change while the app runs, and the mic button is absent when it
+    /// is false.
+    supported: bool,
+    session: Option<Dictation>,
+}
+
+impl Voice {
+    pub(in super::super) fn new() -> Self {
+        Self {
+            supported: tcode_voice::is_supported(),
+            session: None,
+        }
+    }
+}
+
+/// A running session and the byte bookkeeping for its insertion point. The
+/// transcript occupies `anchor .. anchor + committed_len + volatile_len`; each
+/// `Volatile` rewrites the trailing volatile slice, each `Final` turns it into
+/// committed text.
+struct Dictation {
+    session: DictationSession,
+    /// False between `start` and the engine's `Ready` — the first session may
+    /// still be downloading speech assets, so the button shows a busy state.
+    ready: bool,
+    /// Cursor offset (UTF-8 bytes) captured when dictation started.
+    anchor: usize,
+    committed_len: usize,
+    volatile_len: usize,
+    /// The input value we last wrote. Any change away from it is a user edit,
+    /// which ends the session.
+    expected: String,
+    /// Pumps engine events (delivered on the engine's own threads) into the UI
+    /// thread; dropped with the session.
+    _events: Task<()>,
+}
+
+/// Where a `len`-byte chunk goes and what the counters become: every chunk
+/// replaces the volatile tail, and a final one turns it into committed text.
+/// Offsets are UTF-8 bytes, as `TextareaState` selections are.
+fn transcript_edit(
+    anchor: usize,
+    committed_len: usize,
+    volatile_len: usize,
+    len: usize,
+    commit: bool,
+) -> (std::ops::Range<usize>, usize, usize) {
+    let start = anchor + committed_len;
+    let replaced = start..start + volatile_len;
+    if commit {
+        (replaced, committed_len + len, 0)
+    } else {
+        (replaced, committed_len, len)
+    }
+}
+
+impl Composer {
+    /// The mic toggle, or `None` when this machine has no dictation engine.
+    pub(in super::super) fn render_mic_button(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        if !self.voice.supported {
+            return None;
+        }
+        let dictation = self.voice.session.as_ref();
+        let preparing = dictation.is_some_and(|d| !d.ready);
+        let tooltip: SharedString = match dictation {
+            None => crate::tr!("composer.voice_start"),
+            Some(_) if preparing => crate::tr!("composer.voice_preparing"),
+            Some(_) => crate::tr!("composer.voice_stop"),
+        }
+        .into_owned()
+        .into();
+        // Recording tints the glyph with the danger accent, matching the stop
+        // button's "something is live" idiom; preparing stays muted.
+        let color = if dictation.is_some() && !preparing {
+            cx.theme().danger
+        } else {
+            cx.theme().muted_foreground
+        };
+
+        Some(
+            Button::new("voice-mic")
+                .ghost()
+                .compact()
+                .h(px(28.))
+                .rounded(crate::material::radius_chip())
+                .tooltip(tooltip)
+                .child(if preparing {
+                    Spinner::new().small().color(color).into_any_element()
+                } else {
+                    Icon::empty()
+                        .path("icons/mic.svg")
+                        .small()
+                        .text_color(color)
+                        .into_any_element()
+                })
+                .on_click(cx.listener(|this, _, window, cx| this.toggle_dictation(window, cx)))
+                .into_any_element(),
+        )
+    }
+
+    /// Click handler: a second click stops (and finalizes) the running session.
+    pub(in super::super) fn toggle_dictation(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.stop_dictation(cx) {
+            return;
+        }
+        let locale = rust_i18n::locale();
+        let (events_tx, events_rx) = smol::channel::unbounded();
+        let session = match tcode_voice::start(
+            tcode_voice::preferred_locale(locale.as_ref()),
+            Box::new(move |event| {
+                let _ = events_tx.try_send(event);
+            }),
+        ) {
+            Ok(session) => session,
+            Err(error) => {
+                window.push_notification(
+                    Notification::error(
+                        crate::tr!("composer.voice_error", error = error).into_owned(),
+                    ),
+                    cx,
+                );
+                return;
+            }
+        };
+
+        let (anchor, expected) = self.input.update(cx, |state, cx| {
+            // Focus keeps Escape (handled on the card) reachable and leaves the
+            // caret where the transcript is about to appear.
+            state.focus(window, cx);
+            (state.cursor(), state.value().to_string())
+        });
+        let events = cx.spawn_in(window, async move |this, cx| {
+            while let Ok(event) = events_rx.recv().await {
+                if this
+                    .update_in(cx, |this, window, cx| {
+                        this.on_dictation_event(event, window, cx)
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+        self.voice.session = Some(Dictation {
+            session,
+            ready: false,
+            anchor,
+            committed_len: 0,
+            volatile_len: 0,
+            expected,
+            _events: events,
+        });
+        cx.notify();
+    }
+
+    /// Stop the running session, keeping every character inserted so far.
+    /// Returns whether there was one (Escape uses this to claim the keystroke).
+    pub(in super::super) fn stop_dictation(&mut self, cx: &mut Context<Self>) -> bool {
+        let Some(dictation) = self.voice.session.take() else {
+            return false;
+        };
+        dictation.session.stop();
+        cx.notify();
+        true
+    }
+
+    /// Typing, pasting or undoing while dictating ends the session in place:
+    /// the anchor no longer describes the text, and merging a live hypothesis
+    /// with concurrent edits is not worth the ambiguity.
+    pub(in super::super) fn stop_dictation_on_user_edit(&mut self, cx: &mut Context<Self>) {
+        let value = self.input.read(cx).value();
+        if self
+            .voice
+            .session
+            .as_ref()
+            .is_some_and(|dictation| dictation.expected != value.as_ref())
+        {
+            self.stop_dictation(cx);
+        }
+    }
+
+    fn on_dictation_event(
+        &mut self,
+        event: DictationEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        match event {
+            DictationEvent::Ready => {
+                if let Some(dictation) = self.voice.session.as_mut() {
+                    dictation.ready = true;
+                    cx.notify();
+                }
+            }
+            DictationEvent::Volatile(text) => self.insert_transcript(text, false, window, cx),
+            DictationEvent::Final(text) => self.insert_transcript(text, true, window, cx),
+            DictationEvent::Error(message) => {
+                self.stop_dictation(cx);
+                window.push_notification(
+                    Notification::error(
+                        crate::tr!("composer.voice_error", error = message).into_owned(),
+                    ),
+                    cx,
+                );
+            }
+            DictationEvent::Ended => {
+                self.voice.session = None;
+                cx.notify();
+            }
+        }
+    }
+
+    /// Replace the current volatile range with `text`, committing it when the
+    /// engine says it is final.
+    fn insert_transcript(
+        &mut self,
+        text: String,
+        commit: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let input = self.input.clone();
+        let Some(dictation) = self.voice.session.as_mut() else {
+            return;
+        };
+        let (range, committed_len, volatile_len) = transcript_edit(
+            dictation.anchor,
+            dictation.committed_len,
+            dictation.volatile_len,
+            text.len(),
+            commit,
+        );
+        input.update(cx, |state, cx| {
+            state.set_selected_range(range, cx);
+            state.replace(text, window, cx);
+        });
+        dictation.committed_len = committed_len;
+        dictation.volatile_len = volatile_len;
+        // The replacement emits `Change` like any edit; record the result so
+        // the edit guard can tell our own writes from the user's.
+        dictation.expected = input.read(cx).value().to_string();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::transcript_edit;
+
+    /// A hypothesis is rewritten in place until it is finalized, after which
+    /// the next one starts where the committed text ends.
+    #[test]
+    fn each_chunk_replaces_only_the_volatile_tail() {
+        let (anchor, mut committed, mut volatile) = (5, 0, 0);
+
+        let (range, c, v) = transcript_edit(anchor, committed, volatile, 2, false);
+        assert_eq!(range, 5..5);
+        (committed, volatile) = (c, v);
+
+        // A longer hypothesis replaces the shorter one it grew from.
+        let (range, c, v) = transcript_edit(anchor, committed, volatile, 6, false);
+        assert_eq!(range, 5..7);
+        (committed, volatile) = (c, v);
+
+        let (range, c, v) = transcript_edit(anchor, committed, volatile, 6, true);
+        assert_eq!(range, 5..11);
+        assert_eq!((c, v), (6, 0));
+        (committed, volatile) = (c, v);
+
+        // The next hypothesis is inserted after the committed text.
+        let (range, ..) = transcript_edit(anchor, committed, volatile, 3, false);
+        assert_eq!(range, 11..11);
+    }
+}

--- a/crates/ui/src/composer/components/voice.rs
+++ b/crates/ui/src/composer/components/voice.rs
@@ -34,6 +34,10 @@ struct Dictation {
     /// False between `start` and the engine's `Ready` — the first session may
     /// still be downloading speech assets, so the button shows a busy state.
     ready: bool,
+    /// True after a graceful stop: capture is over but the pump stays alive so
+    /// the engine's finalization flush still lands in the editor; the session
+    /// is dropped when the terminal event arrives.
+    stopping: bool,
     /// Smoothed microphone level (`0.0..=1.0`) shown as a glow behind the mic
     /// icon so the user can see their speech is being picked up.
     level: f32,
@@ -75,7 +79,7 @@ impl Composer {
             return None;
         }
         let dictation = self.voice.session.as_ref();
-        let preparing = dictation.is_some_and(|d| !d.ready);
+        let preparing = dictation.is_some_and(|d| !d.ready || d.stopping);
         let tooltip: SharedString = match dictation {
             None => crate::tr!("composer.voice_start"),
             Some(_) if preparing => crate::tr!("composer.voice_preparing"),
@@ -172,6 +176,7 @@ impl Composer {
         self.voice.session = Some(Dictation {
             session,
             ready: false,
+            stopping: false,
             level: 0.0,
             anchor,
             committed_len: 0,
@@ -182,15 +187,30 @@ impl Composer {
         cx.notify();
     }
 
-    /// Stop the running session, keeping every character inserted so far.
-    /// Returns whether there was one (Escape uses this to claim the keystroke).
+    /// Gracefully stop the running session: capture ends now, but the pump
+    /// stays alive so the engine's finalization flush still reaches the editor
+    /// before `Ended` clears the state. Returns whether a session existed
+    /// (Escape uses this to claim the keystroke).
     pub(in super::super) fn stop_dictation(&mut self, cx: &mut Context<Self>) -> bool {
-        let Some(dictation) = self.voice.session.take() else {
+        let Some(dictation) = self.voice.session.as_mut() else {
             return false;
         };
-        dictation.session.stop();
-        cx.notify();
+        if !dictation.stopping {
+            dictation.stopping = true;
+            dictation.session.stop();
+            cx.notify();
+        }
         true
+    }
+
+    /// Drop the session immediately, discarding any pending finalization. For
+    /// paths where a late flush would land in the wrong place: submit clears
+    /// the editor, destination switches change it, and user edits invalidate
+    /// the anchor.
+    pub(in super::super) fn abort_dictation(&mut self, cx: &mut Context<Self>) {
+        if self.voice.session.take().is_some() {
+            cx.notify();
+        }
     }
 
     /// Typing, pasting or undoing while dictating ends the session in place:
@@ -204,7 +224,7 @@ impl Composer {
             .as_ref()
             .is_some_and(|dictation| dictation.expected != value.as_ref())
         {
-            self.stop_dictation(cx);
+            self.abort_dictation(cx);
         }
     }
 
@@ -214,6 +234,10 @@ impl Composer {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        match &event {
+            DictationEvent::Level(_) => {}
+            other => log::info!("dictation event: {other:?}"),
+        }
         match event {
             DictationEvent::Ready => {
                 if let Some(dictation) = self.voice.session.as_mut() {

--- a/crates/ui/src/composer/mod.rs
+++ b/crates/ui/src/composer/mod.rs
@@ -303,7 +303,7 @@ impl Composer {
         };
         // The dictation anchor belongs to the text we are about to swap out.
         #[cfg(target_os = "macos")]
-        self.stop_dictation(cx);
+        self.abort_dictation(cx);
         let cursor = incoming_text.len();
         self.input.update(cx, |state, cx| {
             state.set_value(incoming_text, window, cx);
@@ -519,7 +519,7 @@ impl Composer {
         cx: &mut Context<Self>,
     ) {
         #[cfg(target_os = "macos")]
-        self.stop_dictation(cx);
+        self.abort_dictation(cx);
         self.text_cache.clear_current();
         input.update(cx, |state, cx| state.set_value("", window, cx));
         self.pending_images.clear();

--- a/crates/ui/src/composer/mod.rs
+++ b/crates/ui/src/composer/mod.rs
@@ -6,6 +6,8 @@ mod components;
 mod model;
 
 use components::images::PendingImage;
+#[cfg(target_os = "macos")]
+use components::voice::Voice;
 use model::*;
 
 use std::cell::Cell;
@@ -155,6 +157,9 @@ pub struct Composer {
     /// One cancellable one-second repaint loop, present only while the queue
     /// strip contains at least one scheduled row.
     scheduled_countdown_tick: Option<Task<()>>,
+    /// Mic button + live dictation session (see `components::voice`).
+    #[cfg(target_os = "macos")]
+    voice: Voice,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -220,6 +225,10 @@ impl Composer {
                     // Recompute the active `@`/`/`/`$` trigger and re-render (also
                     // refreshes the send button's has-text state).
                     InputEvent::Change => {
+                        // An edit that did not come from the transcript writer
+                        // ends dictation (see `components::voice`).
+                        #[cfg(target_os = "macos")]
+                        this.stop_dictation_on_user_edit(cx);
                         this.recompute_trigger(cx);
                         cx.notify();
                     }
@@ -272,6 +281,8 @@ impl Composer {
             image_load_generation: 0,
             pending_image_loads: 0,
             scheduled_countdown_tick: None,
+            #[cfg(target_os = "macos")]
+            voice: Voice::new(),
             _subscriptions: subscriptions,
         }
     }
@@ -290,6 +301,9 @@ impl Composer {
         let Some(incoming_text) = self.text_cache.switch_to(destination, &outgoing_text) else {
             return;
         };
+        // The dictation anchor belongs to the text we are about to swap out.
+        #[cfg(target_os = "macos")]
+        self.stop_dictation(cx);
         let cursor = incoming_text.len();
         self.input.update(cx, |state, cx| {
             state.set_value(incoming_text, window, cx);
@@ -504,6 +518,8 @@ impl Composer {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        #[cfg(target_os = "macos")]
+        self.stop_dictation(cx);
         self.text_cache.clear_current();
         input.update(cx, |state, cx| state.set_value("", window, cx));
         self.pending_images.clear();
@@ -743,11 +759,18 @@ impl Render for Composer {
             .gap_1()
             .items_center();
 
+        // Absent unless this machine has a dictation engine (macOS 26+).
+        #[cfg(target_os = "macos")]
+        let mic = self.render_mic_button(cx);
+        #[cfg(not(target_os = "macos"))]
+        let mic: Option<AnyElement> = None;
+
         let control_row = if compact {
             control_row_base
                 .child(self.render_model_picker(cx))
                 .child(self.render_overflow_menu(cx))
                 .child(div().flex_1())
+                .children(mic)
                 .child(self.render_primary_action(turn_running, cx))
         } else {
             control_row_base
@@ -758,6 +781,7 @@ impl Render for Composer {
                 .child(self.render_permission_picker(cx))
                 .child(self.render_mode_chip(cx))
                 .child(div().flex_1())
+                .children(mic)
                 .child(self.render_primary_action(turn_running, cx))
         };
 
@@ -897,6 +921,13 @@ impl Render for Composer {
             .capture_key_down(cx.listener(|this, ev: &gpui::KeyDownEvent, window, cx| {
                 let key = ev.keystroke.key.as_str();
                 if this.handle_user_input_digit(ev, window, cx) {
+                    cx.stop_propagation();
+                    return;
+                }
+                // Escape ends dictation (keeping the transcript) before it can
+                // mean anything else.
+                #[cfg(target_os = "macos")]
+                if key == "escape" && this.stop_dictation(cx) {
                     cx.stop_propagation();
                     return;
                 }

--- a/crates/voice/Cargo.toml
+++ b/crates/voice/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "tcode-voice"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+log = "0.4"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(voice_shim)"] }

--- a/crates/voice/build.rs
+++ b/crates/voice/build.rs
@@ -1,0 +1,109 @@
+use std::{env, fs, path::PathBuf, process::Command};
+
+fn command_output(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(args).output().ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+fn sdk_is_at_least_26(version: &str) -> bool {
+    version
+        .split('.')
+        .next()
+        .and_then(|part| part.parse::<u32>().ok())
+        .is_some_and(|major| major >= 26)
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=swift/shim.swift");
+    println!("cargo:rerun-if-env-changed=TCODE_VOICE_FORCE_STUB");
+
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos")
+        || env::var("TCODE_VOICE_FORCE_STUB").as_deref() == Ok("1")
+    {
+        return;
+    }
+
+    let Some(sdk_version) = command_output("xcrun", &["--sdk", "macosx", "--show-sdk-version"])
+    else {
+        return;
+    };
+    if !sdk_is_at_least_26(&sdk_version) {
+        return;
+    }
+
+    let sdk_path = command_output("xcrun", &["--sdk", "macosx", "--show-sdk-path"])
+        .expect("macOS SDK path is unavailable");
+    let swiftc =
+        command_output("xcrun", &["--find", "swiftc"]).expect("Swift compiler is unavailable");
+    let arch = match env::var("CARGO_CFG_TARGET_ARCH").as_deref() {
+        Ok("aarch64") => "arm64",
+        Ok("x86_64") => "x86_64",
+        Ok(other) => panic!("unsupported macOS architecture for tcode-voice: {other}"),
+        Err(error) => panic!("CARGO_CFG_TARGET_ARCH is unavailable: {error}"),
+    };
+    let target = format!("{arch}-apple-macosx26.0");
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is unavailable"));
+    let library = out_dir.join("libtcode_voice_shim.a");
+    let module_cache = out_dir.join("swift-module-cache");
+
+    // The SDK's concurrency text stub contains `$ld$previous` directives that
+    // rewrite its install name to @rpath when the final Rust executable keeps
+    // an older deployment target. The shim itself is macOS 26-only and needs
+    // the current Swift concurrency ABI, which macOS 26 provides in the dyld
+    // cache at /usr/lib/swift. Keep the final app's deployment target intact,
+    // but make its Swift autolink resolve to that system install name.
+    let concurrency_stub_source =
+        PathBuf::from(&sdk_path).join("usr/lib/swift/libswift_Concurrency.tbd");
+    let mut concurrency_stub = fs::read_to_string(&concurrency_stub_source)
+        .expect("failed to read the Swift concurrency text stub");
+    while let Some(start) = concurrency_stub.find("'$ld$previous") {
+        let end = concurrency_stub[start..]
+            .find("',")
+            .map(|offset| start + offset + 2)
+            .expect("malformed $ld$previous directive in Swift concurrency text stub");
+        concurrency_stub.replace_range(start..end, "");
+    }
+    fs::write(out_dir.join("libswift_Concurrency.tbd"), concurrency_stub)
+        .expect("failed to write the adjusted Swift concurrency text stub");
+
+    let status = Command::new(&swiftc)
+        .args([
+            "-parse-as-library",
+            "-swift-version",
+            "5",
+            "-target",
+            &target,
+            "-sdk",
+            &sdk_path,
+            "-module-cache-path",
+        ])
+        .arg(&module_cache)
+        .args(["-static", "-emit-library", "swift/shim.swift", "-o"])
+        .arg(&library)
+        .status()
+        .expect("failed to invoke swiftc for tcode-voice");
+    assert!(
+        status.success(),
+        "swiftc failed to compile swift/shim.swift"
+    );
+
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=static=tcode_voice_shim");
+    for framework in ["Speech", "AVFoundation", "Foundation", "CoreMedia"] {
+        println!("cargo:rustc-link-lib=framework={framework}");
+    }
+
+    println!("cargo:rustc-link-search=native=/usr/lib/swift");
+    println!("cargo:rustc-link-search=native={sdk_path}/usr/lib/swift");
+    println!("cargo:rustc-link-search=native={sdk_path}/usr/lib/swift/macosx");
+    if let Some(toolchain) = PathBuf::from(swiftc).parent().and_then(|bin| bin.parent()) {
+        println!(
+            "cargo:rustc-link-search=native={}",
+            toolchain.join("lib/swift/macosx").display()
+        );
+    }
+    println!("cargo:rustc-cfg=voice_shim");
+}

--- a/crates/voice/examples/file_dictation.rs
+++ b/crates/voice/examples/file_dictation.rs
@@ -1,0 +1,41 @@
+use std::{env, process, sync::mpsc};
+
+use tcode_voice::DictationEvent;
+
+fn main() {
+    let mut args = env::args().skip(1);
+    let (Some(path), Some(locale), None) = (args.next(), args.next(), args.next()) else {
+        eprintln!("usage: file_dictation <audio-path> <locale>");
+        process::exit(2);
+    };
+
+    let (sender, receiver) = mpsc::channel();
+    let session = tcode_voice::start_file(
+        &locale,
+        &path,
+        Box::new(move |event| {
+            let _ = sender.send(event);
+        }),
+    )
+    .unwrap_or_else(|error| {
+        eprintln!("error: {error}");
+        process::exit(1);
+    });
+
+    while let Ok(event) = receiver.recv() {
+        match event {
+            DictationEvent::Ready => println!("ready"),
+            DictationEvent::Volatile(text) => println!("volatile: {text}"),
+            DictationEvent::Final(text) => println!("final: {text}"),
+            DictationEvent::Error(error) => {
+                eprintln!("error: {error}");
+                drop(session);
+                process::exit(1);
+            }
+            DictationEvent::Ended => {
+                println!("ended");
+                break;
+            }
+        }
+    }
+}

--- a/crates/voice/examples/file_dictation.rs
+++ b/crates/voice/examples/file_dictation.rs
@@ -25,6 +25,7 @@ fn main() {
     while let Ok(event) = receiver.recv() {
         match event {
             DictationEvent::Ready => println!("ready"),
+            DictationEvent::Level(_) => {}
             DictationEvent::Volatile(text) => println!("volatile: {text}"),
             DictationEvent::Final(text) => println!("final: {text}"),
             DictationEvent::Error(error) => {

--- a/crates/voice/examples/file_dictation.rs
+++ b/crates/voice/examples/file_dictation.rs
@@ -10,7 +10,8 @@ fn main() {
     };
 
     let (sender, receiver) = mpsc::channel();
-    let session = tcode_voice::start_file(
+    // Held for its lifetime: dropping it would cancel the session.
+    let _session = tcode_voice::start_file(
         &locale,
         &path,
         Box::new(move |event| {
@@ -30,7 +31,6 @@ fn main() {
             DictationEvent::Final(text) => println!("final: {text}"),
             DictationEvent::Error(error) => {
                 eprintln!("error: {error}");
-                drop(session);
                 process::exit(1);
             }
             DictationEvent::Ended => {

--- a/crates/voice/examples/mic_dictation.rs
+++ b/crates/voice/examples/mic_dictation.rs
@@ -1,0 +1,19 @@
+//! Live microphone dictation smoke test: `cargo run -p tcode-voice --example
+//! mic_dictation -- zh_CN [seconds]`. Prints every event with a timestamp.
+use std::time::{Duration, Instant};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let locale = args.next().unwrap_or_else(|| "zh_CN".into());
+    let seconds: u64 = args.next().and_then(|s| s.parse().ok()).unwrap_or(8);
+    let start = Instant::now();
+    let session = tcode_voice::start(
+        &locale,
+        Box::new(move |event| println!("[{:6.2}s] {event:?}", start.elapsed().as_secs_f32())),
+    )
+    .expect("failed to start dictation");
+    std::thread::sleep(Duration::from_secs(seconds));
+    println!("[{:6.2}s] calling stop()", start.elapsed().as_secs_f32());
+    session.stop();
+    std::thread::sleep(Duration::from_secs(3));
+}

--- a/crates/voice/src/imp.rs
+++ b/crates/voice/src/imp.rs
@@ -1,0 +1,155 @@
+use std::{
+    ffi::{CStr, CString, c_char, c_int, c_void},
+    panic::{AssertUnwindSafe, catch_unwind},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use super::DictationEvent;
+
+type EventCallback = unsafe extern "C" fn(*mut c_void, c_int, *const c_char);
+
+unsafe extern "C" {
+    fn voice_is_supported(locale: *const c_char) -> bool;
+    fn voice_start(
+        locale: *const c_char,
+        context: *mut c_void,
+        callback: EventCallback,
+    ) -> *mut c_void;
+    fn voice_start_file(
+        locale: *const c_char,
+        path: *const c_char,
+        context: *mut c_void,
+        callback: EventCallback,
+    ) -> *mut c_void;
+    fn voice_stop(session: *mut c_void);
+    fn voice_free(session: *mut c_void);
+}
+
+struct CallbackState {
+    callback: Box<dyn Fn(DictationEvent) + Send + Sync>,
+    terminal: AtomicBool,
+}
+
+unsafe extern "C" fn event_callback(context: *mut c_void, kind: c_int, text: *const c_char) {
+    let pointer = context.cast::<CallbackState>();
+
+    // Keep a temporary strong reference for the duration of this callback. The
+    // raw context owns another reference until the terminal event below.
+    unsafe { Arc::increment_strong_count(pointer) };
+    let state = unsafe { Arc::from_raw(pointer) };
+
+    if state.terminal.load(Ordering::Acquire) {
+        return;
+    }
+
+    let string = || {
+        if text.is_null() {
+            String::new()
+        } else {
+            unsafe { CStr::from_ptr(text) }
+                .to_string_lossy()
+                .into_owned()
+        }
+    };
+    let (event, terminal) = match kind {
+        0 => (DictationEvent::Ready, false),
+        1 => (DictationEvent::Volatile(string()), false),
+        2 => (DictationEvent::Final(string()), false),
+        3 => (DictationEvent::Error(string()), true),
+        4 => (DictationEvent::Ended, true),
+        _ => return,
+    };
+
+    if terminal
+        && state
+            .terminal
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+    {
+        return;
+    }
+
+    let _ = catch_unwind(AssertUnwindSafe(|| (state.callback)(event)));
+
+    if terminal {
+        // Release the strong reference transferred to Swift as the context.
+        drop(unsafe { Arc::from_raw(pointer) });
+    }
+}
+
+pub struct Session {
+    raw: *mut c_void,
+    _callback: Arc<CallbackState>,
+}
+
+// The shim serializes access to its opaque session and accepts stop/free from
+// any thread. CallbackState itself contains only Send + Sync data.
+unsafe impl Send for Session {}
+
+impl Session {
+    pub fn stop(&self) {
+        unsafe { voice_stop(self.raw) };
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        unsafe { voice_free(self.raw) };
+    }
+}
+
+pub fn is_supported() -> bool {
+    let locale = CString::new(super::preferred_locale("en")).expect("locale contains no NUL");
+    unsafe { voice_is_supported(locale.as_ptr()) }
+}
+
+pub fn start(
+    locale: &str,
+    on_event: Box<dyn Fn(DictationEvent) + Send + Sync>,
+) -> Result<Session, String> {
+    start_inner(locale, None, on_event)
+}
+
+pub fn start_file(
+    locale: &str,
+    path: &str,
+    on_event: Box<dyn Fn(DictationEvent) + Send + Sync>,
+) -> Result<Session, String> {
+    start_inner(locale, Some(path), on_event)
+}
+
+fn start_inner(
+    locale: &str,
+    path: Option<&str>,
+    on_event: Box<dyn Fn(DictationEvent) + Send + Sync>,
+) -> Result<Session, String> {
+    let locale = CString::new(locale).map_err(|_| "locale contains an interior NUL byte")?;
+    let path = path
+        .map(CString::new)
+        .transpose()
+        .map_err(|_| "audio path contains an interior NUL byte")?;
+    let callback = Arc::new(CallbackState {
+        callback: on_event,
+        terminal: AtomicBool::new(false),
+    });
+    let context = Arc::into_raw(Arc::clone(&callback)).cast_mut().cast();
+    let raw = unsafe {
+        match path.as_ref() {
+            Some(path) => voice_start_file(locale.as_ptr(), path.as_ptr(), context, event_callback),
+            None => voice_start(locale.as_ptr(), context, event_callback),
+        }
+    };
+
+    if raw.is_null() {
+        drop(unsafe { Arc::from_raw(context.cast::<CallbackState>()) });
+        return Err("failed to create dictation session".into());
+    }
+
+    Ok(Session {
+        raw,
+        _callback: callback,
+    })
+}

--- a/crates/voice/src/imp.rs
+++ b/crates/voice/src/imp.rs
@@ -60,6 +60,10 @@ unsafe extern "C" fn event_callback(context: *mut c_void, kind: c_int, text: *co
         2 => (DictationEvent::Final(string()), false),
         3 => (DictationEvent::Error(string()), true),
         4 => (DictationEvent::Ended, true),
+        5 => match string().parse::<f32>() {
+            Ok(level) => (DictationEvent::Level(level.clamp(0.0, 1.0)), false),
+            Err(_) => return,
+        },
         _ => return,
     };
 

--- a/crates/voice/src/lib.rs
+++ b/crates/voice/src/lib.rs
@@ -1,0 +1,87 @@
+//! Live dictation backed by the macOS 26 SpeechAnalyzer/SpeechTranscriber API.
+//!
+//! On macOS 26+ (built against an SDK ≥ 26) [`is_supported`] returns true and
+//! [`start`] opens a microphone dictation session whose transcript is streamed
+//! through [`DictationEvent`]s. Everywhere else the crate compiles to a stub
+//! that reports unsupported.
+//!
+//! Event contract: after `start` returns, the callback receives at most one
+//! `Ready`, then any number of `Volatile`/`Final` events, then exactly one
+//! terminal event (`Error` or `Ended`). Each `Volatile` replaces the previous
+//! volatile text; a `Final` commits text (the current volatile range becomes
+//! the final text and a new empty volatile range begins after it). Callbacks
+//! arrive on arbitrary non-UI threads.
+
+/// A transcription event delivered to the callback passed to [`start`].
+#[derive(Debug, Clone)]
+pub enum DictationEvent {
+    /// Speech assets are installed and the microphone is live.
+    Ready,
+    /// In-progress hypothesis; replaces the previous `Volatile` text.
+    Volatile(String),
+    /// Finalized text; replaces the current volatile text and is stable.
+    Final(String),
+    /// The session failed. Terminal.
+    Error(String),
+    /// The session ended after [`DictationSession::stop`] or drop. Terminal.
+    Ended,
+}
+
+/// A running dictation session. Dropping it cancels recognition.
+pub struct DictationSession {
+    #[allow(dead_code)]
+    imp: imp::Session,
+}
+
+impl DictationSession {
+    /// Stop capturing and finalize: remaining audio is decoded, a last
+    /// `Final` may be delivered, then `Ended`.
+    pub fn stop(&self) {
+        self.imp.stop();
+    }
+}
+
+/// Whether live dictation is available on this machine (macOS 26+, shim
+/// compiled in, and the locale returned by [`preferred_locale`] supported).
+pub fn is_supported() -> bool {
+    imp::is_supported()
+}
+
+/// Map an app locale (`"zh-CN"`, `"en"`, …) to the dictation locale to use.
+pub fn preferred_locale(app_locale: &str) -> &'static str {
+    if app_locale.starts_with("zh") { "zh_CN" } else { "en_US" }
+}
+
+/// Start a microphone dictation session for `locale` (an identifier such as
+/// `"zh_CN"`). Events are delivered on arbitrary threads.
+pub fn start(
+    locale: &str,
+    on_event: Box<dyn Fn(DictationEvent) + Send + Sync>,
+) -> Result<DictationSession, String> {
+    imp::start(locale, on_event).map(|imp| DictationSession { imp })
+}
+
+#[cfg(all(target_os = "macos", voice_shim))]
+mod imp;
+
+#[cfg(not(all(target_os = "macos", voice_shim)))]
+mod imp {
+    use super::DictationEvent;
+
+    pub struct Session;
+
+    impl Session {
+        pub fn stop(&self) {}
+    }
+
+    pub fn is_supported() -> bool {
+        false
+    }
+
+    pub fn start(
+        _locale: &str,
+        _on_event: Box<dyn Fn(DictationEvent) + Send + Sync>,
+    ) -> Result<Session, String> {
+        Err("dictation is not supported on this platform".into())
+    }
+}

--- a/crates/voice/src/lib.rs
+++ b/crates/voice/src/lib.rs
@@ -61,6 +61,18 @@ pub fn start(
     imp::start(locale, on_event).map(|imp| DictationSession { imp })
 }
 
+/// Start transcription from an audio file.
+///
+/// This is an implementation hook for examples and integration testing.
+#[doc(hidden)]
+pub fn start_file(
+    locale: &str,
+    path: &str,
+    on_event: Box<dyn Fn(DictationEvent) + Send + Sync>,
+) -> Result<DictationSession, String> {
+    imp::start_file(locale, path, on_event).map(|imp| DictationSession { imp })
+}
+
 #[cfg(all(target_os = "macos", voice_shim))]
 mod imp;
 
@@ -80,6 +92,14 @@ mod imp {
 
     pub fn start(
         _locale: &str,
+        _on_event: Box<dyn Fn(DictationEvent) + Send + Sync>,
+    ) -> Result<Session, String> {
+        Err("dictation is not supported on this platform".into())
+    }
+
+    pub fn start_file(
+        _locale: &str,
+        _path: &str,
         _on_event: Box<dyn Fn(DictationEvent) + Send + Sync>,
     ) -> Result<Session, String> {
         Err("dictation is not supported on this platform".into())

--- a/crates/voice/src/lib.rs
+++ b/crates/voice/src/lib.rs
@@ -52,7 +52,11 @@ pub fn is_supported() -> bool {
 
 /// Map an app locale (`"zh-CN"`, `"en"`, …) to the dictation locale to use.
 pub fn preferred_locale(app_locale: &str) -> &'static str {
-    if app_locale.starts_with("zh") { "zh_CN" } else { "en_US" }
+    if app_locale.starts_with("zh") {
+        "zh_CN"
+    } else {
+        "en_US"
+    }
 }
 
 /// Start a microphone dictation session for `locale` (an identifier such as

--- a/crates/voice/src/lib.rs
+++ b/crates/voice/src/lib.rs
@@ -17,6 +17,9 @@
 pub enum DictationEvent {
     /// Speech assets are installed and the microphone is live.
     Ready,
+    /// Microphone input level in `0.0..=1.0`, reported continuously while
+    /// recording (roughly at the audio callback rate). Purely cosmetic.
+    Level(f32),
     /// In-progress hypothesis; replaces the previous `Volatile` text.
     Volatile(String),
     /// Finalized text; replaces the current volatile text and is stable.

--- a/crates/voice/swift/shim.swift
+++ b/crates/voice/swift/shim.swift
@@ -8,6 +8,7 @@ private let eventVolatile: Int32 = 1
 private let eventFinal: Int32 = 2
 private let eventError: Int32 = 3
 private let eventEnded: Int32 = 4
+private let eventLevel: Int32 = 5
 
 public typealias VoiceEventCallback = @convention(c) (
     UnsafeMutableRawPointer?, Int32, UnsafePointer<CChar>?
@@ -205,6 +206,11 @@ private actor VoiceCore {
         }
         input.installTap(onBus: 0, bufferSize: 1_024, format: naturalFormat) {
             buffer, _ in
+            if let level = Self.level(of: buffer) {
+                Task { [weak self] in
+                    await self?.emitLevel(level)
+                }
+            }
             do {
                 // A rate-converting AVAudioConverter may legitimately emit an
                 // empty buffer while it primes; skip those instead of failing.
@@ -224,6 +230,22 @@ private actor VoiceCore {
         engine.prepare()
         try engine.start()
         emitReady()
+    }
+
+    /// Perceptual input level in 0...1: RMS mapped over a -50 dBFS..0 dBFS
+    /// range, which tracks speech dynamics far better than linear amplitude.
+    nonisolated private static func level(of buffer: AVAudioPCMBuffer) -> Float? {
+        guard let samples = buffer.floatChannelData?[0], buffer.frameLength > 0 else {
+            return nil
+        }
+        var sum: Float = 0
+        for index in 0..<Int(buffer.frameLength) {
+            sum += samples[index] * samples[index]
+        }
+        let rms = (sum / Float(buffer.frameLength)).squareRoot()
+        guard rms > 0 else { return 0 }
+        let decibels = 20 * log10(rms)
+        return min(1, max(0, (decibels + 50) / 50))
     }
 
     nonisolated private static func convert(
@@ -312,6 +334,11 @@ private actor VoiceCore {
     private func reportFailure(_ error: Error) {
         guard !stopping else { return }
         emitTerminal(kind: eventError, text: error.localizedDescription)
+    }
+
+    private func emitLevel(_ level: Float) {
+        guard !terminal, ready else { return }
+        String(format: "%.3f", level).withCString { callback(context, eventLevel, $0) }
     }
 
     private func emit(kind: Int32, text: String) {

--- a/crates/voice/swift/shim.swift
+++ b/crates/voice/swift/shim.swift
@@ -1,0 +1,473 @@
+@preconcurrency import AVFoundation
+import CoreMedia
+import Foundation
+import Speech
+
+private let eventReady: Int32 = 0
+private let eventVolatile: Int32 = 1
+private let eventFinal: Int32 = 2
+private let eventError: Int32 = 3
+private let eventEnded: Int32 = 4
+
+public typealias VoiceEventCallback = @convention(c) (
+    UnsafeMutableRawPointer?, Int32, UnsafePointer<CChar>?
+) -> Void
+
+@available(macOS 26.0, *)
+private enum VoiceSource: Sendable {
+    case microphone
+    case file(URL)
+}
+
+@available(macOS 26.0, *)
+private final class AudioFeeder: @unchecked Sendable {
+    let stream: AsyncStream<AnalyzerInput>
+
+    private let continuation: AsyncStream<AnalyzerInput>.Continuation
+    private let format: AVAudioFormat
+    private let lock = NSLock()
+    private var frameCount: AVAudioFramePosition = 0
+    private var finished = false
+
+    init(format: AVAudioFormat) {
+        self.format = format
+        (stream, continuation) = AsyncStream<AnalyzerInput>.makeStream()
+    }
+
+    func feed(_ buffer: AVAudioPCMBuffer) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !finished else { return }
+
+        continuation.yield(
+            AnalyzerInput(
+                buffer: buffer,
+                bufferStartTime: CMTime(
+                    value: frameCount,
+                    timescale: CMTimeScale(format.sampleRate.rounded())
+                )
+            )
+        )
+        frameCount += AVAudioFramePosition(buffer.frameLength)
+    }
+
+    func finish() -> CMTime? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !finished else { return currentTime }
+        finished = true
+        continuation.finish()
+        return currentTime
+    }
+
+    private var currentTime: CMTime? {
+        guard frameCount > 0 else { return nil }
+        return CMTime(
+            value: frameCount,
+            timescale: CMTimeScale(format.sampleRate.rounded())
+        )
+    }
+}
+
+@available(macOS 26.0, *)
+private actor VoiceCore {
+    private let localeIdentifier: String
+    private let source: VoiceSource
+    private let context: UnsafeMutableRawPointer?
+    private let callback: VoiceEventCallback
+
+    private var analyzer: SpeechAnalyzer?
+    private var engine: AVAudioEngine?
+    private var feeder: AudioFeeder?
+    private var analysisTask: Task<Void, Never>?
+    private var resultsTask: Task<Void, Never>?
+    private var terminal = false
+    private var ready = false
+    private var stopping = false
+
+    init(
+        localeIdentifier: String,
+        source: VoiceSource,
+        context: UnsafeMutableRawPointer?,
+        callback: @escaping VoiceEventCallback
+    ) {
+        self.localeIdentifier = localeIdentifier
+        self.source = source
+        self.context = context
+        self.callback = callback
+    }
+
+    func run() async {
+        do {
+            let requestedLocale = Locale(identifier: localeIdentifier)
+            guard let locale = await SpeechTranscriber.supportedLocale(
+                equivalentTo: requestedLocale
+            ) else {
+                throw VoiceFailure("unsupported speech locale: \(localeIdentifier)")
+            }
+
+            let transcriber = SpeechTranscriber(
+                locale: locale,
+                transcriptionOptions: [],
+                reportingOptions: [.volatileResults],
+                attributeOptions: []
+            )
+            let modules: [any SpeechModule] = [transcriber]
+            try await installAssets(for: modules)
+            guard !stopping else {
+                await finishAsEnded(cancel: true)
+                return
+            }
+
+            let analyzer = SpeechAnalyzer(modules: modules)
+            self.analyzer = analyzer
+            startResults(from: transcriber)
+
+            switch source {
+            case .file(let url):
+                try await runFile(url: url, analyzer: analyzer)
+            case .microphone:
+                try await runMicrophone(analyzer: analyzer, modules: modules)
+            }
+        } catch {
+            if !stopping {
+                emitTerminal(kind: eventError, text: error.localizedDescription)
+            }
+        }
+    }
+
+    private func installAssets(for modules: [any SpeechModule]) async throws {
+        var status = await AssetInventory.status(forModules: modules)
+        guard status != .unsupported else {
+            throw VoiceFailure("speech assets are unsupported for \(localeIdentifier)")
+        }
+
+        if status != .installed {
+            if let request = try await AssetInventory.assetInstallationRequest(
+                supporting: modules
+            ) {
+                try await request.downloadAndInstall()
+            }
+
+            status = await AssetInventory.status(forModules: modules)
+            while status == .downloading {
+                try await Task.sleep(nanoseconds: 100_000_000)
+                status = await AssetInventory.status(forModules: modules)
+            }
+            guard status == .installed else {
+                throw VoiceFailure("speech assets could not be installed for \(localeIdentifier)")
+            }
+        }
+    }
+
+    private func startResults(from transcriber: SpeechTranscriber) {
+        resultsTask = Task { [weak self] in
+            do {
+                for try await result in transcriber.results {
+                    let text = String(result.text.characters)
+                    await self?.emit(
+                        kind: result.isFinal ? eventFinal : eventVolatile,
+                        text: text
+                    )
+                }
+            } catch {
+                await self?.reportFailure(error)
+            }
+        }
+    }
+
+    private func runFile(url: URL, analyzer: SpeechAnalyzer) async throws {
+        let file = try AVAudioFile(forReading: url)
+        try await analyzer.prepareToAnalyze(in: file.processingFormat)
+        emitReady()
+        let lastSample = try await analyzer.analyzeSequence(from: file)
+        if let lastSample {
+            try await analyzer.finalizeAndFinish(through: lastSample)
+        } else {
+            try await analyzer.finalizeAndFinishThroughEndOfInput()
+        }
+        await resultsTask?.value
+        emitTerminal(kind: eventEnded, text: nil)
+    }
+
+    private func runMicrophone(
+        analyzer: SpeechAnalyzer,
+        modules: [any SpeechModule]
+    ) async throws {
+        let engine = AVAudioEngine()
+        let input = engine.inputNode
+        let naturalFormat = input.outputFormat(forBus: 0)
+        guard naturalFormat.sampleRate > 0, naturalFormat.channelCount > 0 else {
+            throw VoiceFailure("microphone has no usable audio format")
+        }
+        guard let analysisFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
+            compatibleWith: modules,
+            considering: naturalFormat
+        ) else {
+            throw VoiceFailure("no compatible speech audio format")
+        }
+
+        let feeder = AudioFeeder(format: analysisFormat)
+        self.feeder = feeder
+        self.engine = engine
+        try await analyzer.prepareToAnalyze(in: analysisFormat)
+        analysisTask = Task { [weak self] in
+            do {
+                try await analyzer.start(inputSequence: feeder.stream)
+            } catch {
+                await self?.reportFailure(error)
+            }
+        }
+
+        guard let converter = AVAudioConverter(from: naturalFormat, to: analysisFormat) else {
+            throw VoiceFailure("could not create microphone audio converter")
+        }
+        input.installTap(onBus: 0, bufferSize: 1_024, format: naturalFormat) {
+            buffer, _ in
+            do {
+                let converted = try Self.convert(
+                    buffer,
+                    with: converter,
+                    to: analysisFormat
+                )
+                feeder.feed(converted)
+            } catch {
+                Task { [weak self] in
+                    await self?.reportFailure(error)
+                }
+            }
+        }
+        engine.prepare()
+        try engine.start()
+        emitReady()
+    }
+
+    nonisolated private static func convert(
+        _ input: AVAudioPCMBuffer,
+        with converter: AVAudioConverter,
+        to format: AVAudioFormat
+    ) throws -> AVAudioPCMBuffer {
+        let ratio = format.sampleRate / input.format.sampleRate
+        let capacity = AVAudioFrameCount(ceil(Double(input.frameLength) * ratio)) + 1
+        guard let output = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: capacity) else {
+            throw VoiceFailure("could not allocate converted microphone buffer")
+        }
+
+        var suppliedInput = false
+        var conversionError: NSError?
+        let status = converter.convert(to: output, error: &conversionError) { _, state in
+            if suppliedInput {
+                state.pointee = .noDataNow
+                return nil
+            }
+            suppliedInput = true
+            state.pointee = .haveData
+            return input
+        }
+        if let conversionError {
+            throw conversionError
+        }
+        guard (status == .haveData || status == .inputRanDry), output.frameLength > 0 else {
+            throw VoiceFailure("microphone audio conversion produced no data")
+        }
+        return output
+    }
+
+    func stop() async {
+        guard !terminal, !stopping else { return }
+        stopping = true
+        stopCapture()
+
+        do {
+            if let analyzer {
+                if let lastSample = feeder?.finish() {
+                    try await analyzer.finalizeAndFinish(through: lastSample)
+                } else {
+                    try await analyzer.finalizeAndFinishThroughEndOfInput()
+                }
+            }
+            await analysisTask?.value
+            await resultsTask?.value
+            emitTerminal(kind: eventEnded, text: nil)
+        } catch {
+            emitTerminal(kind: eventError, text: error.localizedDescription)
+        }
+    }
+
+    func cancel() async {
+        guard !terminal else { return }
+        stopping = true
+        stopCapture()
+        _ = feeder?.finish()
+        if let analyzer {
+            await analyzer.cancelAndFinishNow()
+        }
+        analysisTask?.cancel()
+        resultsTask?.cancel()
+        emitTerminal(kind: eventEnded, text: nil)
+    }
+
+    private func finishAsEnded(cancel: Bool) async {
+        if cancel, let analyzer {
+            await analyzer.cancelAndFinishNow()
+        }
+        emitTerminal(kind: eventEnded, text: nil)
+    }
+
+    private func stopCapture() {
+        if let engine {
+            engine.inputNode.removeTap(onBus: 0)
+            engine.stop()
+        }
+        engine = nil
+    }
+
+    private func emitReady() {
+        guard !terminal, !ready else { return }
+        ready = true
+        callback(context, eventReady, nil)
+    }
+
+    private func reportFailure(_ error: Error) {
+        guard !stopping else { return }
+        emitTerminal(kind: eventError, text: error.localizedDescription)
+    }
+
+    private func emit(kind: Int32, text: String) {
+        guard !terminal, ready else { return }
+        text.withCString { callback(context, kind, $0) }
+    }
+
+    private func emitTerminal(kind: Int32, text: String?) {
+        guard !terminal else { return }
+        terminal = true
+        if let text {
+            text.withCString { callback(context, kind, $0) }
+        } else {
+            callback(context, kind, nil)
+        }
+    }
+}
+
+private struct VoiceFailure: LocalizedError {
+    let message: String
+
+    init(_ message: String) {
+        self.message = message
+    }
+
+    var errorDescription: String? { message }
+}
+
+private final class LockedFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = false
+
+    func set(_ newValue: Bool) {
+        lock.lock()
+        value = newValue
+        lock.unlock()
+    }
+
+    func get() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
+@available(macOS 26.0, *)
+private final class VoiceSession: @unchecked Sendable {
+    let core: VoiceCore
+
+    init(
+        locale: String,
+        source: VoiceSource,
+        context: UnsafeMutableRawPointer?,
+        callback: @escaping VoiceEventCallback
+    ) {
+        core = VoiceCore(
+            localeIdentifier: locale,
+            source: source,
+            context: context,
+            callback: callback
+        )
+        Task { await core.run() }
+    }
+
+    func stop() {
+        Task { await core.stop() }
+    }
+
+    func cancel() {
+        Task { await core.cancel() }
+    }
+}
+
+@_cdecl("voice_is_supported")
+public func voiceIsSupported(_ localeCString: UnsafePointer<CChar>?) -> Bool {
+    guard #available(macOS 26.0, *), let localeCString else { return false }
+    let identifier = String(cString: localeCString)
+    let semaphore = DispatchSemaphore(value: 0)
+    let supported = LockedFlag()
+    Task {
+        let result = await SpeechTranscriber.supportedLocale(
+            equivalentTo: Locale(identifier: identifier)
+        ) != nil
+        supported.set(result)
+        semaphore.signal()
+    }
+    semaphore.wait()
+    return supported.get()
+}
+
+@_cdecl("voice_start")
+public func voiceStart(
+    _ localeCString: UnsafePointer<CChar>?,
+    _ context: UnsafeMutableRawPointer?,
+    _ callback: VoiceEventCallback?
+) -> UnsafeMutableRawPointer? {
+    guard #available(macOS 26.0, *), let localeCString, let callback else { return nil }
+    let session = VoiceSession(
+        locale: String(cString: localeCString),
+        source: .microphone,
+        context: context,
+        callback: callback
+    )
+    return Unmanaged.passRetained(session).toOpaque()
+}
+
+@_cdecl("voice_start_file")
+public func voiceStartFile(
+    _ localeCString: UnsafePointer<CChar>?,
+    _ pathCString: UnsafePointer<CChar>?,
+    _ context: UnsafeMutableRawPointer?,
+    _ callback: VoiceEventCallback?
+) -> UnsafeMutableRawPointer? {
+    guard #available(macOS 26.0, *),
+          let localeCString,
+          let pathCString,
+          let callback
+    else { return nil }
+    let session = VoiceSession(
+        locale: String(cString: localeCString),
+        source: .file(URL(fileURLWithPath: String(cString: pathCString))),
+        context: context,
+        callback: callback
+    )
+    return Unmanaged.passRetained(session).toOpaque()
+}
+
+@_cdecl("voice_stop")
+public func voiceStop(_ pointer: UnsafeMutableRawPointer?) {
+    guard #available(macOS 26.0, *), let pointer else { return }
+    Unmanaged<VoiceSession>.fromOpaque(pointer).takeUnretainedValue().stop()
+}
+
+@_cdecl("voice_free")
+public func voiceFree(_ pointer: UnsafeMutableRawPointer?) {
+    guard #available(macOS 26.0, *), let pointer else { return }
+    let unmanaged = Unmanaged<VoiceSession>.fromOpaque(pointer)
+    unmanaged.takeUnretainedValue().cancel()
+    unmanaged.release()
+}

--- a/crates/voice/swift/shim.swift
+++ b/crates/voice/swift/shim.swift
@@ -24,48 +24,29 @@ private final class AudioFeeder: @unchecked Sendable {
     let stream: AsyncStream<AnalyzerInput>
 
     private let continuation: AsyncStream<AnalyzerInput>.Continuation
-    private let format: AVAudioFormat
     private let lock = NSLock()
-    private var frameCount: AVAudioFramePosition = 0
     private var finished = false
 
-    init(format: AVAudioFormat) {
-        self.format = format
+    init() {
         (stream, continuation) = AsyncStream<AnalyzerInput>.makeStream()
     }
 
+    // No explicit bufferStartTime: the analyzer tracks the live input timeline
+    // itself, and supplying our own timestamps kept it from ever reporting
+    // results or honoring a targeted finalize.
     func feed(_ buffer: AVAudioPCMBuffer) {
         lock.lock()
         defer { lock.unlock() }
         guard !finished else { return }
-
-        continuation.yield(
-            AnalyzerInput(
-                buffer: buffer,
-                bufferStartTime: CMTime(
-                    value: frameCount,
-                    timescale: CMTimeScale(format.sampleRate.rounded())
-                )
-            )
-        )
-        frameCount += AVAudioFramePosition(buffer.frameLength)
+        continuation.yield(AnalyzerInput(buffer: buffer))
     }
 
-    func finish() -> CMTime? {
+    func finish() {
         lock.lock()
         defer { lock.unlock() }
-        guard !finished else { return currentTime }
+        guard !finished else { return }
         finished = true
         continuation.finish()
-        return currentTime
-    }
-
-    private var currentTime: CMTime? {
-        guard frameCount > 0 else { return nil }
-        return CMTime(
-            value: frameCount,
-            timescale: CMTimeScale(format.sampleRate.rounded())
-        )
     }
 }
 
@@ -207,7 +188,7 @@ private actor VoiceCore {
             throw VoiceFailure("no compatible speech audio format")
         }
 
-        let feeder = AudioFeeder(format: analysisFormat)
+        let feeder = AudioFeeder()
         self.feeder = feeder
         self.engine = engine
         try await analyzer.prepareToAnalyze(in: analysisFormat)
@@ -225,12 +206,15 @@ private actor VoiceCore {
         input.installTap(onBus: 0, bufferSize: 1_024, format: naturalFormat) {
             buffer, _ in
             do {
-                let converted = try Self.convert(
+                // A rate-converting AVAudioConverter may legitimately emit an
+                // empty buffer while it primes; skip those instead of failing.
+                if let converted = try Self.convert(
                     buffer,
                     with: converter,
                     to: analysisFormat
-                )
-                feeder.feed(converted)
+                ) {
+                    feeder.feed(converted)
+                }
             } catch {
                 Task { [weak self] in
                     await self?.reportFailure(error)
@@ -246,7 +230,7 @@ private actor VoiceCore {
         _ input: AVAudioPCMBuffer,
         with converter: AVAudioConverter,
         to format: AVAudioFormat
-    ) throws -> AVAudioPCMBuffer {
+    ) throws -> AVAudioPCMBuffer? {
         let ratio = format.sampleRate / input.format.sampleRate
         let capacity = AVAudioFrameCount(ceil(Double(input.frameLength) * ratio)) + 1
         guard let output = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: capacity) else {
@@ -267,10 +251,10 @@ private actor VoiceCore {
         if let conversionError {
             throw conversionError
         }
-        guard (status == .haveData || status == .inputRanDry), output.frameLength > 0 else {
-            throw VoiceFailure("microphone audio conversion produced no data")
+        guard status == .haveData || status == .inputRanDry else {
+            throw VoiceFailure("microphone audio conversion failed")
         }
-        return output
+        return output.frameLength > 0 ? output : nil
     }
 
     func stop() async {
@@ -279,12 +263,9 @@ private actor VoiceCore {
         stopCapture()
 
         do {
+            feeder?.finish()
             if let analyzer {
-                if let lastSample = feeder?.finish() {
-                    try await analyzer.finalizeAndFinish(through: lastSample)
-                } else {
-                    try await analyzer.finalizeAndFinishThroughEndOfInput()
-                }
+                try await analyzer.finalizeAndFinishThroughEndOfInput()
             }
             await analysisTask?.value
             await resultsTask?.value
@@ -298,7 +279,7 @@ private actor VoiceCore {
         guard !terminal else { return }
         stopping = true
         stopCapture()
-        _ = feeder?.finish()
+        feeder?.finish()
         if let analyzer {
             await analyzer.cancelAndFinishNow()
         }

--- a/crates/voice/swift/shim.swift
+++ b/crates/voice/swift/shim.swift
@@ -82,17 +82,18 @@ private actor VoiceCore {
     func run() async {
         do {
             let requestedLocale = Locale(identifier: localeIdentifier)
-            guard let locale = await SpeechTranscriber.supportedLocale(
+            guard let locale = await DictationTranscriber.supportedLocale(
                 equivalentTo: requestedLocale
             ) else {
                 throw VoiceFailure("unsupported speech locale: \(localeIdentifier)")
             }
 
-            let transcriber = SpeechTranscriber(
+            // DictationTranscriber's progressive preset streams hypotheses
+            // every few hundred ms; SpeechTranscriber with plain
+            // volatileResults buffers everything until finalization.
+            let transcriber = DictationTranscriber(
                 locale: locale,
-                transcriptionOptions: [],
-                reportingOptions: [.volatileResults],
-                attributeOptions: []
+                preset: .progressiveLongDictation
             )
             let modules: [any SpeechModule] = [transcriber]
             try await installAssets(for: modules)
@@ -142,7 +143,7 @@ private actor VoiceCore {
         }
     }
 
-    private func startResults(from transcriber: SpeechTranscriber) {
+    private func startResults(from transcriber: DictationTranscriber) {
         resultsTask = Task { [weak self] in
             do {
                 for try await result in transcriber.results {
@@ -179,6 +180,12 @@ private actor VoiceCore {
         let engine = AVAudioEngine()
         let input = engine.inputNode
         let naturalFormat = input.outputFormat(forBus: 0)
+        let authorization = AVCaptureDevice.authorizationStatus(for: .audio)
+        voiceLog(
+            "mic start: audio authorization=\(authorization.rawValue) "
+                + "(0 notDetermined, 1 restricted, 2 denied, 3 authorized), "
+                + "format=\(naturalFormat)"
+        )
         guard naturalFormat.sampleRate > 0, naturalFormat.channelCount > 0 else {
             throw VoiceFailure("microphone has no usable audio format")
         }
@@ -342,19 +349,29 @@ private actor VoiceCore {
     }
 
     private func emit(kind: Int32, text: String) {
-        guard !terminal, ready else { return }
+        guard !terminal, ready else {
+            voiceLog("dropping event kind=\(kind) (terminal=\(terminal) ready=\(ready))")
+            return
+        }
         text.withCString { callback(context, kind, $0) }
     }
 
     private func emitTerminal(kind: Int32, text: String?) {
         guard !terminal else { return }
         terminal = true
+        voiceLog("terminal kind=\(kind) text=\(text ?? "nil")")
         if let text {
             text.withCString { callback(context, kind, $0) }
         } else {
             callback(context, kind, nil)
         }
     }
+}
+
+/// Diagnostic line on stderr; shows up in the app log next to env_logger
+/// output. Cheap and always on — dictation is short-lived and low-volume.
+private func voiceLog(_ message: String) {
+    FileHandle.standardError.write(Data("[tcode-voice] \(message)\n".utf8))
 }
 
 private struct VoiceFailure: LocalizedError {
@@ -419,7 +436,7 @@ public func voiceIsSupported(_ localeCString: UnsafePointer<CChar>?) -> Bool {
     let semaphore = DispatchSemaphore(value: 0)
     let supported = LockedFlag()
     Task {
-        let result = await SpeechTranscriber.supportedLocale(
+        let result = await DictationTranscriber.supportedLocale(
             equivalentTo: Locale(identifier: identifier)
         ) != nil
         supported.set(result)

--- a/docs/plans/voice-input.md
+++ b/docs/plans/voice-input.md
@@ -1,0 +1,40 @@
+# Voice input (macOS 26 live dictation) — implementation plan
+
+Branch: `feat/voice-input`. Research: `docs/voice-input-research.md`.
+
+Scope: live transcription into the composer via the macOS 26
+SpeechAnalyzer/SpeechTranscriber API. The mic button exists **only** on
+macOS 26+; on every other platform/version it is absent. No settings
+section, no cloud backends, no voice mode.
+
+## Architecture
+
+- `crates/voice` (`tcode-voice`): Swift shim (`swift/shim.swift`, C ABI via
+  `@_cdecl`) compiled by `build.rs` with `swiftc` when the SDK is ≥ 26,
+  gated by the `voice_shim` cfg; stub elsewhere. Swift owns the entire audio
+  path (AVAudioEngine mic → SpeechAnalyzer). Public API pinned in
+  `crates/voice/src/lib.rs`: `is_supported()`, `preferred_locale()`,
+  `start(locale, callback) -> DictationSession`, events
+  `Ready | Volatile | Final | Error | Ended`.
+- `crates/ui`: mic toggle button in the composer control row
+  (macOS + `is_supported()` only). Insertion anchor at cursor; each
+  `Volatile` replaces the provisional range via
+  `set_selected_range` + `TextareaState::replace`; `Final` commits and moves
+  the anchor. Esc or a second click stops; submit/thread-switch stops too.
+- Release packaging: `NSMicrophoneUsageDescription` (+
+  `NSSpeechRecognitionUsageDescription`) added to the generated Info.plist
+  in `.github/workflows/release.yml`.
+
+## Acceptance criteria
+
+1. `cargo run -p tcode-voice --example file_dictation -- /tmp/voice-smoke/zh.aiff zh_CN`
+   prints ≥ 3 `volatile:` lines and one `final:` line containing 超时处理,
+   then `ended`. (Audio fixture from `say -v Tingting`; regenerate with
+   `say -v Tingting -o /tmp/voice-smoke/zh.aiff "把这个函数改成异步的，然后加一个超时处理"`.)
+2. `cargo check --workspace` and `cargo build` pass on macOS.
+3. With `TCODE_VOICE_FORCE_STUB=1` (build.rs env override), the workspace
+   still builds and `is_supported()` is false — proves the non-mac path.
+4. In the running app: mic button visible in the composer, click starts
+   (button shows active state), speech appears live in the editor, second
+   click stops and keeps the text. Esc during recording stops it.
+5. `cargo test -p tcode-ui` passes; locale key-set test passes (en + zh-CN).

--- a/docs/voice-input-research.md
+++ b/docs/voice-input-research.md
@@ -1,0 +1,153 @@
+# 语音输入与语音模式调研报告
+
+调研日期：2026-08-21。所有外部主张均来自一手来源（官方文档 / 仓库源码 / release notes），无法验证的均标注 **未验证**。三份底层调研（代码库集成图、ASR 技术全景、Codex CLI 语音专项）的完整引用见文末来源清单。
+
+## 结论速览
+
+1. **Codex 官方语音输入不可复用**：该功能（0.105.0 按住空格听写）已于 0.118.0 被官方整体删除，且它本来就不是本地识别——是 cpal 录音 + 整段 WAV 上传 OpenAI 云端（`gpt-4o-mini-transcribe`）。代码是 Apache-2.0 可以抄思路，但深度耦合 TUI、不是可依赖的 crate。真正值得抄的是它的 **UX 模式**（插入锚点、按住即说）和 **架构形状**（录完再传的一次性转写）。
+2. **本地方案首选 sherpa-onnx**：Apache-2.0、官方 Rust 绑定 + 50+ 示例、唯一有真流式中英双语模型（Zipformer/Paraformer）的引擎，还内置 Silero VAD 和 TTS——一个依赖同时覆盖语音输入和未来的语音模式。
+3. **MVP 建议"录完即转"而非流式**：按住说话 → 松开 → SenseVoice-small（int8 仅 228MB，中英日韩粤 + 自动标点）离线转写 → 插入光标处。实现量最小，延迟可接受（短句亚秒级），流式 partial 留到二期。
+4. **语音模式（对话）技术上可行但应后置**：sherpa-onnx TTS（Kokoro 中英模型）+ 已有采集/VAD 层即可搭半双工原型；全双工的打断/回声消除/延迟才是难点。
+
+---
+
+## 一、Codex 官方语音输入：能不能复用？
+
+### 事实（源码级确认）
+
+| 事项 | 结论 |
+|---|---|
+| 存在过吗 | 是。0.105.0（2026-02-25）实验性上线"按住空格听写"，需 `features.voice_transcription = true` |
+| 现在还在吗 | **不在**。PR #16114 于 0.118.0（2026-03-31）整体删除；本机 0.148.0 无此功能。另一个"realtime voice" TUI 实验也已在 2026-06 删除 |
+| 是本地识别吗 | **不是**。cpal 采集 → 24kHz 单声道 16-bit WAV（hound 编码，手写重采样）→ 松开后整段上传。API key 走公开 `POST /v1/audio/transcriptions`（`gpt-4o-mini-transcribe`），ChatGPT 登录走未公开的 `chatgpt.com/backend-api/transcribe` |
+| 无流式 | 录音中无 partial、无增量解码，只有松开后的一次性结果 |
+| 可作为 crate 依赖吗 | **不可**。私有 TUI 模块，耦合 Codex 鉴权/配置/事件类型；无 `codex-voice` crate。0.148 的 `codex-utils-audio` 只是 data-URL/token 工具，不含采集或转写 |
+| 许可证 | Apache-2.0，抄代码合法（需保留声明）；但许可证不覆盖服务——`/backend-api/transcribe` 是未公开端点，第三方调用是否被允许 **未验证**，不应依赖 |
+
+### 0.148 仍存在的可编程接口：`thread/realtime/*`
+
+Codex app-server 有一套**实验性** JSON-RPC 实时接口，且暴露流式转写：
+
+- 方法：`thread/realtime/start | appendAudio | appendText | appendSpeech | stop | listVoices`
+- 通知：`thread/realtime/transcript/delta`、`transcript/done`、`outputAudio/delta`、`error`、`closed` 等
+- 配置 `[realtime] version = "v2"`、`type = "transcription"` 时为纯转写会话：24kHz PCM 输入、`gpt-4o-mini-transcribe`、无 VAD/无自动应答
+- 门槛：客户端须声明 `capabilities.experimentalApi: true`（tcode 已声明，见 `crates/agent/src/codex.rs:95`）+ Codex 侧 `features.realtime_conversation = true`（0.148 默认关）
+- **限制：WebSocket 路径要求 API key 鉴权**，纯 ChatGPT OAuth 登录用不了；且整个接口标注 UnderDevelopment，版本间可能随意变动
+
+**判断**：tcode 今天技术上就能驱动它（我们本来就是 app-server 客户端），可以作为"Codex 用户的云端流式转写"实验后端加个 feature flag 试验，但不能当主路径——不稳定、要 API key、只覆盖 Codex 一家 agent。
+
+### 值得抄的 UX（比代码更有价值）
+
+- **插入锚点**：录音开始时在光标处放一个占位符（内联电平动画 → 转写中 spinner → 替换为最终文本），用户可以在已有文字中间听写，异步完成也不会插错位置——这是最值得抄的一条。
+- 按住即说（push-to-talk）为主交互；但空格键 hold 在桌面编辑器里与正常打字冲突，tcode 应改为**麦克风按钮 + 可配置快捷键**，Esc 取消。
+- API-key 分支会把 composer 已有文本作为转写 `prompt` 传入，帮助识别项目名/技术词——本地引擎虽不支持 prompt，云端 BYOK 路径应保留此设计。
+- 不值得抄：失败时静默移除占位符（无重试、无持久错误提示）、Linux 直接编译为 no-op、无权限引导。
+
+---
+
+## 二、本地 ASR 引擎对比（中英混合是硬需求）
+
+| 引擎 | 许可 | 流式 | 中英适配 | 体积 | Rust 成熟度 | 加速 |
+|---|---|---|---|---|---|---|
+| **sherpa-onnx** | Apache-2.0（模型另查） | ✅ 真流式（在线 Zipformer/Paraformer，解码器保态） | ✅ 官方中英双语流式模型（2023-02 起多个） | 双语 Zipformer ~340MB fp32，有 int8 | ★ 官方 in-tree crate，50+ 示例（含麦克风流式、VAD、TTS） | CPU 全平台；Linux CUDA；**macOS Metal 未验证** |
+| **SenseVoice-small**（经 sherpa-onnx） | 引擎 Apache-2.0；转换权重再分发条款**未验证** | ❌ 离线整句（配 Silero VAD 可模拟流式） | ✅ 单模型覆盖中/英/粤/日/韩 + 标点/ITN | **int8 228MB** / fp32 894MB | ★ 官方 Rust 示例 | ONNX Runtime，全平台 CPU |
+| **whisper.cpp**（whisper-rs 0.16.0） | MIT / 权重 MIT | ❌ 架构非流式（官方 stream 例自称 naive 滑窗，partial 会回改） | ✅ 99 语多语基线最强；code-switch 无基准（未验证） | turbo Q5 547MB / fp16 1.5GB | ★ API 完善；注意 GitHub 仓库已归档迁至 Codeberg，需锁版本 | ✅ Metal/CoreML/CUDA/Vulkan 最全 |
+| Vosk | Apache-2.0 | ✅ | ❌ 中英模型分开，无双语 | 小模型 40–50MB | 社区 wrapper（0.3.1，旧） | CPU |
+| Moonshine | 代码 MIT；**非英语模型非商用许可** | 流式仅英语 | ❌ 中文单语离线 | Base 58M 参数 | 走 sherpa | — |
+| Parakeet/Canary | CC-BY-4.0 | — | ❌ 无中文 | — | 走 sherpa（离线英文） | — |
+
+**要点**：
+
+- 想要**打字机式实时 partial** → 只有 sherpa-onnx 的在线双语模型能做（Whisper 的"流式"是每 500ms 重转滑窗，partial 会回改，UI 必须按"可替换临时区间"处理）。
+- 想要**最高一次性质量** → whisper large-v3-turbo（Metal 加速最好）或 SenseVoice-small（体积/中文/标点最平衡）。
+- 所有引擎在"把 `Arc<Mutex<T>>` 改成 `tokio::sync::RwLock`"这类中英夹杂开发者语料上的表现都**无一手基准**——选型定案前必须用自建语料做 bake-off（中文、英文、混合句、crate 名、路径、shell 命令、标识符）。
+
+## 三、系统原生与云端
+
+**macOS**：
+
+- **系统听写可能白嫖**：Apple 听写走 NSTextInputClient 文本输入体系，GPUI 实现了该协议，理论上 tcode 输入框已支持系统听写键——**先冒烟测试**，这是零成本的第一档（但无 UI 控制、无模型选择、不跨平台，不能替代自建方案）。
+- macOS 26 的 **SpeechAnalyzer/SpeechTranscriber** 是理想的免下载后端：系统管理模型资产、本地推理、原生 volatile/final 语义。但 objc2 无现成绑定（`objc2-speech` 只覆盖旧的 SFSpeechRecognizer），需要一小段 Swift shim（swift-bridge）；中文资产可用性需实机枚举 `supportedLocales` 验证。适合作为后续增量后端。
+- 权限：直接开麦需要 `NSMicrophoneUsageDescription`——**当前 release.yml 内联生成的 Info.plist 没有这个 key，必须补**，否则 macOS 上一开麦即崩。已有 TCC 权限层可平行扩展（`crates/computer-use-mcp/src/permissions.rs`，现有 Accessibility/录屏两个变体）。
+
+**Windows**：WinRT `Windows.Media.SpeechRecognition` 的自由听写语法**实际走网络**、基础路径限 10 秒、还要求 MSIX 打包身份——不可用作本地默认。Windows 上走"cpal + 本地模型"。
+
+**Linux**：无原生听写 API，唯一路径就是 cpal（ALSA/PipeWire）+ 本地模型。
+
+**云端 BYOK**（可选后端，tcode 不代理 key，桌面端直连）：
+
+| 供应商 | 价格/分钟 | 流式 | 中文 |
+|---|---|---|---|
+| OpenAI gpt-4o-mini/4o-transcribe | ~$0.003–0.006 | 文件流式 delta；实时走 Realtime（$0.017） | 多语（code-switch 未验证） |
+| ElevenLabs Scribe v2 Realtime | $0.0065 | ✅ WebSocket partial/commit | ✅ 明确列出，WER 5–10% 档 |
+| Deepgram Nova-3 | ~$0.005–0.006 | ✅ <300ms | 单语中文 ✅；`multi` 模型**不含中文** |
+| Groq whisper turbo | $0.00067 | ❌ 仅文件上传 | 多语 |
+
+## 四、音频采集与 VAD
+
+- **cpal 0.18.1**（2026-06）：macOS CoreAudio / Windows WASAPI / Linux ALSA(+PipeWire/Pulse 可选)。注意：0.18 流不再自动 start（需 `play()`）；**CoreAudio 后端文档基线升到 macOS 14.2**（issue #1241），确认 tcode 最低系统版本后再定 0.17/0.18。回调在实时音频线程执行——只做拷贝进有界队列，重采样/推理放 worker。Zed 自己也用 cpal（0.17）；不要为采集引入 LiveKit 全家桶。
+- **VAD**：用 sherpa-onnx 内置 Silero VAD（同一个依赖，官方 Rust 示例齐全）。MVP 里 VAD 只做"说话指示灯 + 可选自动停止"，永远保留手动停止；静音尾巴 800–1500ms 起配，保留 pre-roll 防吞首字。
+
+## 五、先例：VS Code 是交互蓝本
+
+VS Code Insiders 1.132（2026-08）内置本地听写：首次使用下载 `nemotron-3.5-asr-streaming-0.6b`，之后完全离线。值得照抄的交互清单：输入框旁麦克风按钮、interim 文本展示、快捷键短按切换/长按 push-to-talk、Esc 取消并删除本次听写、停止保留文本但不提交、可选麦克风设置、可配静音超时、模型与应用分离安装。Zed 的听写仍停留在 issue #16410（planned 未实现）——tcode 有先发机会。
+
+---
+
+## 六、推荐方案与分阶段计划
+
+### 架构：引擎中立的 trait
+
+```text
+cpal 回调 → 有界 PCM 队列 → 降混+重采样(16k/24k) → [VAD] → ASR worker
+  → partial { text, range, stability } / final { text, range }
+  → GPUI 前台 executor → TextareaState 插入
+```
+
+引擎接口：`start(locale_hint, vocab_context)` / `push_audio` / `partial` / `final` / `stop` / `cancel`。本地 sherpa、macOS SpeechAnalyzer、云端 BYOK、（实验性）Codex realtime 都实现同一 trait。
+
+### Phase 0 — 冒烟验证（几乎零成本）
+
+1. macOS 系统听写键能否直接输入 GPUI 输入框（能 → 文档里告诉用户，立即可用）。
+2. 用 sherpa-onnx 官方 Rust 示例在真机跑通 SenseVoice-small 与流式双语 Zipformer，录一组中英混合开发语料做 bake-off，定引擎与模型档位。
+
+### Phase 1 — 语音输入 MVP（录完即转，Codex 同款形状）
+
+- composer 控制行加麦克风按钮（`mod.rs:739-762`）+ 可配置快捷键；按住即说 / 短按切换；Esc 取消。
+- 录音时在光标处放占位符（电平指示 → spinner → 替换为转写文本），用 `set_selected_range` + `TextareaState::replace`（`trigger_menu.rs:187-201` 现成模式）。
+- 引擎：sherpa-onnx + SenseVoice-small int8（首次使用时下载到数据目录，非打包内置）。
+- macOS：permissions.rs 加 Microphone 变体；release.yml 的 Info.plist 补 `NSMicrophoneUsageDescription`；设置页加权限行。
+- 设置节 `voice`（引擎/模型/语言提示/快捷键/静音超时），按 Orchestrate 节的 13 个接缝照抄；en + zh-CN 文案。
+- 明确错误状态：需授权 / 无设备 / 设备占用 / 录音中 / 转写中 / 失败（保留音频可重试，不静默丢弃）。
+
+### Phase 1.5 — 流式 partial 与更多后端
+
+- 在线双语 Zipformer 流式 partial（灰色临时区间，final 落定替换）。
+- macOS 26 SpeechAnalyzer 后端（Swift shim）；云端 BYOK 后端（OpenAI 一次性 / ElevenLabs Realtime）。
+- （可选实验）Codex `thread/realtime/*` 转写会话，flag 门控、锁 Codex 版本。
+
+### Phase 2 — 语音模式（后置）
+
+复用采集/VAD/ASR 层 + sherpa-onnx TTS（Kokoro 中英模型，~80–300MB）→ 半双工按键对话原型。全双工（打断、回声消除、延迟、双模型内存）等听写层稳定后再评估；云端捷径是 OpenAI Realtime（BYOK，$32/M 音频输入 token）。注意 Piper 后继项目已转 GPL-3.0，避免直接内嵌。
+
+### 主要开放风险
+
+1. 中英 code-switch 实际质量（所有引擎均未验证）→ Phase 0 bake-off 是硬前置。
+2. SenseVoice 转换权重的再分发条款 → 用"运行时下载"而非打包内置可绕开分发问题，仍需核对。
+3. sherpa-onnx 在 Apple Silicon 无 Metal 路径 → 流式小模型 CPU 大概率够用，bake-off 时实测 RTF。
+4. cpal 0.18 的 macOS 最低版本要求 → 确认 tcode 支持矩阵。
+
+---
+
+## 来源清单（关键项）
+
+- Codex 语音：openai/codex PR #3381（新增）、PR #16114（删除）、`rust-v0.105.0`/`rust-v0.118.0` release notes、历史 `codex-rs/tui/src/voice.rs`、0.148.0 `app-server-protocol/src/protocol/v2/realtime.rs` 与 `codex-api/.../realtime_websocket/methods_v2.rs`
+- sherpa-onnx：github.com/k2-fsa/sherpa-onnx（rust-api-examples、在线双语模型目录、SenseVoice 文档）
+- whisper.cpp：ggml-org/whisper.cpp（models README、stream 示例、releases）；whisper-rs 0.16.0（docs.rs，仓库已迁 Codeberg）
+- Apple：SpeechAnalyzer/SpeechTranscriber 文档、WWDC25 session 277、NSMicrophoneUsageDescription、macOS 听写指南
+- Microsoft：Windows.Media.SpeechRecognition 文档（在线语法 + 10 秒限制 + MSIX 要求，2026-07 更新）
+- VS Code：code.visualstudio.com/docs/configure/accessibility/voice（1.132，2026-08）
+- Zed：issue #16410（听写请求，open/planned）；Zed 主仓 Cargo.toml（cpal 0.17）
+- cpal：RustAudio/cpal 0.18.1 changelog、issue #1241
+- 云端定价：platform.openai.com/pricing、deepgram.com/pricing、elevenlabs.io/pricing/api、console.groq.com/docs/speech-to-text（均 2026-08-21 访问）
+- tcode 集成点：`crates/ui/src/composer/mod.rs`、`composer/components/trigger_menu.rs`、`composer/components/images.rs`（异步模式）、`crates/computer-use-mcp/src/permissions.rs`、`crates/core/src/settings.rs`、`.github/workflows/release.yml`

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -554,6 +554,10 @@ composer:
   model_sources: "Model sources"
   model_results: "Models"
   model_option: "Model %{model}"
+  voice_start: "Dictate a message"
+  voice_preparing: "Preparing dictation…"
+  voice_stop: "Stop dictation"
+  voice_error: "Dictation failed: %{error}"
 approval:
   choose_mode: "Choose approval mode"
   mode_option: "%{label}: %{description}"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -548,6 +548,10 @@ composer:
   model_sources: "模型来源"
   model_results: "模型"
   model_option: "模型 %{model}"
+  voice_start: "语音输入"
+  voice_preparing: "正在准备语音输入…"
+  voice_stop: "停止语音输入"
+  voice_error: "语音输入失败：%{error}"
 approval:
   choose_mode: "选择审批模式"
   mode_option: "%{label}：%{description}"


### PR DESCRIPTION
## What

Voice input for the composer: a mic toggle button that streams on-device speech transcription into the message editor as you speak. **macOS 26+ only** — on every other platform/version the button does not exist (compile-time cfg + runtime `is_supported()`).

Research behind the approach: `docs/voice-input-research.md`. Plan: `docs/plans/voice-input.md`.

## How

- **`crates/voice` (new)** — `tcode-voice`: a Swift shim (`swift/shim.swift`, C ABI via `@_cdecl`) around `SpeechAnalyzer`/`SpeechTranscriber`, compiled and linked by `build.rs` only when targeting macOS with an SDK ≥ 26 (`TCODE_VOICE_FORCE_STUB=1` forces the stub). Swift owns the whole audio path: `AVAudioEngine` mic tap → `AVAudioConverter` → `AnalyzerInput` stream; locale assets are installed on demand via `AssetInventory`. Events (`Ready | Volatile | Final | Error | Ended`) cross the FFI on arbitrary threads with a serialized, single-terminal contract.
- **Composer UI** — mic button next to the send button (both row layouts). Click to start (spinner while assets/mic warm up), speech streams into the editor at an anchored insertion point: each volatile hypothesis rewrites the volatile tail in place, finals commit. Click again / Esc stops and keeps the text; submit, thread switch, or typing during dictation also stops it. All offsets are UTF-8 bytes (zh-CN safe).
- **Locale** — follows the app locale: zh → `zh_CN`, otherwise `en_US`.
- **Packaging** — `NSMicrophoneUsageDescription` + `NSSpeechRecognitionUsageDescription` added to the release Info.plist.

## Test plan

- [x] `cargo run -p tcode-voice --example file_dictation -- <aiff> zh_CN` — 21 volatile events, correct final, clean exit (fixture from `say -v Tingting`)
- [x] `cargo check --workspace`, `cargo clippy` — clean (only the pre-existing `block v0.1.6` future-incompat note)
- [x] `cargo test -p tcode-ui` — 254 passed, incl. locale key-set test and the new transcript-edit unit test
- [x] `TCODE_VOICE_FORCE_STUB=1` build — stub path compiles, `is_supported()` false; non-macOS cfg path checked warning-free under `-D warnings`
- [x] Shim symbols present in the final `tcode` binary; `is_supported()` true at runtime on macOS 26.5
- [ ] Live mic dictation in the running app (needs a human to approve the mic TCC prompt on first use)

## Out of scope (per plan)

Settings section, cloud/BYOK backends, other platforms (Windows/Linux need a local ASR engine — see research doc), and conversational voice mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)