### PR TITLE
perf(ui,services): remove render-time filesystem probes from the GPUI thread

### DIFF
--- a/crates/services/src/user_files.rs
+++ b/crates/services/src/user_files.rs
@@ -1,8 +1,48 @@
+use std::collections::VecDeque;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+const WORKSPACE_ROOT_CACHE_CAPACITY: usize = 8;
+
+#[derive(Default)]
+struct WorkspaceRootCache {
+    entries: VecDeque<(PathBuf, PathBuf)>,
+}
+
+impl WorkspaceRootCache {
+    fn resolve(&mut self, cwd: &Path) -> PathBuf {
+        if let Some(index) = self.entries.iter().position(|(root, _)| root == cwd) {
+            let entry = self
+                .entries
+                .remove(index)
+                .expect("cache index should exist");
+            let resolved = entry.1.clone();
+            self.entries.push_back(entry);
+            return resolved;
+        }
+
+        let resolved = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+        if self.entries.len() == WORKSPACE_ROOT_CACHE_CAPACITY {
+            self.entries.pop_front();
+        }
+        self.entries
+            .push_back((cwd.to_path_buf(), resolved.clone()));
+        resolved
+    }
+}
+
+fn canonical_workspace_root(cwd: &Path) -> PathBuf {
+    static CACHE: OnceLock<Mutex<WorkspaceRootCache>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| Mutex::new(WorkspaceRootCache::default()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .resolve(cwd)
+}
 
 pub fn relativize_to_workspace(path: &str, cwd: &Path) -> String {
-    let canonical_cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+    let canonical_cwd = canonical_workspace_root(cwd);
     let path_buf = Path::new(path);
     path_buf
         .strip_prefix(cwd)
@@ -140,6 +180,31 @@ mod tests {
 
         std::fs::remove_file(&path).unwrap();
         assert!(!path.exists());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relativization_reuses_the_resolved_workspace_root() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_dir("relativize-cache");
+        let workspace = root.join("workspace");
+        let workspace_link = root.join("workspace-link");
+        std::fs::create_dir_all(&workspace).unwrap();
+        symlink(&workspace, &workspace_link).unwrap();
+        let path = workspace.canonicalize().unwrap().join("src/main.rs");
+
+        assert_eq!(
+            relativize_to_workspace(path.to_str().unwrap(), &workspace_link),
+            "src/main.rs"
+        );
+        std::fs::remove_file(&workspace_link).unwrap();
+        assert_eq!(
+            relativize_to_workspace(path.to_str().unwrap(), &workspace_link),
+            "src/main.rs"
+        );
+
         std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/crates/ui/src/markdown/inline.rs
+++ b/crates/ui/src/markdown/inline.rs
@@ -17,7 +17,7 @@ use gpui::{
 };
 
 use super::{
-    link_target::{LinkTarget, resolve_link},
+    link_target::LinkTarget,
     nodes::LinkMark,
     state::{MarkdownState, PendingLinkMenu},
 };
@@ -264,7 +264,7 @@ impl Element for Inline {
         self.interactive_text = InteractiveText::new(self.id.clone(), styled_text).tooltip(
             move |position, window, cx| {
                 let (_, link) = links.iter().find(|(range, _)| range.contains(&position))?;
-                let text = resolve_link(&link.url, view.read(cx).base_dir()).tooltip_text();
+                let text = view.read(cx).resolve_link(&link.url).tooltip_text();
                 Some(Tooltip::new(text).build(window, cx))
             },
         );
@@ -368,7 +368,7 @@ impl Element for Inline {
                 }
                 let pending = Self::link_and_range_for_position(&layout, &links, event.position)
                     .map(|(range, link)| {
-                        let target = resolve_link(&link.url, view.read(cx).base_dir());
+                        let target = view.read(cx).resolve_link(&link.url);
                         let text = text.get(range).map(SharedString::from).unwrap_or_default();
                         PendingLinkMenu {
                             target,
@@ -396,7 +396,7 @@ impl Element for Inline {
                 if let Some(link) = Self::link_for_position(&layout, &links, event.position) {
                     gpui_base::TextSelection::end(window, cx);
                     cx.stop_propagation();
-                    match resolve_link(&link.url, view.read(cx).base_dir()) {
+                    match view.read(cx).resolve_link(&link.url) {
                         LinkTarget::Web(url) => cx.open_url(&url),
                         LinkTarget::Local(path) => cx.open_with_system(&path),
                     }

--- a/crates/ui/src/markdown/inline_flow.rs
+++ b/crates/ui/src/markdown/inline_flow.rs
@@ -18,7 +18,7 @@ use gpui::{
 
 use super::{
     inline::{Inline, InlineState},
-    link_target::{LinkTarget, resolve_link},
+    link_target::LinkTarget,
     nodes::LinkMark,
     state::MarkdownState,
 };
@@ -159,7 +159,7 @@ impl InlineFlow {
                     .on_click(move |_, window, cx| {
                         gpui_base::TextSelection::end(window, cx);
                         cx.stop_propagation();
-                        match resolve_link(&link.url, view.read(cx).base_dir()) {
+                        match view.read(cx).resolve_link(&link.url) {
                             LinkTarget::Web(url) => cx.open_url(&url),
                             LinkTarget::Local(path) => cx.open_with_system(&path),
                         }

--- a/crates/ui/src/markdown/link_target.rs
+++ b/crates/ui/src/markdown/link_target.rs
@@ -1,4 +1,8 @@
-use std::path::{Path, PathBuf};
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) enum LinkTarget {
@@ -12,6 +16,28 @@ impl LinkTarget {
             Self::Web(url) => url.clone(),
             Self::Local(path) => path.display().to_string(),
         }
+    }
+}
+
+#[derive(Default)]
+pub(super) struct LinkTargetCache {
+    entries: RefCell<HashMap<String, LinkTarget>>,
+}
+
+impl LinkTargetCache {
+    pub(super) fn resolve(&self, url: &str, base_dir: Option<&Path>) -> LinkTarget {
+        if let Some(target) = self.entries.borrow().get(url) {
+            return target.clone();
+        }
+        let target = resolve_link(url, base_dir);
+        self.entries
+            .borrow_mut()
+            .insert(url.to_string(), target.clone());
+        target
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.entries.get_mut().clear();
     }
 }
 

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -27,7 +27,7 @@ use crate::{diff::model::sub_runs, highlight};
 use super::{
     inline::{Inline, InlineState},
     inline_flow::{InlineCodeStyle, InlineFlow, InlineFlowItem},
-    link_target::{LinkTarget, resolve_link},
+    link_target::LinkTarget,
     nodes::{BlockNode, CodeBlock, ColumnumnAlign, Paragraph, Table, TextMark},
     state::MarkdownState,
     utils::list_item_prefix,
@@ -506,7 +506,7 @@ fn render_paragraph(
                             .on_click(move |_, window, cx| {
                                 gpui_base::TextSelection::end(window, cx);
                                 cx.stop_propagation();
-                                match resolve_link(&link.url, view.read(cx).base_dir()) {
+                                match view.read(cx).resolve_link(&link.url) {
                                     LinkTarget::Web(url) => cx.open_url(&url),
                                     LinkTarget::Local(path) => cx.open_with_system(&path),
                                 }

--- a/crates/ui/src/markdown/state.rs
+++ b/crates/ui/src/markdown/state.rs
@@ -13,7 +13,10 @@ use gpui::{
 use gpui_base::{ElementExt as _, v_flex};
 
 use super::{
-    link_target::LinkTarget, nodes::BlockNode, render, selection_adapter::MarkdownSelectionAdapter,
+    link_target::{LinkTarget, LinkTargetCache},
+    nodes::BlockNode,
+    render,
+    selection_adapter::MarkdownSelectionAdapter,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -30,6 +33,7 @@ pub struct MarkdownState {
     pub(super) selectable: bool,
     pub(super) compact_headings: bool,
     pub(super) base_dir: Option<PathBuf>,
+    link_targets: LinkTargetCache,
     pub(super) pending_context_link: Option<PendingLinkMenu>,
     pub(super) is_selecting: bool,
     text: String,
@@ -52,6 +56,7 @@ impl MarkdownState {
             selectable: false,
             compact_headings: false,
             base_dir: None,
+            link_targets: LinkTargetCache::default(),
             pending_context_link: None,
             is_selecting: false,
             text: text.to_string(),
@@ -125,11 +130,16 @@ impl MarkdownState {
             return;
         }
         self.base_dir = base_dir;
+        self.link_targets.clear();
         cx.notify();
     }
 
     pub(super) fn base_dir(&self) -> Option<&Path> {
         self.base_dir.as_deref()
+    }
+
+    pub(super) fn resolve_link(&self, url: &str) -> LinkTarget {
+        self.link_targets.resolve(url, self.base_dir())
     }
 
     pub(super) fn set_pending_context_link(
@@ -145,6 +155,7 @@ impl MarkdownState {
     }
 
     fn prepare_reparse(&mut self, cx: &mut Context<Self>) {
+        self.link_targets.clear();
         // Don't interrupt an active drag-selection; the window-level endpoints
         // stay valid for append-only growth and per-inline ranges repaint.
         if !self.is_selecting {
@@ -356,6 +367,8 @@ impl Render for MarkdownState {
 
 #[cfg(test)]
 mod tests {
+    use std::{fs, process, time::SystemTime};
+
     use gpui::{
         AppContext as _, Context, Entity, IntoElement, Render, TestAppContext, VisualTestContext,
         Window, div, px,
@@ -407,6 +420,65 @@ mod tests {
             assert_eq!(state.source(), "new **value**");
             assert_eq!(state.rendered_text(), "new value\n");
         });
+    }
+
+    #[gpui::test]
+    fn link_target_cache_tracks_document_content_and_base_dir(cx: &mut TestAppContext) {
+        cx.update(crate::theme::init);
+        cx.update(super::super::init);
+        let nonce = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("clock should be after Unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "tcode-markdown-state-link-cache-{}-{nonce}",
+            process::id()
+        ));
+        let first_base = root.join("first");
+        let second_base = root.join("second");
+        fs::create_dir_all(&first_base).expect("create first base directory");
+        fs::create_dir_all(&second_base).expect("create second base directory");
+        let path = first_base.join("linked.md");
+        fs::write(&path, b"linked").expect("create linked file");
+
+        let state = cx.update(|cx| cx.new(|cx| MarkdownState::new("[link](linked.md)", cx)));
+        state.update(cx, |state, cx| {
+            state.set_base_dir(Some(first_base.clone()), cx);
+            assert_eq!(
+                state.resolve_link("linked.md"),
+                LinkTarget::Local(path.clone())
+            );
+        });
+
+        fs::remove_file(&path).expect("remove linked file");
+        state.update(cx, |state, cx| {
+            assert_eq!(
+                state.resolve_link("linked.md"),
+                LinkTarget::Local(path.clone())
+            );
+            state.set_text("changed [link](linked.md)", cx);
+            assert_eq!(
+                state.resolve_link("linked.md"),
+                LinkTarget::Web("linked.md".to_string())
+            );
+        });
+
+        fs::write(&path, b"linked again").expect("recreate linked file");
+        state.update(cx, |state, cx| {
+            assert_eq!(
+                state.resolve_link("linked.md"),
+                LinkTarget::Web("linked.md".to_string())
+            );
+            state.set_base_dir(Some(second_base), cx);
+            assert_eq!(
+                state.resolve_link("linked.md"),
+                LinkTarget::Web("linked.md".to_string())
+            );
+            state.set_base_dir(Some(first_base), cx);
+            assert_eq!(state.resolve_link("linked.md"), LinkTarget::Local(path));
+        });
+
+        fs::remove_dir_all(root).expect("remove temporary directory");
     }
 
     #[gpui::test]


### PR DESCRIPTION
Render paths performed per-row filesystem I/O: `relativize_to_workspace` canonicalized the workspace root on every call (changed-file rows, diff view, markdown view), and markdown link resolution probed `path.exists()` per candidate.

Both are now cached rather than offloaded:

- **Workspace root**: a process-wide 8-entry LRU maps cwd → canonicalized root, with poison-recovering lock. One probe per distinct cwd instead of one per rendered row.
- **Markdown link targets**: a document-scoped cache on `MarkdownState`, cleared on content reparse and base-dir change. One `exists()` probe per unique URL per document version.

Accepted (bounded) staleness: filesystem-only changes (e.g. a linked file appearing/disappearing without document changes, or a workspace symlink retargeting) can serve a stale resolution until the next invalidation/eviction — per the direction in the issue.

Tests: a symlink-based regression test proving root reuse after the link is removed, and a cache-invalidation test covering content and base-dir changes.

Gates run locally: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked` — all green.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)