### PR TITLE
feat: durable pi MCP-capability surface + warning-severity fix

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -45,6 +45,8 @@ pub struct Caps {
     pub options_apply_live: bool,
     pub live_approval_mode_switch: bool,
     pub live_option_push: LiveOptionPush,
+    /// Whether this adapter can attach tcode's HTTP MCP servers to a session.
+    pub mcp_servers: bool,
     pub preview_mcp: bool,
     pub launch_args: bool,
     pub downgrade_approval_without_native_approvals: bool,
@@ -91,6 +93,7 @@ impl ProviderKind {
                 options_apply_live: false,
                 live_approval_mode_switch: true,
                 live_option_push: LiveOptionPush::None,
+                mcp_servers: true,
                 preview_mcp: true,
                 launch_args: true,
                 downgrade_approval_without_native_approvals: false,
@@ -106,6 +109,7 @@ impl ProviderKind {
                 options_apply_live: false,
                 live_approval_mode_switch: false,
                 live_option_push: LiveOptionPush::None,
+                mcp_servers: true,
                 preview_mcp: true,
                 launch_args: false,
                 downgrade_approval_without_native_approvals: false,
@@ -121,6 +125,9 @@ impl ProviderKind {
                 options_apply_live: true,
                 live_approval_mode_switch: false,
                 live_option_push: LiveOptionPush::All,
+                // ACP support is negotiated per agent; capable agents receive
+                // every tcode HTTP MCP registration in session/new or load.
+                mcp_servers: true,
                 preview_mcp: true,
                 launch_args: true,
                 downgrade_approval_without_native_approvals: false,
@@ -136,6 +143,7 @@ impl ProviderKind {
                 options_apply_live: false,
                 live_approval_mode_switch: false,
                 live_option_push: LiveOptionPush::Only(&["reasoningEffort"]),
+                mcp_servers: false,
                 preview_mcp: false,
                 launch_args: true,
                 downgrade_approval_without_native_approvals: true,
@@ -151,6 +159,7 @@ impl ProviderKind {
                 options_apply_live: false,
                 live_approval_mode_switch: false,
                 live_option_push: LiveOptionPush::None,
+                mcp_servers: true,
                 preview_mcp: true,
                 launch_args: true,
                 downgrade_approval_without_native_approvals: false,
@@ -188,6 +197,7 @@ mod provider_caps_tests {
                 options_apply_live: false,
                 live_approval_mode_switch: true,
                 live_option_push: LiveOptionPush::None,
+                mcp_servers: true,
                 preview_mcp: true,
                 launch_args: true,
                 downgrade_approval_without_native_approvals: false,
@@ -206,6 +216,7 @@ mod provider_caps_tests {
                 options_apply_live: false,
                 live_approval_mode_switch: false,
                 live_option_push: LiveOptionPush::None,
+                mcp_servers: true,
                 preview_mcp: true,
                 launch_args: false,
                 downgrade_approval_without_native_approvals: false,
@@ -224,6 +235,7 @@ mod provider_caps_tests {
                 options_apply_live: true,
                 live_approval_mode_switch: false,
                 live_option_push: LiveOptionPush::All,
+                mcp_servers: true,
                 preview_mcp: true,
                 launch_args: true,
                 downgrade_approval_without_native_approvals: false,
@@ -242,6 +254,7 @@ mod provider_caps_tests {
                 options_apply_live: false,
                 live_approval_mode_switch: false,
                 live_option_push: LiveOptionPush::Only(&["reasoningEffort"]),
+                mcp_servers: false,
                 preview_mcp: false,
                 launch_args: true,
                 downgrade_approval_without_native_approvals: true,
@@ -260,6 +273,7 @@ mod provider_caps_tests {
                 options_apply_live: false,
                 live_approval_mode_switch: false,
                 live_option_push: LiveOptionPush::None,
+                mcp_servers: true,
                 preview_mcp: true,
                 launch_args: true,
                 downgrade_approval_without_native_approvals: false,
@@ -268,6 +282,12 @@ mod provider_caps_tests {
                 trust_project_extensions: false,
             }
         );
+    }
+
+    #[test]
+    fn pi_cannot_attach_mcp_servers_but_claude_can() {
+        assert!(!ProviderKind::Pi.caps().mcp_servers);
+        assert!(ProviderKind::ClaudeCode.caps().mcp_servers);
     }
 }
 

--- a/crates/ui/src/composer/components/pickers.rs
+++ b/crates/ui/src/composer/components/pickers.rs
@@ -776,6 +776,14 @@ fn render_model_row(
                         .text_color(muted)
                         .child(glyph.xsmall())
                         .child(label)
+                })
+                .when(!row.provider.caps().mcp_servers, |this| {
+                    this.child(
+                        div()
+                            .text_size(px(11.))
+                            .text_color(muted)
+                            .child(crate::tr!("providers.mcp_unavailable")),
+                    )
                 }),
         )
         .when(index < 9, |this| {

--- a/crates/ui/src/provider_card.rs
+++ b/crates/ui/src/provider_card.rs
@@ -167,7 +167,15 @@ impl ProviderCard {
                     .min_w_0()
                     .gap_0p5()
                     .child(title)
-                    .child(self.render_summary_line(&summary, cx)),
+                    .child(self.render_summary_line(&summary, cx))
+                    .when(!provider.caps().mcp_servers, |this| {
+                        this.child(
+                            div()
+                                .text_size(px(11.))
+                                .text_color(muted)
+                                .child(crate::tr!("providers.mcp_unavailable")),
+                        )
+                    }),
             )
             .tooltip({
                 let name = name.clone();

--- a/crates/ui/src/runtime_event.rs
+++ b/crates/ui/src/runtime_event.rs
@@ -11,6 +11,7 @@ use crate::toast::ToastKind;
 pub(super) enum RuntimeEventSeverity {
     Error,
     Success,
+    Warning,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -138,7 +139,12 @@ pub(super) fn present_runtime_event(event: &RuntimeEvent) -> PresentedRuntimeEve
                 }
                 _ => format!("Unknown runtime notice: {notice:?}"),
             };
-            (RuntimeEventSeverity::Success, message)
+            let severity = if matches!(notice, RuntimeNotice::ProviderMessage(_)) {
+                RuntimeEventSeverity::Warning
+            } else {
+                RuntimeEventSeverity::Success
+            };
+            (severity, message)
         }
         RuntimeEvent::Toast(_) => unreachable!("rich toasts use present_runtime_toast"),
         RuntimeEvent::Effect(_) => unreachable!("runtime effects are not presentable"),
@@ -418,7 +424,12 @@ mod tests {
             }
             for notice in &notices {
                 let presented = present_runtime_event(&RuntimeEvent::Notice(notice.clone()));
-                assert_eq!(presented.severity, RuntimeEventSeverity::Success);
+                let expected = if matches!(notice, RuntimeNotice::ProviderMessage(_)) {
+                    RuntimeEventSeverity::Warning
+                } else {
+                    RuntimeEventSeverity::Success
+                };
+                assert_eq!(presented.severity, expected);
                 assert!(!presented.message.is_empty());
             }
             for toast in &toasts {
@@ -569,5 +580,14 @@ mod tests {
         }
 
         crate::set_locale(crate::LANGUAGE_ENGLISH);
+    }
+
+    #[test]
+    fn provider_warning_notice_is_presented_as_warning() {
+        let presented = present_runtime_event(&RuntimeEvent::Notice(
+            RuntimeNotice::ProviderMessage("pi MCP tools unavailable".into()),
+        ));
+
+        assert_eq!(presented.severity, RuntimeEventSeverity::Warning);
     }
 }

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -264,6 +264,7 @@ impl AppShell {
                 let notification = match presented.severity {
                     RuntimeEventSeverity::Error => Notification::error(presented.message),
                     RuntimeEventSeverity::Success => Notification::success(presented.message),
+                    RuntimeEventSeverity::Warning => Notification::warning(presented.message),
                 };
                 window.push_notification(notification, cx);
                 return;

--- a/docs/computer-use.md
+++ b/docs/computer-use.md
@@ -1,8 +1,10 @@
 # Computer use
 
-tcode gives every provider (Claude Code, Codex, and all ACP agents that advertise
-`mcpCapabilities.http`) a set of desktop computer-use tools, served by the in-process
-`tcode_computer_use` MCP server. The design follows
+tcode gives MCP-capable providers (Claude Code, Codex, OpenCode, and ACP agents that
+advertise `mcpCapabilities.http`) a set of desktop computer-use tools, served by the
+in-process `tcode_computer_use` MCP server. pi has no MCP client, so its provider card
+and model-picker rows identify computer use, preview, and orchestrate as unavailable
+before a session starts. The design follows
 [pi-computer-use](https://github.com/injaneity/pi-computer-use): accessibility-tree-first,
 state-scoped observation, transactional actions — not blind pixel clicking.
 
@@ -50,8 +52,9 @@ simplified successor-diff heuristic.
   - `permissions.rs` — TCC checks/requests (see below), public API also consumed by the
     settings UI.
 - Registration: `SessionOptions.computer_use_server: Option<McpRegistration>` threaded exactly
-  like `orchestrate_server` — Claude via `--mcp-config`, Codex via `-c mcp_servers.*`, ACP via
-  `session/new` `mcpServers` (HTTP-capability-gated). Enabled/disabled per
+  like `orchestrate_server` — Claude via `--mcp-config`, Codex via `-c mcp_servers.*`, OpenCode
+  via its server config, and ACP via `session/new` `mcpServers` (HTTP-capability-gated).
+  Enabled/disabled per
   `Settings.computer_use.enabled`.
 
 Unlike pi-computer-use, tcode needs **no helper app**: tcode is itself a signed `.app`, so

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -329,6 +329,7 @@ providers:
   enable: "Enable %{name}"
   reveal_email: "Click to reveal email"
   hide_email: "Click to hide email"
+  mcp_unavailable: "MCP tools (computer use / preview / orchestrate) unavailable"
   # Status dot + summary copy (T3 §2)
   status:
     checking: "Checking provider status"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -328,6 +328,7 @@ providers:
   enable: "启用 %{name}"
   reveal_email: "点击显示邮箱"
   hide_email: "点击隐藏邮箱"
+  mcp_unavailable: "MCP 工具（电脑操作 / 预览 / 编排）不可用"
   status:
     checking: "正在检查提供方状态"
     checking_detail: "正在等待服务返回安装与认证详情。"


### PR DESCRIPTION
Implements #109, option (b) from the issue: verified (installed pi 0.84.2 + upstream README) that pi core has no MCP client, so rather than auto-wiring a third-party extension, the gap becomes durable and visible **before** a pi session starts:

- `Caps::mcp_servers` — honest per provider: Claude (`--mcp-config`), Codex (`-c mcp_servers.*`), OpenCode (server config) are `true`; ACP attaches via `session/new`/`load` when the agent negotiates `mcpCapabilities.http` (documented inline); **pi is `false`**.
- Muted localized hint ("MCP tools (computer use / preview / orchestrate) unavailable") on model-picker rows and Settings → Provider cards for providers without it; the one-shot timeline warning stays but is no longer the only signal.
- Bug fix: provider warning notices were classified as `Success` and rendered as success notifications; they now render as warnings (regression test added).
- Capability truth-table tests extended; docs updated.

Gates: fmt / clippy -D warnings / full workspace tests — green locally.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)