### PR TITLE
fix(preview): opt-in native WebView, off by default on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ to uninstall but the file itself.
 
 macOS builds aren't code-signed yet, so the first launch needs
 `xattr -dr com.apple.quarantine /Applications/Tcode.app`. The embedded preview
-browser is not available on Linux yet; everything else is.
+browser is not available on Linux yet. On Windows its native WebView2 preview is
+off by default and can be explicitly enabled in **Settings → Browser**; everything
+else works without it.
 
 Each release uses the native application icon format for its platform: `.icns`
 inside the macOS app bundle, an `.ico` resource embedded directly in the Windows

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -563,6 +563,10 @@ pub struct BrowserSettings {
     /// TRUE; absent in legacy files → allowed.
     #[serde(default = "default_true")]
     pub allow_evaluate: bool,
+    /// Explicit native-webview override. When absent, the WebView is enabled on
+    /// macOS and disabled on Windows. Linux does not build the native preview.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native_webview: Option<bool>,
 }
 
 impl Default for BrowserSettings {
@@ -571,11 +575,22 @@ impl Default for BrowserSettings {
             enabled: true,
             home_url: None,
             allow_evaluate: true,
+            native_webview: None,
         }
     }
 }
 
 impl BrowserSettings {
+    /// Whether this platform should create a native WebView.
+    pub fn native_webview_enabled(&self) -> bool {
+        self.native_webview_enabled_for(cfg!(target_os = "windows"))
+    }
+
+    /// Resolve the platform default while keeping it testable on every target.
+    pub fn native_webview_enabled_for(&self, is_windows: bool) -> bool {
+        self.native_webview.unwrap_or(!is_windows)
+    }
+
     fn is_default(&self) -> bool {
         self == &Self::default()
     }
@@ -1127,11 +1142,22 @@ mod tests {
         assert!(legacy.browser.enabled);
         assert!(legacy.browser.allow_evaluate);
         assert_eq!(legacy.browser.home_url, None);
+        assert_eq!(legacy.browser.native_webview, None);
 
         // A partial block keeps unspecified fields at their (true) defaults.
         let partial: Settings = serde_json::from_str(r#"{"browser":{"enabled":false}}"#).unwrap();
         assert!(!partial.browser.enabled);
         assert!(partial.browser.allow_evaluate);
+        assert_eq!(partial.browser.native_webview, None);
+
+        // An absent override follows the platform default without becoming an
+        // explicit value during serde round-trips.
+        assert!(partial.browser.native_webview_enabled_for(false));
+        assert!(!partial.browser.native_webview_enabled_for(true));
+        let partial_json = serde_json::to_string(&partial).unwrap();
+        assert!(!partial_json.contains("native_webview"));
+        let partial_back: Settings = serde_json::from_str(&partial_json).unwrap();
+        assert_eq!(partial_back.browser.native_webview, None);
 
         // Default browser settings are skipped on serialize, like orchestrate.
         let json = serde_json::to_string(&Settings::default()).unwrap();
@@ -1142,12 +1168,28 @@ mod tests {
                 enabled: false,
                 home_url: Some("https://example.test".into()),
                 allow_evaluate: false,
+                native_webview: Some(true),
             },
             ..Settings::default()
         };
         let json = serde_json::to_string(&settings).unwrap();
         let back: Settings = serde_json::from_str(&json).unwrap();
         assert_eq!(back.browser, settings.browser);
+        assert!(back.browser.native_webview_enabled_for(true));
+    }
+
+    #[test]
+    fn browser_native_webview_explicit_override_wins_on_every_platform() {
+        let mut browser = BrowserSettings {
+            native_webview: Some(false),
+            ..BrowserSettings::default()
+        };
+        assert!(!browser.native_webview_enabled_for(false));
+        assert!(!browser.native_webview_enabled_for(true));
+
+        browser.native_webview = Some(true);
+        assert!(browser.native_webview_enabled_for(false));
+        assert!(browser.native_webview_enabled_for(true));
     }
 
     #[test]

--- a/crates/protocol/src/tests.rs
+++ b/crates/protocol/src/tests.rs
@@ -8,7 +8,7 @@ use tcode_core::{
     acp::AcpAgentPatch,
     project::Project,
     session::{ReviewComment, ReviewSide},
-    settings::{ProfileSettingsPatch, Settings},
+    settings::{BrowserSettings, ProfileSettingsPatch, Settings},
     ui::{TerminalSplitDirection, WorkspaceMode},
 };
 
@@ -31,6 +31,29 @@ fn round_trip_client_payload(id: u64, payload: ClientPayload) {
         decode_client_line(&line).expect("decode client NDJSON"),
         message
     );
+}
+
+#[test]
+fn browser_settings_patch_preserves_native_webview_override_and_legacy_absence() {
+    let patch = SettingsPatch::Browser(BrowserSettings {
+        native_webview: Some(true),
+        ..BrowserSettings::default()
+    });
+    round_trip(&patch);
+
+    let legacy: SettingsPatch = serde_json::from_value(json!({
+        "type": "browser",
+        "content": {
+            "enabled": true,
+            "home_url": null,
+            "allow_evaluate": true
+        }
+    }))
+    .unwrap();
+    let SettingsPatch::Browser(browser) = legacy else {
+        panic!("expected browser patch");
+    };
+    assert_eq!(browser.native_webview, None);
 }
 
 #[test]

