### PR TITLE
feat(palette): full-text search over conversation event logs

### DIFF
--- a/crates/services/src/lib.rs
+++ b/crates/services/src/lib.rs
@@ -9,6 +9,7 @@ pub mod process;
 pub mod provider_auth;
 pub mod provider_probe;
 pub mod relaunch;
+pub mod session_search;
 pub mod settings;
 pub mod shell_env;
 pub mod store;

--- a/crates/services/src/session_search.rs
+++ b/crates/services/src/session_search.rs
@@ -1,0 +1,380 @@
+//! Lazy full-text search over persisted session event logs.
+//!
+//! The index is deliberately in-memory: each session is parsed only when its
+//! JSONL file's length or modification time changes. This keeps the append-only
+//! persistence format authoritative and avoids a second on-disk database.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::time::SystemTime;
+
+use agent::ItemContent;
+use tcode_core::project::SessionMeta;
+use tcode_core::session::{EntryContent, StoredEvent, Timeline};
+
+use crate::store::SessionStore;
+
+/// One final, folded timeline entry that contributes to content search.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchableEntry {
+    pub entry_id: String,
+    pub turn: usize,
+    pub text: String,
+}
+
+/// A content match suitable for presentation by a session picker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionSearchHit {
+    pub session_id: String,
+    pub session_title: String,
+    pub entry_id: String,
+    pub turn: usize,
+    pub snippet: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileFingerprint {
+    len: u64,
+    modified: Option<SystemTime>,
+}
+
+#[derive(Debug, Clone)]
+struct CachedSession {
+    fingerprint: FileFingerprint,
+    entries: Vec<SearchableEntry>,
+}
+
+/// Incremental, file-freshness-based content index for one [`SessionStore`].
+pub struct SessionSearch {
+    store: SessionStore,
+    cache: HashMap<String, CachedSession>,
+}
+
+impl SessionSearch {
+    pub fn new(store: SessionStore) -> Self {
+        Self {
+            store,
+            cache: HashMap::new(),
+        }
+    }
+
+    /// Search sessions in the supplied order, returning at most `limit` hits.
+    /// Empty and whitespace-only queries intentionally return no content hits.
+    pub fn search(
+        &mut self,
+        sessions: &[SessionMeta],
+        query: &str,
+        limit: usize,
+    ) -> Vec<SessionSearchHit> {
+        let query = query.trim();
+        if query.is_empty() || limit == 0 {
+            return Vec::new();
+        }
+
+        let live_ids: HashSet<&str> = sessions.iter().map(|meta| meta.id.as_str()).collect();
+        self.cache.retain(|id, _| live_ids.contains(id.as_str()));
+
+        let mut hits = Vec::new();
+        for meta in sessions {
+            self.refresh(meta);
+            let Some(cached) = self.cache.get(&meta.id) else {
+                continue;
+            };
+            for entry in &cached.entries {
+                let Some(snippet) = match_snippet(&entry.text, query, 140) else {
+                    continue;
+                };
+                hits.push(SessionSearchHit {
+                    session_id: meta.id.clone(),
+                    session_title: meta.title.clone(),
+                    entry_id: entry.entry_id.clone(),
+                    turn: entry.turn,
+                    snippet,
+                });
+                if hits.len() == limit {
+                    return hits;
+                }
+            }
+        }
+        hits
+    }
+
+    fn refresh(&mut self, meta: &SessionMeta) {
+        let path = self.store.root().join(format!("{}.jsonl", meta.id));
+        let fingerprint = match fs::metadata(path) {
+            Ok(metadata) => FileFingerprint {
+                len: metadata.len(),
+                modified: metadata.modified().ok(),
+            },
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => FileFingerprint {
+                len: 0,
+                modified: None,
+            },
+            Err(error) => {
+                log::warn!("cannot inspect session log {}: {error}", meta.id);
+                return;
+            }
+        };
+        if self
+            .cache
+            .get(&meta.id)
+            .is_some_and(|cached| cached.fingerprint == fingerprint)
+        {
+            return;
+        }
+        let entries = extract_searchable_entries(&self.store.read_events(&meta.id));
+        self.cache.insert(
+            meta.id.clone(),
+            CachedSession {
+                fingerprint,
+                entries,
+            },
+        );
+    }
+}
+
+/// Fold persisted events and extract the final searchable representation.
+///
+/// Folding first deduplicates streaming deltas and item lifecycle updates, so
+/// callers index what the chat ultimately displays rather than every wire event.
+pub fn extract_searchable_entries(events: &[StoredEvent]) -> Vec<SearchableEntry> {
+    let timeline = Timeline::fold_events(events.iter().cloned());
+    let mut entries = Vec::new();
+    for entry in timeline
+        .entries
+        .iter()
+        .chain(timeline.children.values().flatten())
+    {
+        let text = match &entry.content {
+            EntryContent::Item(content) => searchable_item_text(content),
+            EntryContent::Steer {
+                text, attachments, ..
+            } => Some(join_parts(
+                std::iter::once(text.as_str()).chain(attachments.iter().map(String::as_str)),
+            )),
+            _ => None,
+        };
+        if let Some(text) = text.filter(|text| !text.trim().is_empty()) {
+            entries.push(SearchableEntry {
+                entry_id: entry.id.clone(),
+                turn: entry.turn,
+                text,
+            });
+        }
+    }
+    entries.sort_by_key(|entry| entry.turn);
+    entries
+}
+
+fn searchable_item_text(content: &ItemContent) -> Option<String> {
+    match content {
+        ItemContent::UserMessage {
+            text, attachments, ..
+        } => Some(join_parts(
+            std::iter::once(text.as_str()).chain(attachments.iter().map(String::as_str)),
+        )),
+        ItemContent::AssistantMessage { text } => Some(text.clone()),
+        ItemContent::CommandExecution { command, .. } => Some(command.clone()),
+        ItemContent::FileChange { changes, .. } => Some(join_parts(
+            changes.iter().map(|change| change.path.as_str()),
+        )),
+        ItemContent::ToolCall { name, input, .. } => {
+            Some(format!("{name} {}", compact_json(input)))
+        }
+        ItemContent::Subagent {
+            agent_type,
+            description,
+            summary,
+            ..
+        } => Some(join_parts(
+            [agent_type.as_str(), description.as_str()]
+                .into_iter()
+                .chain(summary.iter().map(String::as_str)),
+        )),
+        ItemContent::WebSearch { query } => Some(query.clone()),
+        ItemContent::Other {
+            provider_kind,
+            summary,
+        } => Some(format!("{provider_kind} {summary}")),
+        ItemContent::Reasoning { .. } => None,
+    }
+}
+
+fn compact_json(value: &serde_json::Value) -> String {
+    serde_json::to_string(value).unwrap_or_default()
+}
+
+fn join_parts<'a>(parts: impl Iterator<Item = &'a str>) -> String {
+    parts
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Return a compact, whitespace-normalized snippet for a case-insensitive hit.
+pub fn match_snippet(text: &str, query: &str, max_chars: usize) -> Option<String> {
+    let normalized = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let query = query.trim().to_lowercase();
+    if normalized.is_empty() || query.is_empty() {
+        return None;
+    }
+    let (match_start, match_end) = case_insensitive_range(&normalized, &query)?;
+    let chars: Vec<char> = normalized.chars().collect();
+    let start_char = normalized[..match_start].chars().count();
+    let end_char = normalized[..match_end].chars().count();
+    if chars.len() <= max_chars {
+        return Some(normalized);
+    }
+
+    let match_len = end_char.saturating_sub(start_char);
+    let context = max_chars.saturating_sub(match_len);
+    let mut start = start_char.saturating_sub(context / 2);
+    let end = (start + max_chars).min(chars.len());
+    start = end.saturating_sub(max_chars);
+    let mut snippet: String = chars[start..end].iter().collect();
+    if start > 0 {
+        snippet.insert(0, '…');
+    }
+    if end < chars.len() {
+        snippet.push('…');
+    }
+    Some(snippet)
+}
+
+fn case_insensitive_range(text: &str, lower_query: &str) -> Option<(usize, usize)> {
+    for (start, _) in text.char_indices() {
+        let suffix = &text[start..];
+        if !suffix.to_lowercase().starts_with(lower_query) {
+            continue;
+        }
+        let mut folded_len = 0;
+        let mut end = start;
+        for ch in suffix.chars() {
+            folded_len += ch.to_lowercase().map(char::len_utf8).sum::<usize>();
+            end += ch.len_utf8();
+            if folded_len >= lower_query.len() {
+                return Some((start, end));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use agent::{AgentEvent, ItemStatus, ProviderKind, ThreadItem};
+    use serde_json::json;
+    use tcode_core::project::SessionMeta;
+
+    use super::*;
+
+    fn completed(id: &str, content: ItemContent) -> StoredEvent {
+        AgentEvent::ItemCompleted(ThreadItem {
+            id: id.into(),
+            parent_item_id: None,
+            content,
+        })
+        .into()
+    }
+
+    #[test]
+    fn extracts_user_and_assistant_messages() {
+        let entries = extract_searchable_entries(&[
+            completed(
+                "user",
+                ItemContent::UserMessage {
+                    text: "Where is auth.rs?".into(),
+                    context_len: None,
+                    attachments: Vec::new(),
+                },
+            ),
+            completed(
+                "assistant",
+                ItemContent::AssistantMessage {
+                    text: "It is under crates/runtime.".into(),
+                },
+            ),
+        ]);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].text, "Where is auth.rs?");
+        assert_eq!(entries[1].text, "It is under crates/runtime.");
+    }
+
+    #[test]
+    fn extracts_tool_titles_paths_and_commands() {
+        let entries = extract_searchable_entries(&[
+            completed(
+                "command",
+                ItemContent::CommandExecution {
+                    command: "rg auth.rs crates".into(),
+                    output: "large output is deliberately not indexed".into(),
+                    exit_code: Some(0),
+                    status: ItemStatus::Completed,
+                },
+            ),
+            completed(
+                "tool",
+                ItemContent::ToolCall {
+                    name: "read_file".into(),
+                    input: json!({"path": "src/auth.rs"}),
+                    output: None,
+                    status: ItemStatus::Completed,
+                },
+            ),
+        ]);
+        assert_eq!(entries[0].text, "rg auth.rs crates");
+        assert!(entries[1].text.contains("read_file"));
+        assert!(entries[1].text.contains("src/auth.rs"));
+    }
+
+    #[test]
+    fn query_matching_is_case_insensitive_and_generates_a_bounded_snippet() {
+        let text = format!("{} AUTH.rs {}", "before ".repeat(20), "after ".repeat(20));
+        let snippet = match_snippet(&text, "auth.RS", 60).expect("match");
+        assert!(snippet.contains("AUTH.rs"));
+        assert!(snippet.chars().count() <= 62); // up to two ellipses
+        assert!(match_snippet(&text, "missing", 60).is_none());
+    }
+
+    #[test]
+    fn searches_a_fixture_session_log_to_a_session_and_turn() {
+        let root = std::env::temp_dir().join(format!(
+            "tcode-session-search-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let store = SessionStore::open_at(root.clone()).expect("store");
+        let mut meta = SessionMeta::new(ProviderKind::Codex, PathBuf::from("/project"), None);
+        meta.title = "Authentication cleanup".into();
+        store
+            .append_event(
+                &meta.id,
+                1,
+                &AgentEvent::TurnStarted {
+                    turn_id: "turn-1".into(),
+                },
+            )
+            .unwrap();
+        store
+            .append_event(
+                &meta.id,
+                2,
+                &completed(
+                    "assistant",
+                    ItemContent::AssistantMessage {
+                        text: "I updated crates/runtime/src/auth.rs".into(),
+                    },
+                )
+                .event,
+            )
+            .unwrap();
+
+        let hits = SessionSearch::new(store).search(&[meta.clone()], "auth.rs", 10);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].session_id, meta.id);
+        assert_eq!(hits[0].turn, 0);
+        assert!(hits[0].snippet.contains("auth.rs"));
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -18,9 +18,9 @@ use crate::{
 use agent::{ItemContent, ItemStatus, RewindMode};
 use gpui::{
     Anchor, AnyElement, App, AppContext as _, ClipboardItem, Context, Entity, FollowMode,
-    InteractiveElement as _, IntoElement, ListAlignment, ListState, ParentElement as _, Render,
-    Role, SharedString, StatefulInteractiveElement as _, Styled as _, Subscription, Task, Window,
-    div, list, prelude::FluentBuilder as _, px,
+    InteractiveElement as _, IntoElement, ListAlignment, ListOffset, ListState, ParentElement as _,
+    Render, Role, SharedString, StatefulInteractiveElement as _, Styled as _, Subscription, Task,
+    Window, div, list, prelude::FluentBuilder as _, px,
 };
 use gpui_base::{StyledExt as _, h_flex, v_flex};
 
@@ -71,6 +71,8 @@ pub struct ChatView {
     /// Open/closed keys for collapsibles (work logs, activity rows, cards, files).
     expanded: HashSet<String>,
     session_key: Option<String>,
+    /// Turn selected from a command-palette content hit.
+    highlighted_turn: Option<usize>,
     /// 1s ticker kept alive while a turn is running (drives live "Working for Ns").
     _tick: Option<Task<()>>,
     /// Which copy button is currently showing its "Copied!" confirmation (2s):
@@ -119,6 +121,7 @@ impl ChatView {
             md_states: HashMap::new(),
             expanded: HashSet::new(),
             session_key: None,
+            highlighted_turn: None,
             _tick: None,
             copied: None,
             _copied_task: None,
@@ -172,10 +175,14 @@ impl ChatView {
             .unwrap_or_default();
 
         let session_changed = session_key != self.session_key;
+        let requested_turn = session_key
+            .as_deref()
+            .and_then(|session_id| self.workspace_store.read(cx).pending_chat_turn(session_id));
         let list_sync = list_sync(&self.turn_items, &turn_items, session_changed);
         if session_changed {
             self.md_states.clear();
             self.expanded.clear();
+            self.highlighted_turn = None;
             self.session_key = session_key;
         }
         self.turn_items = turn_items;
@@ -198,6 +205,20 @@ impl ChatView {
                 for index in remeasure {
                     self.list_state.remeasure_items(index..index + 1);
                 }
+            }
+        }
+
+        if let Some(turn) = requested_turn.filter(|turn| *turn < self.turn_items.len()) {
+            self.list_state.set_follow_mode(FollowMode::Normal);
+            self.list_state.scroll_to(ListOffset {
+                item_ix: turn,
+                offset_in_item: px(0.),
+            });
+            self.highlighted_turn = Some(turn);
+            if let Some(session_id) = self.session_key.as_deref() {
+                self.workspace_store.update(cx, |store, _cx| {
+                    store.take_pending_chat_turn(session_id, turn);
+                });
             }
         }
 
@@ -1612,6 +1633,10 @@ impl Render for ChatView {
                     .w_full()
                     .justify_center()
                     .px(px(CONTENT_MIN_PADDING))
+                    .when(this.highlighted_turn == Some(index), |item| {
+                        item.rounded(crate::material::radius_card())
+                            .bg(cx.theme().list_active)
+                    })
                     .when(index + 1 < item_count, |item| item.pb(px(TURN_GAP)))
                     .child(div().w_full().max_w(px(CONTENT_MAX_WIDTH)).child(rendered))
                     .into_any_element()

--- a/crates/ui/src/palette.rs
+++ b/crates/ui/src/palette.rs
@@ -5,10 +5,14 @@
 //! Rendered by [`crate::AppShell`] as a full-window overlay only while
 //! [`crate::WindowState::palette_open`] is set. Sources:
 //! - Threads: fuzzy match over session titles (enter opens the thread).
+//! - Messages: debounced full-text search over persisted conversation events.
 //! - Actions: "New thread…" per project, "Open settings", "Toggle theme",
 //!   "Toggle diff panel".
 //!
 //! Fuzzy matching is a hand-rolled subsequence scorer ([`fuzzy_score`], no deps).
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use crate::theme::ActiveTheme as _;
 use crate::widgets::input::{Input, InputEvent, InputState};
@@ -20,10 +24,12 @@ use agent::ProviderKind;
 use gpui::{
     AppContext as _, Context, Entity, FocusHandle, Focusable, InteractiveElement as _, IntoElement,
     KeyDownEvent, ParentElement as _, Render, Role, StatefulInteractiveElement as _, Styled as _,
-    Subscription, Window, div, prelude::FluentBuilder as _, px,
+    Subscription, Task, Window, div, prelude::FluentBuilder as _, px,
 };
 use gpui_base::{StyledExt as _, h_flex, v_flex};
 use tcode_protocol::ThreadExportFormat;
+use tcode_services::session_search::{SessionSearch, SessionSearchHit};
+use tcode_services::store::SessionStore;
 
 use crate::provider_card::provider_glyph;
 use crate::settings::ThemeMode;
@@ -80,6 +86,7 @@ enum Action {
     },
     OpenThread {
         session_id: String,
+        turn: Option<usize>,
     },
 }
 
@@ -107,6 +114,10 @@ pub struct CommandPalette {
     query: Entity<InputState>,
     focus_handle: FocusHandle,
     selected: usize,
+    content_search: Option<Arc<Mutex<SessionSearch>>>,
+    content_hits: Vec<SessionSearchHit>,
+    search_generation: u64,
+    _search_task: Option<Task<()>>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -128,6 +139,7 @@ impl CommandPalette {
                 |this, _query, event, window, cx| match event {
                     InputEvent::Change => {
                         this.selected = 0;
+                        this.schedule_content_search(cx);
                         cx.notify();
                     }
                     InputEvent::PressEnter { .. } => {
@@ -144,6 +156,13 @@ impl CommandPalette {
             query,
             focus_handle: cx.focus_handle(),
             selected: 0,
+            content_search: SessionStore::open_default()
+                .ok()
+                .map(SessionSearch::new)
+                .map(|search| Arc::new(Mutex::new(search))),
+            content_hits: Vec::new(),
+            search_generation: 0,
+            _search_task: None,
             _subscriptions: subscriptions,
         }
     }
@@ -155,6 +174,45 @@ impl CommandPalette {
             state.focus(window, cx);
         });
         self.selected = 0;
+        self.content_hits.clear();
+    }
+
+    fn schedule_content_search(&mut self, cx: &mut Context<Self>) {
+        self.search_generation = self.search_generation.wrapping_add(1);
+        let generation = self.search_generation;
+        self.content_hits.clear();
+
+        let raw = self.query.read(cx).value().to_string();
+        let query = raw.trim();
+        if query.is_empty() || query.starts_with('>') {
+            self._search_task = None;
+            return;
+        }
+        let Some(search) = self.content_search.clone() else {
+            return;
+        };
+        let sessions = self.store.read(cx).sidebar_sessions();
+        let query = query.to_string();
+        self._search_task = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(150))
+                .await;
+            let hits = cx
+                .background_executor()
+                .spawn(async move {
+                    search
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .search(&sessions, &query, 50)
+                })
+                .await;
+            let _ = this.update(cx, |palette, cx| {
+                if palette.search_generation == generation {
+                    palette.content_hits = hits;
+                    cx.notify();
+                }
+            });
+        }));
     }
 
     fn close(&self, cx: &mut Context<Self>) {
@@ -289,6 +347,7 @@ impl CommandPalette {
                                 updated_at: Some(meta.updated_at),
                                 action: Action::OpenThread {
                                     session_id: meta.id.clone(),
+                                    turn: None,
                                 },
                             },
                         ));
@@ -300,6 +359,32 @@ impl CommandPalette {
                 groups.push(Group {
                     label: crate::tr!("palette.threads").into_owned(),
                     items: threads.into_iter().map(|(_, i)| i).collect(),
+                });
+            }
+
+            if !query.trim().is_empty() && !self.content_hits.is_empty() {
+                let sessions = store.sidebar_sessions();
+                let messages = self
+                    .content_hits
+                    .iter()
+                    .map(|hit| {
+                        let meta = sessions.iter().find(|meta| meta.id == hit.session_id);
+                        Item {
+                            icon: IconName::Search,
+                            label: hit.session_title.clone(),
+                            subtitle: Some(hit.snippet.clone()),
+                            provider: meta.map(|meta| meta.provider),
+                            updated_at: meta.map(|meta| meta.updated_at),
+                            action: Action::OpenThread {
+                                session_id: hit.session_id.clone(),
+                                turn: Some(hit.turn),
+                            },
+                        }
+                    })
+                    .collect();
+                groups.push(Group {
+                    label: crate::tr!("palette.messages").into_owned(),
+                    items: messages,
                 });
             }
         }
@@ -380,9 +465,14 @@ impl CommandPalette {
                     cx,
                 );
             }
-            Action::OpenThread { session_id } => {
-                self.store.update(cx, |store, _cx| {
-                    store.select_session(session_id);
+            Action::OpenThread { session_id, turn } => {
+                self.store.update(cx, |store, cx| {
+                    if let Some(turn) = turn {
+                        store.select_session_at_turn(session_id, turn);
+                        cx.notify();
+                    } else {
+                        store.select_session(session_id);
+                    }
                 });
                 self.close(cx);
             }

--- a/crates/ui/src/store/intents.rs
+++ b/crates/ui/src/store/intents.rs
@@ -173,6 +173,10 @@ impl WorkspaceStore {
     pub fn select_session(&mut self, session_id: String) {
         self.dispatch(Command::SelectSession { session_id });
     }
+    pub fn select_session_at_turn(&mut self, session_id: String, turn: usize) {
+        self.pending_chat_turn = Some((session_id.clone(), turn));
+        self.dispatch(Command::SelectSession { session_id });
+    }
     pub fn send_turn(&mut self, text: String, attachment_paths: Vec<PathBuf>) {
         self.dispatch(Command::SendTurn {
             text,

--- a/crates/ui/src/store/mod.rs
+++ b/crates/ui/src/store/mod.rs
@@ -98,6 +98,8 @@ pub struct WorkspaceStore {
     git_status_replica: GitStatusStatus,
     background_session_flags: HashMap<String, (bool, bool, bool)>,
     active_destination: Option<ConversationDestination>,
+    /// One-shot turn navigation requested by a cross-session content search.
+    pending_chat_turn: Option<(String, usize)>,
     native_rewind_prefills: HashMap<String, String>,
     conversation_ui: HashMap<ConversationDestination, ConversationUiState>,
 }
@@ -153,6 +155,7 @@ impl WorkspaceStore {
             git_status_replica: GitStatusStatus::default(),
             background_session_flags: HashMap::new(),
             active_destination: None,
+            pending_chat_turn: None,
             native_rewind_prefills: HashMap::new(),
             conversation_ui: HashMap::new(),
         };
@@ -1377,6 +1380,19 @@ impl WorkspaceStore {
         self.session_replica
             .as_ref()
             .map(|(_, timeline)| read(timeline))
+    }
+
+    pub(crate) fn pending_chat_turn(&self, session_id: &str) -> Option<usize> {
+        self.pending_chat_turn
+            .as_ref()
+            .filter(|(id, _)| id == session_id)
+            .map(|(_, turn)| *turn)
+    }
+
+    pub(crate) fn take_pending_chat_turn(&mut self, session_id: &str, turn: usize) {
+        if self.pending_chat_turn.as_ref() == Some(&(session_id.to_string(), turn)) {
+            self.pending_chat_turn = None;
+        }
     }
 
     #[cfg(test)]

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -479,6 +479,7 @@ palette:
   actions: "Actions"
   results: "Command palette results"
   threads: "Threads"
+  messages: "Messages"
   no_matches: "No matches"
   navigate: "↑↓ Navigate"
   select: "Enter Select"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -473,6 +473,7 @@ palette:
   actions: "操作"
   results: "命令面板结果"
   threads: "对话"
+  messages: "消息"
   no_matches: "没有匹配项"
   navigate: "↑↓ 导航"
   select: "Enter 选择"


### PR DESCRIPTION
Implements #122. The ⌘K palette matched session titles only; content was unsearchable.

- **Index**: lazy, in-memory, in `tcode-services` over the existing per-session JSONL. Each cached session is fingerprinted by file length + mtime; queries reparse only changed sessions. No SQLite (no existing dep), no watcher threads — freshness checks ride the query.
- **Extraction**: pure `extract_searchable_entries` folds `StoredEvent`s through the timeline (no duplicate streaming deltas), covering user/assistant/steering messages, attachment paths, commands, changed files, tool names/inputs, subagent summaries, web searches.
- **Palette**: a localized **Messages** group appears after a 150 ms debounce; parsing/search run on the background executor. Selecting a hit opens the session with a one-shot turn target — the chat list leaves tail-follow, scrolls to the turn, and highlights it (works for the already-active session too).
- **Latency (estimated)**: cold ~100–300 ms for ~200 sessions (20–40 MB JSONL), warm ~5–20 ms.
- Tests: extraction (user/assistant/tool events), matching + snippet bounds, and a persisted-fixture query→(session, turn) integration test.

Gates: fmt / clippy -D warnings / full workspace tests — green locally.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)