### PR TITLE
ci: disable debug_assertions in the dev-build artifact

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -14,6 +14,10 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      # The artifact runs on machines without the Graphics Tools SDK layers;
+      # debug_assertions would make gpui request D3D11_CREATE_DEVICE_DEBUG
+      # and die at startup with DXGI_ERROR_SDK_COMPONENT_MISSING.
+      CARGO_PROFILE_DEV_DEBUG_ASSERTIONS: "false"
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
Verified on real hardware: the debug artifact dies at startup with `DXGI_ERROR_SDK_COMPONENT_MISSING` (0x887A002D) because `gpui_windows` requests the D3D11 debug layer under `debug_assertions`, and clean machines don't have the Graphics Tools optional feature. Dev-build artifacts are for exactly such machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)