### PR TITLE
ci: on-demand Windows debug build artifact

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,0 +1,41 @@
+name: Dev build
+
+# On-demand debug build of the tcode binary for a branch, for smoke-testing on
+# real hardware without a local toolchain (e.g. Windows preview lifecycle).
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  windows-x64:
+    runs-on: windows-2022
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Disable Windows Defender real-time scanning
+        shell: pwsh
+        continue-on-error: true
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo build data
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-${{ runner.os }}-${{ runner.arch }}
+          save-if: false
+
+      - name: Build
+        run: cargo build --locked --bin tcode
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tcode-windows-x64-debug
+          path: target/debug/tcode.exe
+          retention-days: 3


### PR DESCRIPTION
Adds a `workflow_dispatch`-only workflow that builds the `tcode` debug binary on windows-2022 (reusing the CI cache read-only) and uploads it as a short-retention artifact. Needed to smoke-test preview/WebView lifecycle changes (#149) on real Windows hardware that deliberately has no dev toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)