--- a/crates/ui/src/preview_panel.rs
+++ b/crates/ui/src/preview_panel.rs
@@ -10,8 +10,10 @@
 //!
 //! ## Platform support
 //!
-//! macOS + Windows get the real WebView. **Linux does not**: lb-wry's
-//! `build_as_child` is X11-only there *and* requires a GTK main loop (`gtk::init`
+//! macOS enables the real WebView by default. Windows builds it too, but keeps
+//! it off by default behind Settings → Browser while a WebView2 process-crash
+//! path is investigated; users may explicitly opt in. **Linux does not**:
+//! lb-wry's `build_as_child` is X11-only there *and* requires a GTK main loop (`gtk::init`
 //! plus `gtk::main_iteration_do` pumped on the UI thread), while gpui's Linux
 //! backend runs calloop/xcb and never pumps GTK — the webview would panic at
 //! construction and could never be driven. So `wry`/`gpui-wry` are not even
@@ -126,10 +128,11 @@ mod native {
         dev_ports: Vec<u16>,
         /// Discards a completed scan when a newer click has superseded it.
         port_scan_generation: u64,
-        /// Why the platform webview could not be created (Windows without the
-        /// WebView2 runtime). Set once; the tab then explains itself instead of
-        /// retrying on every frame.
+        /// Why the platform webview is unavailable. Builder failures are kept
+        /// to avoid retrying every frame; a settings-disabled error is cleared
+        /// when the user opts in again.
         webview_error: Option<String>,
+        webview_disabled_by_setting: bool,
         _subscriptions: Vec<Subscription>,
     }
 
@@ -164,6 +167,7 @@ mod native {
                 dev_ports: Vec::new(),
                 port_scan_generation: 0,
                 webview_error: None,
+                webview_disabled_by_setting: false,
                 _subscriptions: subscriptions,
             }
         }
