### PR TITLE
feat(preview): --preview-smoke lifecycle harness

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -21,6 +21,9 @@ use tcode_ui::{assets, settings};
 use tcode_ui::overlay::{DialogActions, OverlayExt as _, OverlayHost};
 use tcode_ui::widgets::button::{Button, ButtonVariants as _};
 
+#[cfg(not(target_os = "linux"))]
+mod preview_smoke;
+
 const TCODE_THEME: &str = include_str!("../../../themes/tcode.json");
 
 /// macOS vibrancy can be disabled with `TCODE_NO_VIBRANCY=1` as a diagnostic
@@ -168,6 +171,17 @@ fn handle_quit(
 
 fn main() {
     env_logger::init();
+
+    let preview_smoke = std::env::args().any(|arg| arg == "--preview-smoke");
+    #[cfg(target_os = "linux")]
+    if preview_smoke {
+        use std::io::Write as _;
+        eprintln!("preview-smoke: SKIP (no native webview)");
+        let _ = std::io::stderr().flush();
+        return;
+    }
+    #[cfg(not(target_os = "linux"))]
+    let preview_smoke_watchdog = preview_smoke.then(preview_smoke::Watchdog::start);
 
     // A Finder/Dock launch inherits launchd's minimal PATH, under which none of
     // the provider CLIs resolve — import the login shell's environment first,
@@ -330,6 +344,8 @@ fn main() {
             };
 
             cx.spawn(async move |cx| {
+                let smoke_shell = std::rc::Rc::new(std::cell::RefCell::new(None));
+                let smoke_shell_for_window = smoke_shell.clone();
                 let window = cx
                     .open_window(window_options, {
                         let theme_store = workspace_store.clone();
@@ -349,6 +365,7 @@ fn main() {
                             }
                             let shell = cx
                                 .new(|cx| AppShell::new(workspace_store, window_state, window, cx));
+                            *smoke_shell_for_window.borrow_mut() = Some(shell.clone());
                             cx.new(|cx| OverlayHost::new(shell, window, cx))
                         }
                     })
@@ -358,6 +375,16 @@ fn main() {
                     window.set_window_title("tcode");
                     window.activate_window();
                 });
+
+                #[cfg(not(target_os = "linux"))]
+                if let Some(watchdog) = preview_smoke_watchdog {
+                    let shell = smoke_shell
+                        .borrow_mut()
+                        .take()
+                        .expect("preview smoke shell was not captured");
+                    preview_smoke::run(watchdog, shell, window, cx).await;
+                    return;
+                }
 
                 if open_latest {
                     let _ = host.dispatch(Command::OpenLatestSession);

--- a/crates/app/src/preview_smoke.rs
+++ b/crates/app/src/preview_smoke.rs
@@ -1,0 +1,183 @@
+use std::io::Write as _;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::Duration;
+
+use gpui::{AsyncApp, Entity, WindowHandle, px, size};
+use tcode_ui::{AppShell, overlay::OverlayHost};
+
+const STEP_DELAY: Duration = Duration::from_millis(20);
+const RAPID_DELAY: Duration = Duration::from_millis(5);
+const WATCHDOG_TIMEOUT: Duration = Duration::from_secs(120);
+const KEYS: [&str; 6] = [
+    "preview-smoke-0",
+    "preview-smoke-1",
+    "preview-smoke-2",
+    "preview-smoke-3",
+    "preview-smoke-4",
+    "preview-smoke-5",
+];
+
+fn log_line(message: &str) {
+    eprintln!("{message}");
+    let _ = std::io::stderr().flush();
+}
+
+pub struct Watchdog {
+    phase: Arc<Mutex<&'static str>>,
+    finished: Arc<AtomicBool>,
+}
+
+impl Watchdog {
+    pub fn start() -> Self {
+        let phase = Arc::new(Mutex::new("startup"));
+        let finished = Arc::new(AtomicBool::new(false));
+        let watchdog_phase = phase.clone();
+        let watchdog_finished = finished.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(WATCHDOG_TIMEOUT);
+            if !watchdog_finished.load(Ordering::SeqCst) {
+                let phase = *watchdog_phase
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner());
+                log_line(&format!("preview-smoke: TIMEOUT phase {phase}"));
+                std::process::exit(124);
+            }
+        });
+        Self { phase, finished }
+    }
+
+    fn start_phase(&self, phase: &'static str) {
+        *self.phase.lock().unwrap_or_else(|error| error.into_inner()) = phase;
+        log_line(&format!("preview-smoke: phase {phase} start"));
+    }
+
+    fn finish_phase(&self, phase: &'static str) {
+        log_line(&format!("preview-smoke: phase {phase} ok"));
+    }
+
+    fn pass(&self) {
+        log_line("preview-smoke: PASS");
+        self.finished.store(true, Ordering::SeqCst);
+    }
+}
+
+async fn yield_for(cx: &AsyncApp, delay: Duration) {
+    cx.background_executor().timer(delay).await;
+}
+
+pub async fn run(
+    watchdog: Watchdog,
+    shell: Entity<AppShell>,
+    window: WindowHandle<OverlayHost>,
+    cx: &mut AsyncApp,
+) {
+    watchdog.start_phase("create-first");
+    window
+        .update(cx, |_, window, cx| {
+            shell.update(cx, |shell, cx| {
+                shell.preview_smoke_create(KEYS[0], "about:blank", window, cx)
+            })
+        })
+        .expect("preview smoke window closed during create-first")
+        .expect("native preview webview creation failed");
+    yield_for(cx, STEP_DELAY).await;
+    watchdog.finish_phase("create-first");
+
+    watchdog.start_phase("show-hide-churn");
+    for _ in 0..20 {
+        shell.update(cx, |shell, cx| shell.preview_smoke_set_visible(None, cx));
+        yield_for(cx, RAPID_DELAY).await;
+        shell.update(cx, |shell, cx| {
+            shell.preview_smoke_set_visible(Some(KEYS[0]), cx)
+        });
+        yield_for(cx, RAPID_DELAY).await;
+    }
+    watchdog.finish_phase("show-hide-churn");
+
+    watchdog.start_phase("multi-create");
+    for key in &KEYS[1..] {
+        window
+            .update(cx, |_, window, cx| {
+                shell.update(cx, |shell, cx| {
+                    shell.preview_smoke_create(key, "about:blank", window, cx)
+                })
+            })
+            .expect("preview smoke window closed during multi-create")
+            .expect("native preview webview creation failed");
+        yield_for(cx, STEP_DELAY).await;
+    }
+    watchdog.finish_phase("multi-create");
+
+    watchdog.start_phase("rapid-switch");
+    for ix in 0..30 {
+        shell.update(cx, |shell, cx| {
+            shell.preview_smoke_set_visible(Some(KEYS[ix % KEYS.len()]), cx)
+        });
+        yield_for(cx, RAPID_DELAY).await;
+    }
+    watchdog.finish_phase("rapid-switch");
+
+    watchdog.start_phase("resize-churn");
+    for (width, height) in [(1100., 720.), (940., 640.), (1280., 820.), (1000., 700.)] {
+        window
+            .update(cx, |_, window, _| {
+                window.resize(size(px(width), px(height)))
+            })
+            .expect("preview smoke window closed during resize-churn");
+        yield_for(cx, STEP_DELAY).await;
+    }
+    watchdog.finish_phase("resize-churn");
+
+    watchdog.start_phase("navigate-all");
+    for (ix, key) in KEYS.iter().enumerate() {
+        let url = format!("about:blank#preview-smoke-{ix}");
+        window
+            .update(cx, |_, window, cx| {
+                shell.update(cx, |shell, cx| {
+                    shell.preview_smoke_create(key, &url, window, cx)
+                })
+            })
+            .expect("preview smoke window closed during navigate-all")
+            .expect("native preview navigation failed");
+        yield_for(cx, STEP_DELAY).await;
+    }
+    watchdog.finish_phase("navigate-all");
+
+    watchdog.start_phase("drop-one");
+    shell.update(cx, |shell, cx| {
+        shell.preview_smoke_set_visible(Some(KEYS[1]), cx);
+        shell.preview_smoke_drop(KEYS[0], cx);
+    });
+    yield_for(cx, STEP_DELAY).await;
+    watchdog.finish_phase("drop-one");
+
+    watchdog.start_phase("drop-during-create");
+    let close_window = window;
+    window
+        .update(cx, |_, window, cx| {
+            shell.update(cx, |shell, cx| {
+                cx.defer(move |cx| {
+                    let _ = close_window.update(cx, |_, window, _| window.remove_window());
+                });
+                shell.preview_smoke_create(
+                    "preview-smoke-drop-during-create",
+                    "about:blank#drop-during-create",
+                    window,
+                    cx,
+                )
+            })
+        })
+        .expect("preview smoke window closed before drop-during-create")
+        .expect("native preview webview creation failed");
+    drop(shell);
+    yield_for(cx, STEP_DELAY).await;
+    watchdog.finish_phase("drop-during-create");
+
+    watchdog.start_phase("quit");
+    watchdog.finish_phase("quit");
+    watchdog.pass();
+    cx.update(|cx| cx.quit());
+}

