### PR TITLE
ci: include tcode.pdb in the Windows dev-build artifact

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -37,5 +37,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: tcode-windows-x64-debug
-          path: target/debug/tcode.exe
+          path: |
+            target/debug/tcode.exe
+            target/debug/tcode.pdb
           retention-days: 3


### PR DESCRIPTION
Crash-dump symbolization for the #149 WebView2 diagnosis needs the PDB alongside the exe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)