@@ -248,16 +252,28 @@ mod native {
 
         /// Get or lazily create the WebView for `session_id`.
         ///
-        /// `None` when the platform webview cannot be created — on Windows that
-        /// means the WebView2 runtime is absent. Only the preview browser needs
-        /// it, so this is a missing feature, not a dead app: the tab explains
-        /// itself and every other surface keeps working.
+        /// `None` when native webviews are disabled or the platform webview
+        /// cannot be created. Only preview needs it, so the tab explains itself
+        /// and every other surface keeps working.
         fn ensure_webview(
             &mut self,
             session_id: &str,
             window: &mut Window,
             cx: &mut Context<Self>,
         ) -> Option<Entity<WebView>> {
+            if !self
+                .store
+                .read(cx)
+                .preview_browser_settings()
+                .native_webview_enabled()
+            {
+                self.mark_native_webview_disabled(cx);
+                return None;
+            }
+            if self.webview_disabled_by_setting {
+                self.webview_disabled_by_setting = false;
+                self.webview_error = None;
+            }
             if let Some(view) = self.webviews.get(session_id) {
                 return Some(view.clone());
             }
@@ -296,9 +312,27 @@ mod native {
             Some(webview)
         }
 
+        fn mark_native_webview_disabled(&mut self, cx: &mut Context<Self>) -> String {
+            for view in self.webviews.values() {
+                view.update(cx, |view, _| view.hide());
+            }
+            let message = if cfg!(target_os = "windows") {
+                crate::tr!("browser.native_webview.disabled_windows").into_owned()
+            } else {
+                crate::tr!("browser.native_webview.disabled").into_owned()
+            };
+            self.webview_error = Some(message.clone());
+            self.webview_disabled_by_setting = true;
+            message
+        }
+
         /// Navigate one conversation's WebView to `url`, remembering it.
         fn navigate(&mut self, key: &str, url: &str, window: &mut Window, cx: &mut Context<Self>) {
             let url = normalize_url(url);
+            // Preserve the target for the system-browser affordance even when
+            // the native webview is unavailable.
+            self.store
+                .update(cx, |store, cx| store.set_preview_url(key, url.clone(), cx));
             let Some(webview) = self.ensure_webview(key, window, cx) else {
                 cx.notify();
                 return;
@@ -307,8 +341,6 @@ mod native {
             // A navigation flushes lb-wry's pending-scripts buffer, so subsequent
             // evaluate callbacks will fire.
             self.warm.insert(key.to_string());
-            self.store
-                .update(cx, |store, cx| store.set_preview_url(key, url, cx));
             self.sync_visibility(cx);
             cx.notify();
         }
@@ -429,6 +461,29 @@ mod native {
             let browser = self.store.read(cx).preview_browser_settings();
             if !browser.enabled {
                 let _ = reply.try_send(Err(crate::tr!("browser.disabled_error").into_owned()));
+                return;
+            }
+            if !browser.native_webview_enabled() {
+                let target = match &op {
+                    PreviewOp::Open { url } => url
+                        .as_deref()
+                        .or_else(|| browser.home_url.as_deref().map(str::trim))
+                        .filter(|url| !url.is_empty()),
+                    PreviewOp::Navigate { url } => Some(url.as_str()),
+                    _ => None,
+                }
+                .map(normalize_url);
+                if matches!(&op, PreviewOp::Open { .. } | PreviewOp::Navigate { .. }) {
+                    self.store.update(cx, |store, cx| {
+                        store.open_preview_panel_for(&session_id, cx);
+                        if let Some(url) = target {
+                            store.set_preview_url(&key, url, cx);
+                        }
+                    });
+                }
+                let err = self.mark_native_webview_disabled(cx);
+                let _ = reply.try_send(Err(unavailable_message(&err)));
+                cx.notify();
                 return;
             }
             if matches!(&op, PreviewOp::Evaluate { .. }) && !browser.allow_evaluate {
@@ -943,11 +998,11 @@ mod native {
                         .text_center()
                         .text_color(cx.theme().muted_foreground)
                         .child(crate::tr!("preview.unavailable"))
-                        .child(
-                            div()
-                                .text_size(gpui::px(13.))
-                                .child(crate::tr!("preview.unavailable_hint")),
-                        )
+                        .child(div().text_size(gpui::px(13.)).child(
+                            self.webview_error.clone().unwrap_or_else(|| {
+                                crate::tr!("preview.unavailable_hint").into_owned()
+                            }),
+                        ))
                         .into_any_element(),
                 },
                 None => v_flex()
@@ -1179,9 +1234,8 @@ fn snapshot_reply(image: &objc2_app_kit::NSImage) -> Result<PreviewReply, String
     })
 }
 
-/// What an automation tool answers when the platform webview cannot be created
-/// (Windows without the WebView2 runtime): say so plainly, with the underlying
-/// error, rather than leaving the agent to guess why nothing happened.
+/// What an automation tool answers when the native webview is disabled or the
+/// platform component cannot be created.
 #[cfg_attr(target_os = "linux", allow(dead_code))]
 fn unavailable_message(err: &str) -> String {
     format!(

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -1052,6 +1052,14 @@ impl SettingsPage {
                 cx,
                 |s, checked| s.browser.enabled = checked,
             ),
+            self.toggle_row(
+                "browser-native-webview",
+                crate::tr!("browser.native_webview.title"),
+                crate::tr!("browser.native_webview.description"),
+                settings.browser.native_webview_enabled(),
+                cx,
+                |s, checked| s.browser.native_webview = Some(checked),
+            ),
             self.home_url_row(cx),
             self.toggle_row(
                 "browser-allow-eval",

--- a/docs/computer-use.md
+++ b/docs/computer-use.md
@@ -67,8 +67,10 @@ install/signing/attribution handling entirely.
 
 Settings gains two pages:
 
-- **Browser** — enable/disable the embedded preview browser, default home URL, and
-  allow-JS-evaluate toggle. Its in-process WKWebView snapshot tool needs no TCC permission.
+- **Browser** — enable/disable the embedded preview browser, control its native-webview
+  kill-switch, set the default home URL, and allow or deny JavaScript evaluation. The native
+  webview defaults off on Windows and on elsewhere; its in-process WKWebView snapshot tool needs
+  no TCC permission on macOS.
 - **Computer Use** — master enable toggle, image mode (`auto` / `always` / `never`),
   allow-input-actions toggle (off = observe-only), and one permission row per TCC kind:
   live status, a **Grant** button (fires the TCC prompt and opens the matching

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -251,6 +251,11 @@ browser:
   enable:
     title: "Enable embedded browser"
     description: "Show the preview panel and expose its browser automation tools to provider sessions."
+  native_webview:
+    title: "Enable native webview"
+    description: "Create the native embedded preview. It is off by default on Windows while WebView2 crash containment is investigated."
+    disabled_windows: "The embedded preview is disabled on Windows by default. Enable it in Settings → Browser, or open pages in your system browser."
+    disabled: "The native embedded preview is disabled. Enable it in Settings → Browser, or open pages in your system browser."
   home_url:
     title: "Home URL"
     description: "Page opened when the preview panel is shown without a target."

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -251,6 +251,11 @@ browser:
   enable:
     title: "启用内嵌浏览器"
     description: "显示预览面板，并向提供方会话开放其浏览器自动化工具。"
+  native_webview:
+    title: "启用原生 WebView"
+    description: "创建原生内嵌预览。调查 WebView2 崩溃隔离问题期间，Windows 默认关闭此功能。"
+    disabled_windows: "Windows 默认关闭内嵌预览。请在“设置 → 浏览器”中启用，或在系统浏览器中打开页面。"
+    disabled: "原生内嵌预览已关闭。请在“设置 → 浏览器”中启用，或在系统浏览器中打开页面。"
   home_url:
     title: "主页地址"
     description: "预览面板在没有指定目标时打开的页面。"


### PR DESCRIPTION
Containment for #149: creating or using the embedded WebView2 preview on Windows can terminate the whole app, and preview is an optional feature.

- New `BrowserSettings.native_webview: Option<bool>` — absent means platform default: **enabled on macOS, disabled on Windows**. Explicit override wins everywhere. Serde stays back-compatible (absent stays absent; settings files without the field are untouched).
- `ensure_webview` never constructs a WebView while the effective setting is off; the panel reuses the existing unavailable state with a localized explanation (en + zh-CN), and re-enabling clears the settings-derived error without dropping real builder errors.
- `Open`/`Navigate` MCP ops still open the panel and record the URL so the open-in-system-browser affordance works; all webview-dependent ops answer a clear unavailable error.
- Settings → Browser gains the toggle; README and docs updated.
- Tests: platform-parameterized effective-default logic, serde round-trip/back-compat, and patch-flow coverage.

Windows re-enable by default stays gated on understanding the WebView2 crash path (tracked in the issue history); this PR makes the default path crash-safe.

**Real-device validation planned before merge**: a dev-build artifact of this branch will be smoke-tested on a physical Windows 11 machine (launch, preview tab fallback, opt-in toggle, open/close/switch/quit).

Gates run locally: fmt / clippy -D warnings / full workspace tests — green.

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)