### PR TITLE
feat: app update-available check via GitHub releases

### DIFF
--- a/crates/protocol/src/event.rs
+++ b/crates/protocol/src/event.rs
@@ -85,6 +85,7 @@ pub struct ProvidersStatus {
     pub model_catalogs: HashMap<ProviderKind, Vec<agent::ModelSpec>>,
     pub models_loading: HashMap<ProviderKind, bool>,
     pub provider_versions: HashMap<ProviderKind, ProviderVersionStatus>,
+    pub tcode_update: TcodeUpdateStatus,
     pub provider_snapshots: HashMap<String, ProviderSnapshot>,
     pub acp_marketplace_items: Vec<AcpMarketplaceItem>,
     pub acp_registry_loading: bool,
@@ -105,6 +106,15 @@ pub struct ProviderVersionStatus {
     pub checking: bool,
     pub updating: bool,
     pub update_command: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct TcodeUpdateStatus {
+    pub current: String,
+    pub latest: Option<String>,
+    pub release_url: Option<String>,
+    pub update_available: bool,
+    pub checking: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -316,6 +326,9 @@ pub enum RuntimeNotice {
     ProviderMessage(String),
     UpdateAvailable {
         provider: ProviderKind,
+        version: String,
+    },
+    TcodeUpdateAvailable {
         version: String,
     },
     UpdatingProvider {

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -14,8 +14,8 @@ pub use event::{
     AcpMarketplaceItem, EventEnvelope, GitActionRequest, GitStatusStatus, IndexSnapshot,
     ProviderVersionStatus, ProvidersStatus, QueuedMessageStatus, RuntimeEffect, RuntimeError,
     RuntimeNotice, RuntimeNotification, RuntimeOperationId, RuntimeToast, ServerEvent,
-    SessionEventRecord, SessionStatus, TerminalContextStatus, TerminalSplitStatus, TerminalStatus,
-    Topic,
+    SessionEventRecord, SessionStatus, TcodeUpdateStatus, TerminalContextStatus,
+    TerminalSplitStatus, TerminalStatus, Topic,
 };
 pub use query::{
     ExternalThread, GitDiffResult, GitDiffScope, GitFileText, PathEntry, Query, QueryResponse,

--- a/crates/protocol/src/tests.rs
+++ b/crates/protocol/src/tests.rs
@@ -170,6 +170,13 @@ fn round_trips_top_level_wire_types() {
                     update_command: Some("npm install -g @openai/codex@latest".into()),
                 },
             )]),
+            tcode_update: TcodeUpdateStatus {
+                current: "1.2.3".into(),
+                latest: Some("1.2.4".into()),
+                release_url: Some("https://github.com/Tryanks/tcode/releases/tag/v1.2.4".into()),
+                update_available: true,
+                checking: false,
+            },
             provider_snapshots: HashMap::from([(
                 "codex".into(),
                 tcode_core::provider_status::ProviderSnapshot {

--- a/crates/runtime/src/app/mod.rs
+++ b/crates/runtime/src/app/mod.rs
@@ -50,8 +50,8 @@ use tcode_protocol::ThreadExportFormat;
 use tcode_protocol::{
     AcpMarketplaceItem, EventEnvelope, ExternalThread, GitStatusStatus, IndexSnapshot, PathEntry,
     ProviderVersionStatus as ProtocolProviderVersionStatus, ProvidersStatus, QueuedMessageStatus,
-    RecentDir, ServerEvent, SessionEventRecord, SessionStatus, TerminalContextStatus,
-    TerminalSplitStatus, TerminalStatus, Topic,
+    RecentDir, ServerEvent, SessionEventRecord, SessionStatus, TcodeUpdateStatus,
+    TerminalContextStatus, TerminalSplitStatus, TerminalStatus, Topic,
 };
 use tcode_services::acp_registry::{
     Registry, RegistryAgent, cached, install, load, platform_key, resolve_recipe, uninstall,
@@ -74,8 +74,8 @@ use tcode_services::settings::SettingsStore;
 use tcode_services::store::{SessionStore, now_millis, now_secs};
 use tcode_services::user_files;
 use tcode_services::version_check::{
-    InstallSource, detect_install_source, is_update_available, npm_package, parse_version,
-    update_command, update_command_string,
+    InstallSource, detect_install_source, fetch_latest_tcode_release, is_update_available,
+    npm_package, parse_version, tcode_update_available, update_command, update_command_string,
 };
 use tcode_services::workspace::list_workspace;
 
@@ -282,6 +282,28 @@ pub struct ProviderVersionState {
     pub updating: bool,
     /// How the binary was installed (drives the update command).
     pub install_source: InstallSource,
+}
+
+/// The result of checking the running tcode build against GitHub Releases.
+#[derive(Debug, Clone)]
+pub struct TcodeUpdateState {
+    pub current: String,
+    pub latest: Option<String>,
+    pub release_url: Option<String>,
+    pub update_available: bool,
+    pub checking: bool,
+}
+
+impl Default for TcodeUpdateState {
+    fn default() -> Self {
+        Self {
+            current: env!("CARGO_PKG_VERSION").to_string(),
+            latest: None,
+            release_url: None,
+            update_available: false,
+            checking: false,
+        }
+    }
 }
 
 pub struct AppState {

--- a/crates/runtime/src/app/providers.rs
+++ b/crates/runtime/src/app/providers.rs
@@ -4,6 +4,7 @@ pub struct ProviderCatalog {
     pub model_catalogs: HashMap<ProviderKind, Vec<ModelSpec>>,
     pub models_loading: HashMap<ProviderKind, bool>,
     pub provider_versions: HashMap<ProviderKind, ProviderVersionState>,
+    pub tcode_update: TcodeUpdateState,
     pub provider_snapshots: HashMap<String, ProviderSnapshot>,
     pub(super) provider_secret_names: HashMap<String, HashSet<String>>,
 }
@@ -17,6 +18,7 @@ impl ProviderCatalog {
             model_catalogs,
             models_loading: HashMap::new(),
             provider_versions: HashMap::new(),
+            tcode_update: TcodeUpdateState::default(),
             provider_snapshots: HashMap::new(),
             provider_secret_names,
         }
@@ -49,6 +51,13 @@ impl ProviderCatalog {
                     )
                 })
                 .collect(),
+            tcode_update: TcodeUpdateStatus {
+                current: self.tcode_update.current.clone(),
+                latest: self.tcode_update.latest.clone(),
+                release_url: self.tcode_update.release_url.clone(),
+                update_available: self.tcode_update.update_available,
+                checking: self.tcode_update.checking,
+            },
             provider_snapshots: self.provider_snapshots.clone(),
             acp_marketplace_items,
             acp_registry_loading,
@@ -66,7 +75,8 @@ impl ProviderCatalog {
                 || self
                     .provider_versions
                     .values()
-                    .any(|status| status.checking),
+                    .any(|status| status.checking)
+                || self.tcode_update.checking,
             secret_names: self.provider_secret_names.clone(),
         }
     }
@@ -384,9 +394,8 @@ impl AppState {
         }
     }
 
-    /// Check every provider's installed vs. latest version in the background,
-    /// storing results in `provider_versions` and toasting once per provider
-    /// that has an update available.
+    /// Check every provider and the running tcode build in the background,
+    /// storing results and toasting once for each newly available update.
     pub fn check_provider_versions(&mut self, cx: &mut HostCx) {
         for provider in NATIVE_PROVIDER_KINDS {
             let binary = self.resolve_provider_binary(provider);
@@ -473,6 +482,41 @@ impl AppState {
                 });
             });
         }
+
+        if self.providers.tcode_update.checking {
+            return;
+        }
+        self.providers.tcode_update.checking = true;
+        let current = self.providers.tcode_update.current.clone();
+        let host_cx = cx.clone();
+        HostCx::spawn_detached(cx, async move {
+            let release = host_cx.unblock(fetch_latest_tcode_release).await;
+            host_cx.enqueue(move |state, cx| {
+                let already = state.providers.tcode_update.update_available;
+                let update_available = release.as_ref().is_some_and(|release| {
+                    (!release.prerelease || current.contains('-'))
+                        && tcode_update_available(&current, &release.tag_name).unwrap_or(false)
+                });
+                let status = &mut state.providers.tcode_update;
+                status.checking = false;
+                status.latest = release
+                    .as_ref()
+                    .map(|release| release.tag_name.trim_start_matches('v').to_string());
+                status.release_url = release.as_ref().map(|release| release.html_url.clone());
+                status.update_available = update_available;
+                if update_available
+                    && !already
+                    && let Some(version) = &status.latest
+                {
+                    emit_runtime(
+                        cx,
+                        RuntimeEvent::Notice(RuntimeNotice::TcodeUpdateAvailable {
+                            version: version.clone(),
+                        }),
+                    );
+                }
+            });
+        });
     }
 
     /// Run the provider's self-update command (per its detected install source),

--- a/crates/services/src/version_check.rs
+++ b/crates/services/src/version_check.rs
@@ -1,15 +1,97 @@
-//! Provider CLI version checks and self-update command mapping (s3 §6).
+//! Provider CLI and tcode release version checks (s3 §6).
 //!
-//! Pure helpers: parse a version out of `<provider> --version` output, compare
-//! it against the latest published version, guess how the binary was installed
-//! (Homebrew / npm / native installer), and derive the update command for that
-//! install source. All I/O (spawning `--version`, `npm view`, the update
-//! command itself) lives in the later runtime caller; this module stays
-//! unit-testable.
+//! Helpers parse and compare versions, infer provider install sources, and map
+//! those sources to update commands. The tcode release lookup lives here beside
+//! its fixture-testable JSON parser; process spawning and provider updates stay
+//! in the runtime caller.
 
+use std::io::Read as _;
 use std::path::Path;
+use std::time::Duration;
 
 use agent::ProviderKind;
+use serde::Deserialize;
+
+const TCODE_LATEST_RELEASE_URL: &str = "https://api.github.com/repos/Tryanks/tcode/releases/latest";
+
+/// The release metadata needed by the app's update notice.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct TcodeRelease {
+    pub tag_name: String,
+    pub html_url: String,
+    #[serde(default)]
+    pub prerelease: bool,
+}
+
+/// Fetch the latest published tcode release. Network, rate-limit, and response
+/// errors deliberately collapse to `None`: update checks must never disrupt
+/// app startup or provider checks.
+pub fn fetch_latest_tcode_release() -> Option<TcodeRelease> {
+    let response = ureq::get(TCODE_LATEST_RELEASE_URL)
+        .set("Accept", "application/vnd.github+json")
+        .set("X-GitHub-Api-Version", "2022-11-28")
+        .set("User-Agent", "tcode-update-check")
+        .timeout(Duration::from_secs(10))
+        .call()
+        .ok()?;
+    let mut body = Vec::new();
+    response
+        .into_reader()
+        .take(1024 * 1024)
+        .read_to_end(&mut body)
+        .ok()?;
+    parse_tcode_release(&body)
+}
+
+/// Parse the subset of GitHub's release JSON used by the update surface.
+pub fn parse_tcode_release(bytes: &[u8]) -> Option<TcodeRelease> {
+    serde_json::from_slice(bytes).ok()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TcodeVersion {
+    core: (u32, u32, u32),
+    prerelease: bool,
+}
+
+fn parse_tcode_version(raw: &str) -> Option<TcodeVersion> {
+    let raw = raw.trim().strip_prefix('v').unwrap_or(raw.trim());
+    let without_build = raw.split_once('+').map_or(raw, |(core, _)| core);
+    let (core, prerelease) = match without_build.split_once('-') {
+        Some((core, suffix)) if !suffix.is_empty() => (core, true),
+        Some(_) => return None,
+        None => (without_build, false),
+    };
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(TcodeVersion {
+        core: (major, minor, patch),
+        prerelease,
+    })
+}
+
+/// Compare a running app version with a GitHub release tag.
+///
+/// Prerelease releases are ignored for stable builds. A prerelease build may
+/// advance to a newer prerelease numeric triple or to the stable release with
+/// the same numeric triple. Malformed input returns `None`.
+pub fn tcode_update_available(running: &str, latest_tag: &str) -> Option<bool> {
+    let running = parse_tcode_version(running)?;
+    let latest = parse_tcode_version(latest_tag)?;
+    if latest.prerelease && !running.prerelease {
+        return Some(false);
+    }
+    Some(match latest.core.cmp(&running.core) {
+        std::cmp::Ordering::Greater => true,
+        std::cmp::Ordering::Less => false,
+        std::cmp::Ordering::Equal => running.prerelease && !latest.prerelease,
+    })
+}
 
 /// The npm package name whose published version is the provider's "latest".
 /// `npm view <pkg> version` works for every native provider (verified 2026-07);
@@ -216,6 +298,52 @@ mod tests {
         assert!(is_update_available("codex-cli 0.144.1", "0.145.0"));
         // Unparseable → no update claimed.
         assert!(!is_update_available("unknown", "2.0.0"));
+    }
+
+    #[test]
+    fn compares_tcode_release_versions() {
+        assert_eq!(tcode_update_available("0.4.0", "v0.4.0"), Some(false));
+        assert_eq!(tcode_update_available("0.4.0", "v0.4.1"), Some(true));
+        assert_eq!(tcode_update_available("0.4.1", "v0.4.0"), Some(false));
+    }
+
+    #[test]
+    fn handles_tcode_prereleases() {
+        assert_eq!(
+            tcode_update_available("0.4.0", "v0.5.0-beta.1"),
+            Some(false)
+        );
+        assert_eq!(tcode_update_available("0.5.0-beta.1", "v0.5.0"), Some(true));
+        assert_eq!(
+            tcode_update_available("0.5.0-beta.1", "v0.6.0-beta.1"),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn malformed_tcode_release_tag_has_no_comparison() {
+        assert_eq!(tcode_update_available("0.4.0", "latest"), None);
+        assert_eq!(tcode_update_available("0.4", "v0.4.1"), None);
+    }
+
+    #[test]
+    fn parses_github_release_json() {
+        let release = parse_tcode_release(
+            br#"{
+                "tag_name": "v0.4.1",
+                "html_url": "https://github.com/Tryanks/tcode/releases/tag/v0.4.1",
+                "prerelease": false,
+                "assets": [{"name": "SHA256SUMS.txt"}]
+            }"#,
+        )
+        .expect("release fixture should parse");
+
+        assert_eq!(release.tag_name, "v0.4.1");
+        assert_eq!(
+            release.html_url,
+            "https://github.com/Tryanks/tcode/releases/tag/v0.4.1"
+        );
+        assert!(!release.prerelease);
     }
 
     #[test]

--- a/crates/ui/src/runtime_event.rs
+++ b/crates/ui/src/runtime_event.rs
@@ -110,6 +110,9 @@ pub(super) fn present_runtime_event(event: &RuntimeEvent) -> PresentedRuntimeEve
                     version = version
                 )
                 .into_owned(),
+                RuntimeNotice::TcodeUpdateAvailable { version } => {
+                    crate::tr!("notice.tcode_update_available", version = version).into_owned()
+                }
                 RuntimeNotice::UpdatingProvider { provider } => crate::tr!(
                     "notice.updating_provider",
                     provider = provider.display_name()
@@ -352,6 +355,9 @@ mod tests {
             RuntimeNotice::ProviderMessage("provider-warning\0diagnostic".into()),
             RuntimeNotice::UpdateAvailable {
                 provider: ProviderKind::Codex,
+                version: "1.2.3".into(),
+            },
+            RuntimeNotice::TcodeUpdateAvailable {
                 version: "1.2.3".into(),
             },
             RuntimeNotice::UpdatingProvider {

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -737,6 +737,52 @@ impl SettingsPage {
             .into_any_element()
     }
 
+    fn render_tcode_update_popover(&self, cx: &mut Context<Self>) -> AnyElement {
+        let status = self.store.read(cx).tcode_update_status();
+        let version = status.latest.unwrap_or_default();
+        let release_url = status.release_url.unwrap_or_default();
+
+        crate::material::overlay_popover("tcode-update-popover")
+            .trigger(
+                Button::new("tcode-update-available")
+                    .ghost()
+                    .xsmall()
+                    .icon(Icon::empty().path("icons/download.svg"))
+                    .label(crate::tr!(
+                        "providers.tcode_update_available",
+                        version = version
+                    ))
+                    .tooltip(crate::tr!("providers.tcode_update_aria")),
+            )
+            .content(move |_, _, cx| {
+                let muted = cx.theme().muted_foreground;
+                let release_url = release_url.clone();
+                v_flex()
+                    .w(px(320.))
+                    .gap_2()
+                    .child(
+                        div()
+                            .text_size(px(13.))
+                            .font_semibold()
+                            .child(crate::tr!("providers.tcode_update_title")),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(13.))
+                            .text_color(muted)
+                            .child(crate::tr!("providers.tcode_update_message")),
+                    )
+                    .child(
+                        Button::new("view-tcode-release")
+                            .primary()
+                            .small()
+                            .label(crate::tr!("providers.view_release"))
+                            .on_click(move |_, _, cx| cx.open_url(&release_url)),
+                    )
+            })
+            .into_any_element()
+    }
+
     /// Settings → Providers: native providers and installed ACP agents share one
     /// bordered list. The marketplace lives behind the Add agent dialog.
     fn render_providers(&mut self, window: &mut Window, cx: &mut Context<Self>) -> gpui::Div {
@@ -780,6 +826,9 @@ impl SettingsPage {
                     .text_color(muted)
                     .child(crate::tr!("providers.checked", when = ago).into_owned()),
             );
+        }
+        if self.store.read(cx).tcode_update_status().update_available {
+            header = header.child(self.render_tcode_update_popover(cx));
         }
         header = header.child(
             Button::new("add-acp-agent")

--- a/crates/ui/src/store/mod.rs
+++ b/crates/ui/src/store/mod.rs
@@ -1067,6 +1067,10 @@ impl WorkspaceStore {
             .cloned()
     }
 
+    pub fn tcode_update_status(&self) -> tcode_protocol::TcodeUpdateStatus {
+        self.providers_replica.tcode_update.clone()
+    }
+
     pub fn provider_profile_accent(&self, profile_id: &str) -> Option<u32> {
         let raw = self
             .settings_replica

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -223,7 +223,7 @@ settings:
     description: "Open the right-side plan and task panel automatically when steps appear."
   provider_updates:
     title: "Provider update checks"
-    description: "Check for newer provider CLI versions on launch."
+    description: "Check for newer tcode and provider CLI versions on launch."
   title_generation:
     title: "Thread title model"
     description: "Choose the provider and model used to name new threads. Title requests always use low reasoning effort."
@@ -369,6 +369,11 @@ providers:
   updating: "Updating"
   update_manual: "or, update manually using"
   copy_command: "Copy command"
+  tcode_update_available: "tcode %{version} available"
+  tcode_update_aria: "tcode update available — view details"
+  tcode_update_title: "tcode update available"
+  tcode_update_message: "Download the latest release from GitHub."
+  view_release: "View release"
   # Per-profile settings dialog (opened from a provider row's gear).
   configure: "Configure %{name}"
   dialog:
@@ -703,6 +708,7 @@ notice:
   thread_exported: "Exported thread to %{file}"
   dirty_tree: "Working tree has uncommitted changes"
   update_available: "Update Available: %{provider} v%{version}"
+  tcode_update_available: "tcode %{version} available"
   updating_provider: "Updating %{provider}…"
   update_done: "%{provider} updated"
 attach:

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -223,7 +223,7 @@ settings:
     description: "当出现步骤时自动打开右侧的计划和任务面板。"
   provider_updates:
     title: "提供方更新检查"
-    description: "启动时检查更新的提供方 CLI 版本。"
+    description: "启动时检查 tcode 和提供方 CLI 的新版本。"
   title_generation:
     title: "对话命名模型"
     description: "选择负责为新对话命名的提供方和模型。命名请求始终使用 low 推理强度。"
@@ -365,6 +365,11 @@ providers:
   updating: "更新中"
   update_manual: "或者手动更新："
   copy_command: "复制命令"
+  tcode_update_available: "tcode %{version} 可用"
+  tcode_update_aria: "tcode 有可用更新 — 查看详情"
+  tcode_update_title: "tcode 有可用更新"
+  tcode_update_message: "从 GitHub 下载最新版本。"
+  view_release: "查看发布版本"
   # 单个配置的设置对话框（点击提供方行的齿轮图标打开）。
   configure: "配置 %{name}"
   dialog:
@@ -697,6 +702,7 @@ notice:
   thread_exported: "对话已导出至 %{file}"
   dirty_tree: "工作树中有未提交的更改"
   update_available: "有可用更新：%{provider} v%{version}"
+  tcode_update_available: "tcode %{version} 可用"
   updating_provider: "正在更新 %{provider}…"
   update_done: "%{provider} 已更新"
 attach:


### PR DESCRIPTION
The feasible half of #120 (does not close it — signing/notarization and a self-replacing updater need maintainer credentials):

- Rides the existing provider version-check cadence (startup + Settings refresh; no new timers) and the existing `ureq` dependency; every network/API failure degrades silently to "no update info".
- Numeric-triple compare vs `CARGO_PKG_VERSION` (leading `v` stripped): stable builds ignore prereleases; prerelease builds can advance to newer prereleases or same-triple stable; malformed tags → `None`.
- New release ⇒ localized "tcode X.Y.Z available" notice + a download-style row in Settings → Providers on the same popover surface as provider updates; "View release" opens the GitHub release page.
- 15 version_check tests incl. fixture-only release-JSON parsing (no network).

Gates: fmt / clippy -D warnings / full workspace tests — green locally.

Part of #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)