--- a/crates/app/src/preview_smoke.rs
+++ b/crates/app/src/preview_smoke.rs
@@ -23,6 +23,17 @@ const KEYS: [&str; 6] = [
 fn log_line(message: &str) {
     eprintln!("{message}");
     let _ = std::io::stderr().flush();
+    // Windows-subsystem builds have no console under a scheduled task, so the
+    // on-device runner reads phases from this file instead of stderr.
+    if let Ok(path) = std::env::var("TCODE_SMOKE_LOG")
+        && let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+    {
+        let _ = writeln!(file, "{message}");
+        let _ = file.sync_all();
+    }
 }
 
 pub struct Watchdog {

--- a/crates/ui/src/preview_panel.rs
+++ b/crates/ui/src/preview_panel.rs
@@ -130,6 +130,10 @@ mod native {
         /// WebView2 runtime). Set once; the tab then explains itself instead of
         /// retrying on every frame.
         webview_error: Option<String>,
+        /// Harness-only routing override. Normal runs leave this unset and use
+        /// the active conversation identity from `WorkspaceStore`.
+        smoke_active_key: Option<String>,
+        smoke_visible: bool,
         _subscriptions: Vec<Subscription>,
     }
 
@@ -148,6 +152,7 @@ mod native {
                     // Native child views outlive GPUI layout nodes. Visibility
                     // therefore follows WorkspaceStore directly, even while this
                     // entity is no longer mounted in the right-panel tree.
+                    this.prune_deleted_webviews(cx);
                     this.sync_visibility(cx);
                     cx.notify();
                 }),
@@ -164,6 +169,8 @@ mod native {
                 dev_ports: Vec::new(),
                 port_scan_generation: 0,
                 webview_error: None,
+                smoke_active_key: None,
+                smoke_visible: false,
                 _subscriptions: subscriptions,
             }
         }
@@ -172,6 +179,9 @@ mod native {
         /// Draft -> stored-thread commits retain the same session id, so move
         /// all cached browser state across that one key transition.
         fn active_key(&mut self, cx: &Context<Self>) -> Option<String> {
+            if let Some(key) = &self.smoke_active_key {
+                return Some(key.clone());
+            }
             let current = self.store.read(cx).preview_active_identity();
 
             if let (Some((old_session, old_key)), Some((session, key))) =
@@ -224,7 +234,9 @@ mod native {
 
         fn update_visibility(&mut self, allow_show: bool, cx: &mut Context<Self>) {
             let active = self.active_key(cx);
-            let visible = {
+            let visible = if self.smoke_active_key.is_some() {
+                self.smoke_visible.then_some(active).flatten()
+            } else {
                 let window_state = self.window_state.read(cx);
                 visible_preview_key(
                     active.as_deref(),
@@ -294,6 +306,62 @@ mod native {
             self.webviews
                 .insert(session_id.to_string(), webview.clone());
             Some(webview)
+        }
+
+        pub(crate) fn smoke_create(
+            &mut self,
+            key: &str,
+            url: &str,
+            window: &mut Window,
+            cx: &mut Context<Self>,
+        ) -> Result<(), String> {
+            self.smoke_active_key = Some(key.to_string());
+            self.smoke_visible = true;
+            self.navigate(key, url, window, cx);
+            match &self.webview_error {
+                Some(error) => Err(error.clone()),
+                None => Ok(()),
+            }
+        }
+
+        pub(crate) fn smoke_set_visible(&mut self, key: Option<&str>, cx: &mut Context<Self>) {
+            if let Some(key) = key {
+                self.smoke_active_key = Some(key.to_string());
+                self.smoke_visible = true;
+            } else {
+                self.smoke_visible = false;
+            }
+            self.update_visibility(true, cx);
+            cx.notify();
+        }
+
+        pub(crate) fn smoke_drop(&mut self, key: &str, cx: &mut Context<Self>) {
+            self.drop_webview(key);
+            cx.notify();
+        }
+
+        fn drop_webview(&mut self, key: &str) {
+            self.webviews.remove(key);
+            self.warm.remove(key);
+            if self.mirrored.as_deref() == Some(key) {
+                self.mirrored = None;
+            }
+        }
+
+        fn prune_deleted_webviews(&mut self, cx: &Context<Self>) {
+            if self.smoke_active_key.is_some() {
+                return;
+            }
+            let live = self.store.read(cx).preview_live_keys();
+            let deleted = self
+                .webviews
+                .keys()
+                .filter(|key| !live.contains(*key))
+                .cloned()
+                .collect::<Vec<_>>();
+            for key in deleted {
+                self.drop_webview(&key);
+            }
         }
 
         /// Navigate one conversation's WebView to `url`, remembering it.
@@ -377,8 +445,7 @@ mod native {
         /// recreates a fresh webview on demand.
         fn close_panel(&mut self, cx: &mut Context<Self>) {
             if let Some(key) = self.active_key(cx) {
-                self.webviews.remove(&key);
-                self.warm.remove(&key);
+                self.drop_webview(&key);
                 self.store
                     .update(cx, |store, cx| store.clear_preview_chrome(&key, cx));
             }

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -124,6 +124,9 @@ pub struct AppShell {
     /// Collapsed-only overlay visibility. Purely transient and never persisted;
     /// expanded/non-workspace renders clear it synchronously.
     sidebar_overlay_visible: bool,
+    /// Forces the production preview entity into the right-panel layout while
+    /// the lifecycle smoke driver uses synthetic conversation keys.
+    preview_smoke_active: bool,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -239,8 +242,39 @@ impl AppShell {
             last_viewport_width: None,
             sidebar_restore_pending: false,
             sidebar_overlay_visible: false,
+            preview_smoke_active: false,
             _subscriptions: vec![subscription, event_subscription, window_subscription],
         }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn preview_smoke_create(
+        &mut self,
+        key: &str,
+        url: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Result<(), String> {
+        self.preview_smoke_active = true;
+        let result = self
+            .preview
+            .update(cx, |preview, cx| preview.smoke_create(key, url, window, cx));
+        cx.notify();
+        result
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn preview_smoke_set_visible(&mut self, key: Option<&str>, cx: &mut Context<Self>) {
+        self.preview
+            .update(cx, |preview, cx| preview.smoke_set_visible(key, cx));
+        cx.notify();
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn preview_smoke_drop(&mut self, key: &str, cx: &mut Context<Self>) {
+        self.preview
+            .update(cx, |preview, cx| preview.smoke_drop(key, cx));
+        cx.notify();
     }
 
     fn present_app_event(
@@ -378,8 +412,12 @@ impl Render for AppShell {
             self.sidebar_overlay_visible = false;
         }
         let panel = self.store.read(cx).shell_panel_state();
-        let diff_open = panel.right_panel_open;
-        let right_tab = panel.right_tab;
+        let diff_open = panel.right_panel_open || self.preview_smoke_active;
+        let right_tab = if self.preview_smoke_active {
+            RightTab::Preview
+        } else {
+            panel.right_tab
+        };
         let diff_expanded = panel.right_panel_expanded;
         // "Expanded" (full-width) is a diff-only affordance; the preview tab
         // always shares the split so the webview keeps a stable size.

--- a/crates/ui/src/store/mod.rs
+++ b/crates/ui/src/store/mod.rs
@@ -978,6 +978,8 @@ impl WorkspaceStore {
         })
     }
 
+    /// Only the native preview panel prunes by liveness; Linux compiles it out.
+    #[cfg_attr(target_os = "linux", allow(dead_code))]
     pub(crate) fn preview_live_keys(&self) -> HashSet<String> {
         let mut keys = self
             .index_replica

--- a/crates/ui/src/store/mod.rs
+++ b/crates/ui/src/store/mod.rs
@@ -978,6 +978,19 @@ impl WorkspaceStore {
         })
     }
 
+    pub(crate) fn preview_live_keys(&self) -> HashSet<String> {
+        let mut keys = self
+            .index_replica
+            .0
+            .iter()
+            .map(|session| session.id.clone())
+            .collect::<HashSet<_>>();
+        if let Some(destination) = &self.active_destination {
+            keys.insert(destination.preference_key());
+        }
+        keys
+    }
+
     pub fn preview_panel_showing(&self) -> bool {
         self.active_conversation_ui()
             .is_some_and(|ui| ui.right_panel_open && ui.right_tab == RightTab::Preview)


### PR DESCRIPTION
Diagnostic groundwork for #149 (does not close it).

`tcode --preview-smoke` drives the real `PreviewPanel` through scripted lifecycle phases — create, 20x hide/show churn, multi-create (6 views), 30x rapid switch, resize churn, navigate-all, drop-one, drop-during-create, graceful quit — each logged+flushed to stderr so a crash pinpoints its phase, with a 120s watchdog to catch nested-pump deadlocks. Linux prints `SKIP` and exits 0. Verified end-to-end on macOS (all phases PASS, exit 0).

Also fixes a real retention bug found while wiring drop-one: deleting a conversation now prunes its cached webview (previously it lived until app exit).

Next step: run this artifact under procdump on physical Windows 11 to capture and symbolize the #149 crash.

Gates: fmt / clippy -D warnings / full workspace tests / real macOS `--preview-smoke` run — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)