### PR TITLE
refactor: one field-scoped settings-mutation interface

### DIFF
--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -570,6 +570,41 @@ pub struct BrowserSettings {
     pub allow_evaluate: bool,
 }
 
+/// A field-scoped mutation of persisted application settings.
+///
+/// Keeping nested settings mutations field-scoped prevents a writer holding a
+/// stale snapshot from replacing unrelated fields changed by another writer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "content", rename_all = "snake_case")]
+pub enum SettingsPatch {
+    Language(Option<String>),
+    ThemeMode(ThemeMode),
+    WordWrapDiffs(bool),
+    SkipDeleteConfirmation(bool),
+    AutoOpenTaskPanel(bool),
+    ProviderUpdateChecksDisabled(bool),
+    AutoArchiveDisabled(bool),
+    AutoArchiveMaxIdleDays(u32),
+    AutoArchiveKeepCount(usize),
+    AutoArchiveNoticeShown(bool),
+    OrchestrateGenericIdentity(String),
+    OrchestrateModelIdentities(Vec<OrchestratorIdentity>),
+    OrchestrateChildModels(Vec<OrchestrateChildModel>),
+    OrchestrateChildApproval(ChildApprovalMode),
+    OrchestrateChildWorktrees(bool),
+    OrchestrateArchiveOnComplete(bool),
+    ComputerUseEnabled(bool),
+    ComputerUseImageMode(ImageMode),
+    ComputerUseAllowInput(bool),
+    BrowserEnabled(bool),
+    BrowserHomeUrl(Option<String>),
+    BrowserAllowEvaluate(bool),
+    TitleGenerationProvider(ProviderKind),
+    TitleGenerationModel(String),
+    TitleGenerationProfileId(Option<String>),
+    SidebarLayout(SidebarLayout),
+}
+
 impl Default for BrowserSettings {
     fn default() -> Self {
         Self {
@@ -731,6 +766,66 @@ impl Default for Settings {
             last_visited: HashMap::new(),
             acp_agents: BTreeMap::new(),
             unknown: serde_json::Map::new(),
+        }
+    }
+}
+
+impl Settings {
+    /// Apply one field-scoped mutation without replacing sibling fields.
+    pub fn apply(&mut self, patch: SettingsPatch) {
+        match patch {
+            SettingsPatch::Language(value) => self.language = value,
+            SettingsPatch::ThemeMode(value) => self.theme_mode = value,
+            SettingsPatch::WordWrapDiffs(value) => self.word_wrap_diffs = value,
+            SettingsPatch::SkipDeleteConfirmation(value) => {
+                self.skip_delete_confirmation = value;
+            }
+            SettingsPatch::AutoOpenTaskPanel(value) => self.auto_open_task_panel = value,
+            SettingsPatch::ProviderUpdateChecksDisabled(value) => {
+                self.provider_update_checks_disabled = value;
+            }
+            SettingsPatch::AutoArchiveDisabled(value) => self.auto_archive_disabled = value,
+            SettingsPatch::AutoArchiveMaxIdleDays(value) => {
+                self.auto_archive_max_idle_days = value;
+            }
+            SettingsPatch::AutoArchiveKeepCount(value) => {
+                self.auto_archive_keep_count = value;
+            }
+            SettingsPatch::AutoArchiveNoticeShown(value) => {
+                self.auto_archive_notice_shown = value;
+            }
+            SettingsPatch::OrchestrateGenericIdentity(value) => {
+                self.orchestrate.generic_identity = value;
+            }
+            SettingsPatch::OrchestrateModelIdentities(value) => {
+                self.orchestrate.model_identities = value;
+            }
+            SettingsPatch::OrchestrateChildModels(value) => {
+                self.orchestrate.child_models = value;
+            }
+            SettingsPatch::OrchestrateChildApproval(value) => {
+                self.orchestrate.child_approval = value;
+            }
+            SettingsPatch::OrchestrateChildWorktrees(value) => {
+                self.orchestrate.child_worktrees = value;
+            }
+            SettingsPatch::OrchestrateArchiveOnComplete(value) => {
+                self.orchestrate.archive_on_complete = value;
+            }
+            SettingsPatch::ComputerUseEnabled(value) => self.computer_use.enabled = value,
+            SettingsPatch::ComputerUseImageMode(value) => self.computer_use.image_mode = value,
+            SettingsPatch::ComputerUseAllowInput(value) => self.computer_use.allow_input = value,
+            SettingsPatch::BrowserEnabled(value) => self.browser.enabled = value,
+            SettingsPatch::BrowserHomeUrl(value) => self.browser.home_url = value,
+            SettingsPatch::BrowserAllowEvaluate(value) => self.browser.allow_evaluate = value,
+            SettingsPatch::TitleGenerationProvider(value) => {
+                self.title_generation.provider = value;
+            }
+            SettingsPatch::TitleGenerationModel(value) => self.title_generation.model = value,
+            SettingsPatch::TitleGenerationProfileId(value) => {
+                self.title_generation.profile_id = value;
+            }
+            SettingsPatch::SidebarLayout(value) => self.sidebar_layout = value,
         }
     }
 }

--- a/crates/protocol/src/command.rs
+++ b/crates/protocol/src/command.rs
@@ -6,12 +6,11 @@ use tcode_core::{
     acp::AcpAgentPatch,
     git::GitAction,
     session::ReviewComment,
-    settings::{
-        BrowserSettings, ComputerUseSettings, OrchestrateSettings, ProfileSettingsPatch,
-        SidebarLayout, ThemeMode, TitleGenerationSettings,
-    },
+    settings::ProfileSettingsPatch,
     ui::{TerminalSplitDirection, WorkspaceMode},
 };
+
+pub use tcode_core::settings::SettingsPatch;
 
 use crate::ExternalThread;
 
@@ -23,28 +22,6 @@ pub enum ThreadExportFormat {
     Jsonl,
     /// A readable, deterministic rendering of the folded conversation timeline.
     Markdown,
-}
-
-/// A field-scoped settings mutation applied to the host's current settings.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "type", content = "content", rename_all = "snake_case")]
-pub enum SettingsPatch {
-    Language(Option<String>),
-    ThemeMode(ThemeMode),
-    WordWrapDiffs(bool),
-    SkipDeleteConfirmation(bool),
-    AutoOpenTaskPanel(bool),
-    ProviderUpdateChecksDisabled(bool),
-    AutoArchiveDisabled(bool),
-    AutoArchiveMaxIdleDays(u32),
-    AutoArchiveKeepCount(usize),
-    AutoArchiveNoticeShown(bool),
-    Orchestrate(OrchestrateSettings),
-    OrchestrateChildWorktrees(bool),
-    ComputerUse(ComputerUseSettings),
-    Browser(BrowserSettings),
-    TitleGeneration(TitleGenerationSettings),
-    SidebarLayout(SidebarLayout),
 }
 
 /// A backend mutation requested by a client.

--- a/crates/protocol/src/tests.rs
+++ b/crates/protocol/src/tests.rs
@@ -8,7 +8,9 @@ use tcode_core::{
     acp::AcpAgentPatch,
     project::Project,
     session::{ReviewComment, ReviewSide},
-    settings::{ProfileSettingsPatch, Settings},
+    settings::{
+        ChildApprovalMode, ImageMode, ProfileSettingsPatch, Settings, SidebarLayout, ThemeMode,
+    },
     ui::{TerminalSplitDirection, WorkspaceMode},
 };
 
@@ -228,8 +230,39 @@ fn round_trips_top_level_wire_types() {
 }
 
 #[test]
-fn orchestrate_child_worktrees_patch_round_trips() {
-    round_trip(&SettingsPatch::OrchestrateChildWorktrees(true));
+fn settings_patches_round_trip() {
+    let patches = vec![
+        SettingsPatch::Language(Some("zh-CN".into())),
+        SettingsPatch::ThemeMode(ThemeMode::Dark),
+        SettingsPatch::WordWrapDiffs(true),
+        SettingsPatch::SkipDeleteConfirmation(true),
+        SettingsPatch::AutoOpenTaskPanel(true),
+        SettingsPatch::ProviderUpdateChecksDisabled(true),
+        SettingsPatch::AutoArchiveDisabled(true),
+        SettingsPatch::AutoArchiveMaxIdleDays(14),
+        SettingsPatch::AutoArchiveKeepCount(42),
+        SettingsPatch::AutoArchiveNoticeShown(true),
+        SettingsPatch::OrchestrateGenericIdentity("lead".into()),
+        SettingsPatch::OrchestrateModelIdentities(Vec::new()),
+        SettingsPatch::OrchestrateChildModels(Vec::new()),
+        SettingsPatch::OrchestrateChildApproval(ChildApprovalMode::AlwaysAllow),
+        SettingsPatch::OrchestrateChildWorktrees(true),
+        SettingsPatch::OrchestrateArchiveOnComplete(false),
+        SettingsPatch::ComputerUseEnabled(true),
+        SettingsPatch::ComputerUseImageMode(ImageMode::Always),
+        SettingsPatch::ComputerUseAllowInput(false),
+        SettingsPatch::BrowserEnabled(false),
+        SettingsPatch::BrowserHomeUrl(Some("https://example.com".into())),
+        SettingsPatch::BrowserAllowEvaluate(false),
+        SettingsPatch::TitleGenerationProvider(ProviderKind::ClaudeCode),
+        SettingsPatch::TitleGenerationModel("claude-sonnet".into()),
+        SettingsPatch::TitleGenerationProfileId(Some("work".into())),
+        SettingsPatch::SidebarLayout(SidebarLayout::Grouped),
+    ];
+
+    for patch in patches {
+        round_trip(&patch);
+    }
 }
 
 fn assert_command_crosses_ndjson(id: u64, command: Command) {

--- a/crates/runtime/src/app/sessions.rs
+++ b/crates/runtime/src/app/sessions.rs
@@ -366,42 +366,7 @@ impl AppState {
 
     pub fn patch_settings(&mut self, patch: tcode_protocol::SettingsPatch, cx: &mut HostCx) {
         let mut settings = self.settings.clone();
-        match patch {
-            tcode_protocol::SettingsPatch::Language(value) => settings.language = value,
-            tcode_protocol::SettingsPatch::ThemeMode(value) => settings.theme_mode = value,
-            tcode_protocol::SettingsPatch::WordWrapDiffs(value) => settings.word_wrap_diffs = value,
-            tcode_protocol::SettingsPatch::SkipDeleteConfirmation(value) => {
-                settings.skip_delete_confirmation = value;
-            }
-            tcode_protocol::SettingsPatch::AutoOpenTaskPanel(value) => {
-                settings.auto_open_task_panel = value;
-            }
-            tcode_protocol::SettingsPatch::ProviderUpdateChecksDisabled(value) => {
-                settings.provider_update_checks_disabled = value;
-            }
-            tcode_protocol::SettingsPatch::AutoArchiveDisabled(value) => {
-                settings.auto_archive_disabled = value;
-            }
-            tcode_protocol::SettingsPatch::AutoArchiveMaxIdleDays(value) => {
-                settings.auto_archive_max_idle_days = value;
-            }
-            tcode_protocol::SettingsPatch::AutoArchiveKeepCount(value) => {
-                settings.auto_archive_keep_count = value;
-            }
-            tcode_protocol::SettingsPatch::AutoArchiveNoticeShown(value) => {
-                settings.auto_archive_notice_shown = value;
-            }
-            tcode_protocol::SettingsPatch::Orchestrate(value) => settings.orchestrate = value,
-            tcode_protocol::SettingsPatch::OrchestrateChildWorktrees(value) => {
-                settings.orchestrate.child_worktrees = value;
-            }
-            tcode_protocol::SettingsPatch::ComputerUse(value) => settings.computer_use = value,
-            tcode_protocol::SettingsPatch::Browser(value) => settings.browser = value,
-            tcode_protocol::SettingsPatch::TitleGeneration(value) => {
-                settings.title_generation = value;
-            }
-            tcode_protocol::SettingsPatch::SidebarLayout(value) => settings.sidebar_layout = value,
-        }
+        settings.apply(patch);
         self.update_settings(settings, cx);
     }
 

--- a/crates/runtime/src/app/tests.rs
+++ b/crates/runtime/src/app/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use super::{active_session::*, events::*, orchestrate::*, providers::*};
 
 use tcode_core::project::group_sessions;
-use tcode_core::settings::ThemeMode;
+use tcode_core::settings::{SettingsPatch, ThemeMode};
 use tcode_protocol::{Command, CommandResponse, HostMessage};
 
 #[test]
@@ -44,6 +44,48 @@ fn settings_patch_preserves_concurrently_changed_other_field() {
             event: ServerEvent::SettingsReplaced(replaced),
             ..
         }) if replaced.sidebar_collapsed && replaced.theme_mode == ThemeMode::Dark
+    )));
+}
+
+#[test]
+fn settings_patches_from_stale_snapshot_preserve_nested_sibling_fields() {
+    let cx = &mut TestAppContext::default();
+    let test_store = TestStore::new("tcode-dispatch-nested-settings-seam-test");
+    let state = cx.new_entity(|_| AppState::new((*test_store).clone()));
+    let stale = Settings::default().browser;
+    let mut home_url_writer = stale.clone();
+    home_url_writer.home_url = Some("https://example.com".into());
+    let mut allow_evaluate_writer = stale;
+    allow_evaluate_writer.allow_evaluate = false;
+    let home_url_patch = SettingsPatch::BrowserHomeUrl(home_url_writer.home_url);
+    let allow_evaluate_patch =
+        SettingsPatch::BrowserAllowEvaluate(allow_evaluate_writer.allow_evaluate);
+
+    state.dispatch_command(
+        cx,
+        42,
+        Command::PatchSettings {
+            patch: home_url_patch,
+        },
+    );
+    state.dispatch_command(
+        cx,
+        43,
+        Command::PatchSettings {
+            patch: allow_evaluate_patch,
+        },
+    );
+    cx.run_until_parked();
+
+    let outgoing = cx.drain_outgoing();
+    assert!(outgoing.iter().any(|message| matches!(
+        message,
+        HostMessage::Event(EventEnvelope {
+            topic: Topic::Settings,
+            event: ServerEvent::SettingsReplaced(replaced),
+            ..
+        }) if replaced.browser.home_url.as_deref() == Some("https://example.com")
+            && !replaced.browser.allow_evaluate
     )));
 }
 

--- a/crates/ui/src/orchestrate_settings.rs
+++ b/crates/ui/src/orchestrate_settings.rs
@@ -21,7 +21,7 @@ use agent::ProviderKind;
 use crate::provider_card::provider_glyph;
 use crate::provider_model_picker::{ModelOption, ProviderModelPicker};
 use crate::settings::{
-    ChildApprovalMode, OrchestrateChildModel, OrchestrateSettings, OrchestratorIdentity, Settings,
+    ChildApprovalMode, OrchestrateChildModel, OrchestrateSettings, OrchestratorIdentity,
     provider_label,
 };
 use crate::store::{TopicKind, WorkspaceStore, observe_store_topics};
@@ -118,17 +118,34 @@ impl OrchestrateSettingsPanel {
         panel
     }
 
-    fn update_settings(&self, mutate: impl FnOnce(&mut Settings), cx: &mut Context<Self>) {
+    fn update_model_identities(
+        &self,
+        mutate: impl FnOnce(&mut Vec<OrchestratorIdentity>),
+        cx: &mut Context<Self>,
+    ) {
+        let mut identities = self.store.read(cx).settings().orchestrate.model_identities;
+        mutate(&mut identities);
+        self.store.update(cx, |store, _cx| {
+            store.set_orchestrate_model_identities(identities)
+        });
+    }
+
+    fn update_child_models(
+        &self,
+        mutate: impl FnOnce(&mut Vec<OrchestrateChildModel>),
+        cx: &mut Context<Self>,
+    ) {
+        let mut models = self.store.read(cx).settings().orchestrate.child_models;
+        mutate(&mut models);
         self.store
-            .update(cx, |store, _cx| store.update_settings(mutate));
+            .update(cx, |store, _cx| store.set_orchestrate_child_models(models));
     }
 
     fn commit_generic_identity(&self, cx: &mut Context<Self>) {
         let identity = self.generic_identity.read(cx).value().to_string();
-        self.update_settings(
-            move |settings| settings.orchestrate.generic_identity = identity,
-            cx,
-        );
+        self.store.update(cx, |store, _cx| {
+            store.set_orchestrate_generic_identity(identity)
+        });
     }
 
     fn rebuild_rows(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -215,11 +232,9 @@ impl OrchestrateSettingsPanel {
         };
         let value = row.identity.read(cx).value().to_string();
         let model = model.to_string();
-        self.update_settings(
-            move |settings| {
-                if let Some(entry) = settings
-                    .orchestrate
-                    .model_identities
+        self.update_model_identities(
+            move |identities| {
+                if let Some(entry) = identities
                     .iter_mut()
                     .find(|entry| entry.provider == provider && entry.model == model)
                 {
@@ -237,9 +252,9 @@ impl OrchestrateSettingsPanel {
         let description = row.description.read(cx).value().to_string();
         let provider = row.provider;
         let model = row.model.clone();
-        self.update_settings(
-            move |settings| {
-                if let Some(entry) = settings.orchestrate.child_models.get_mut(index)
+        self.update_child_models(
+            move |models| {
+                if let Some(entry) = models.get_mut(index)
                     && entry.provider == provider
                     && entry.model == model
                 {
@@ -258,9 +273,9 @@ impl OrchestrateSettingsPanel {
         let effort = (!effort.is_empty()).then_some(effort);
         let provider = row.provider;
         let model = row.model.clone();
-        self.update_settings(
-            move |settings| {
-                if let Some(entry) = settings.orchestrate.child_models.get_mut(index)
+        self.update_child_models(
+            move |models| {
+                if let Some(entry) = models.get_mut(index)
                     && entry.provider == provider
                     && entry.model == model
                 {
@@ -281,22 +296,17 @@ impl OrchestrateSettingsPanel {
             .orchestrate
             .generic_identity
             .clone();
-        self.update_settings(
-            move |settings| {
-                if !settings
-                    .orchestrate
-                    .model_identities
+        self.update_model_identities(
+            move |identities| {
+                if !identities
                     .iter()
                     .any(|entry| entry.provider == provider && entry.model == model)
                 {
-                    settings
-                        .orchestrate
-                        .model_identities
-                        .push(OrchestratorIdentity {
-                            provider,
-                            model,
-                            identity,
-                        });
+                    identities.push(OrchestratorIdentity {
+                        provider,
+                        model,
+                        identity,
+                    });
                 }
             },
             cx,
@@ -313,12 +323,9 @@ impl OrchestrateSettingsPanel {
         cx: &mut Context<Self>,
     ) {
         let model = model.to_string();
-        self.update_settings(
-            move |settings| {
-                settings
-                    .orchestrate
-                    .model_identities
-                    .retain(|entry| !(entry.provider == provider && entry.model == model));
+        self.update_model_identities(
+            move |identities| {
+                identities.retain(|entry| !(entry.provider == provider && entry.model == model));
             },
             cx,
         );
@@ -341,15 +348,15 @@ impl OrchestrateSettingsPanel {
             .unwrap_or_default()
             .to_string(),
         };
-        self.update_settings(
-            move |settings| {
-                if !settings.orchestrate.child_models.iter().any(|entry| {
+        self.update_child_models(
+            move |models| {
+                if !models.iter().any(|entry| {
                     entry.provider == profile.provider
                         && entry.model == profile.model
                         && entry.effort == profile.effort
                         && entry.profile_id == profile.profile_id
                 }) {
-                    settings.orchestrate.child_models.push(profile);
+                    models.push(profile);
                 }
             },
             cx,
@@ -359,10 +366,10 @@ impl OrchestrateSettingsPanel {
     }
 
     fn remove_child(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
-        self.update_settings(
-            move |settings| {
-                if index < settings.orchestrate.child_models.len() {
-                    settings.orchestrate.child_models.remove(index);
+        self.update_child_models(
+            move |models| {
+                if index < models.len() {
+                    models.remove(index);
                 }
             },
             cx,
@@ -372,9 +379,9 @@ impl OrchestrateSettingsPanel {
     }
 
     fn set_child_enabled(&self, index: usize, enabled: bool, cx: &mut Context<Self>) {
-        self.update_settings(
-            move |settings| {
-                if let Some(entry) = settings.orchestrate.child_models.get_mut(index) {
+        self.update_child_models(
+            move |models| {
+                if let Some(entry) = models.get_mut(index) {
                     entry.enabled = enabled;
                 }
             },
@@ -385,10 +392,9 @@ impl OrchestrateSettingsPanel {
     fn reset_generic_identity(&self, window: &mut Window, cx: &mut Context<Self>) {
         let value = OrchestrateSettings::builtin_generic_identity().to_string();
         let persisted = value.clone();
-        self.update_settings(
-            move |settings| settings.orchestrate.generic_identity = persisted,
-            cx,
-        );
+        self.store.update(cx, |store, _cx| {
+            store.set_orchestrate_generic_identity(persisted)
+        });
         self.generic_identity
             .update(cx, |input, cx| input.set_value(value, window, cx));
     }
@@ -403,11 +409,9 @@ impl OrchestrateSettingsPanel {
         let value = OrchestrateSettings::builtin_identity_for(provider, model).to_string();
         let persisted = value.clone();
         let model_key = model.to_string();
-        self.update_settings(
-            move |settings| {
-                if let Some(entry) = settings
-                    .orchestrate
-                    .model_identities
+        self.update_model_identities(
+            move |identities| {
+                if let Some(entry) = identities
                     .iter_mut()
                     .find(|entry| entry.provider == provider && entry.model == model_key)
                 {
@@ -441,9 +445,9 @@ impl OrchestrateSettingsPanel {
         .unwrap_or_default()
         .to_string();
         let persisted = value.clone();
-        self.update_settings(
-            move |settings| {
-                if let Some(entry) = settings.orchestrate.child_models.get_mut(index)
+        self.update_child_models(
+            move |models| {
+                if let Some(entry) = models.get_mut(index)
                     && entry.provider == provider
                     && entry.model == model
                 {
@@ -588,10 +592,9 @@ impl OrchestrateSettingsPanel {
                         })
                         .on_click(move |_, window, cx| {
                             panel.update(cx, |panel, cx| {
-                                panel.update_settings(
-                                    |settings| settings.orchestrate.child_approval = mode,
-                                    cx,
-                                );
+                                panel.store.update(cx, |store, _cx| {
+                                    store.set_orchestrate_child_approval(mode)
+                                });
                             });
                             popover.update(cx, |state, cx| state.dismiss(window, cx));
                         })
@@ -698,12 +701,9 @@ impl OrchestrateSettingsPanel {
                             .checked(checked)
                             .on_click(cx.listener(|this, checked: &bool, _, cx| {
                                 let checked = *checked;
-                                this.update_settings(
-                                    move |settings| {
-                                        settings.orchestrate.archive_on_complete = checked
-                                    },
-                                    cx,
-                                );
+                                this.store.update(cx, |store, _cx| {
+                                    store.set_orchestrate_archive_on_complete(checked)
+                                });
                             })),
                     ),
             )
@@ -744,10 +744,9 @@ impl OrchestrateSettingsPanel {
                             .checked(checked)
                             .on_click(cx.listener(|this, checked: &bool, _, cx| {
                                 let checked = *checked;
-                                this.update_settings(
-                                    move |settings| settings.orchestrate.child_worktrees = checked,
-                                    cx,
-                                );
+                                this.store.update(cx, |store, _cx| {
+                                    store.set_orchestrate_child_worktrees(checked)
+                                });
                             })),
                     ),
             )

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -31,9 +31,7 @@ use crate::acp_panel::{AcpAgentCard, AcpPanel};
 use crate::orchestrate_settings::OrchestrateSettingsPanel;
 use crate::provider_card::ProviderCard;
 use crate::provider_model_picker::ProviderModelPicker;
-use crate::settings::{
-    ImageMode, LANGUAGE_ENGLISH, LANGUAGE_SIMPLIFIED_CHINESE, Settings, ThemeMode,
-};
+use crate::settings::{ImageMode, LANGUAGE_ENGLISH, LANGUAGE_SIMPLIFIED_CHINESE, ThemeMode};
 use crate::shell::Quit;
 use crate::store::WorkspaceStore;
 use crate::theme::{self, ActiveTheme as _, ThemeMode as UiThemeMode};
@@ -167,11 +165,11 @@ impl SettingsPage {
             }),
             cx.subscribe(&title_model_picker, |this, _, event, cx| {
                 let selected = event.0.clone();
-                this.update_settings(
-                    move |settings| {
-                        settings.title_generation.provider = selected.provider;
-                        settings.title_generation.model = selected.id;
-                        settings.title_generation.profile_id = selected.profile_id;
+                this.dispatch_settings(
+                    move |store| {
+                        store.set_title_generation_provider(selected.provider);
+                        store.set_title_generation_model(selected.id);
+                        store.set_title_generation_profile_id(selected.profile_id);
                     },
                     cx,
                 );
@@ -248,7 +246,7 @@ impl SettingsPage {
     fn commit_home_url(&self, cx: &mut Context<Self>) {
         let value = self.home_url_input.read(cx).value().trim().to_string();
         let home_url = (!value.is_empty()).then_some(value);
-        self.update_settings(move |settings| settings.browser.home_url = home_url, cx);
+        self.dispatch_settings(move |store| store.set_browser_home_url(home_url), cx);
     }
 
     fn commit_auto_archive_idle_days(&self, cx: &mut Context<Self>) {
@@ -262,8 +260,8 @@ impl SettingsPage {
         else {
             return;
         };
-        self.update_settings(
-            move |settings| settings.auto_archive_max_idle_days = days.max(1),
+        self.dispatch_settings(
+            move |store| store.set_auto_archive_max_idle_days(days.max(1)),
             cx,
         );
     }
@@ -279,8 +277,8 @@ impl SettingsPage {
         else {
             return;
         };
-        self.update_settings(
-            move |settings| settings.auto_archive_keep_count = keep.max(1),
+        self.dispatch_settings(
+            move |store| store.set_auto_archive_keep_count(keep.max(1)),
             cx,
         );
     }
@@ -339,9 +337,8 @@ impl SettingsPage {
         });
     }
 
-    fn update_settings(&self, mutate: impl FnOnce(&mut Settings), cx: &mut Context<Self>) {
-        self.store
-            .update(cx, |store, _cx| store.update_settings(mutate));
+    fn dispatch_settings(&self, intent: impl FnOnce(&mut WorkspaceStore), cx: &mut Context<Self>) {
+        self.store.update(cx, |store, _cx| intent(store));
     }
 
     // -- left nav -----------------------------------------------------------
@@ -677,7 +674,7 @@ impl SettingsPage {
                 crate::tr!("settings.delete_confirmation.description"),
                 !settings.skip_delete_confirmation,
                 cx,
-                |s, checked| s.skip_delete_confirmation = !checked,
+                |store, checked| store.set_skip_delete_confirmation(!checked),
             ),
             self.toggle_row(
                 "auto-open-task-panel",
@@ -685,7 +682,7 @@ impl SettingsPage {
                 crate::tr!("settings.auto_open_task_panel.description"),
                 settings.auto_open_task_panel,
                 cx,
-                |s, checked| s.auto_open_task_panel = checked,
+                WorkspaceStore::set_auto_open_task_panel,
             ),
         ];
         let workspace = vec![
@@ -695,7 +692,7 @@ impl SettingsPage {
                 crate::tr!("settings.word_wrap.description"),
                 settings.word_wrap_diffs,
                 cx,
-                |s, checked| s.word_wrap_diffs = checked,
+                WorkspaceStore::set_word_wrap_diffs,
             ),
             self.toggle_row(
                 "provider-update-checks",
@@ -704,7 +701,7 @@ impl SettingsPage {
                 // Stored inverted: checked = enabled.
                 !settings.provider_update_checks_disabled,
                 cx,
-                |s, checked| s.provider_update_checks_disabled = !checked,
+                |store, checked| store.set_provider_update_checks_disabled(!checked),
             ),
         ];
         v_flex()
@@ -897,7 +894,7 @@ impl SettingsPage {
                         ),
                         !settings.auto_archive_disabled,
                         cx,
-                        |settings, checked| settings.auto_archive_disabled = !checked,
+                        |store, checked| store.set_auto_archive_disabled(!checked),
                     ),
                     self.row_frame(cx)
                         .child(self.row_labels(
@@ -1062,7 +1059,7 @@ impl SettingsPage {
                 crate::tr!("computer_use.enable.description"),
                 settings.computer_use.enabled,
                 cx,
-                |s, checked| s.computer_use.enabled = checked,
+                WorkspaceStore::set_computer_use_enabled,
             ),
             self.image_mode_row(settings.computer_use.image_mode, cx),
             self.toggle_row(
@@ -1071,7 +1068,7 @@ impl SettingsPage {
                 crate::tr!("computer_use.allow_input.description"),
                 settings.computer_use.allow_input,
                 cx,
-                |s, checked| s.computer_use.allow_input = checked,
+                WorkspaceStore::set_computer_use_allow_input,
             ),
         ];
         v_flex()
@@ -1099,7 +1096,7 @@ impl SettingsPage {
                 crate::tr!("browser.enable.description"),
                 settings.browser.enabled,
                 cx,
-                |s, checked| s.browser.enabled = checked,
+                WorkspaceStore::set_browser_enabled,
             ),
             self.home_url_row(cx),
             self.toggle_row(
@@ -1108,7 +1105,7 @@ impl SettingsPage {
                 crate::tr!("browser.allow_evaluate.description"),
                 settings.browser.allow_evaluate,
                 cx,
-                |s, checked| s.browser.allow_evaluate = checked,
+                WorkspaceStore::set_browser_allow_evaluate,
             ),
         ];
         v_flex().gap(px(24.)).child(
@@ -1179,7 +1176,7 @@ impl SettingsPage {
             ],
             |mode, page, _, cx| {
                 page.update(cx, |page, cx| {
-                    page.update_settings(|settings| settings.computer_use.image_mode = mode, cx)
+                    page.dispatch_settings(|store| store.set_computer_use_image_mode(mode), cx)
                 })
             },
             cx,
@@ -1425,7 +1422,7 @@ impl SettingsPage {
         desc: impl Into<SharedString>,
         checked: bool,
         cx: &mut Context<Self>,
-        mutate: fn(&mut Settings, bool),
+        intent: fn(&mut WorkspaceStore, bool),
     ) -> AnyElement {
         let title = title.into();
         let desc = desc.into();
@@ -1453,12 +1450,12 @@ impl SettingsPage {
                 {
                     window.prevent_default();
                     cx.stop_propagation();
-                    this.update_settings(|settings| mutate(settings, !checked), cx);
+                    this.dispatch_settings(|store| intent(store, !checked), cx);
                 }
             }),
         )
         .on_click(cx.listener(move |this, _, _, cx| {
-            this.update_settings(|settings| mutate(settings, !checked), cx);
+            this.dispatch_settings(|store| intent(store, !checked), cx);
         }))
         .child(self.row_labels(title, desc, cx))
         // The Switch is intentionally visual here; the semantic row above
@@ -1611,7 +1608,7 @@ impl SettingsPage {
             ],
             |mode, page, window, cx| {
                 page.update(cx, |page, cx| {
-                    page.update_settings(|settings| settings.theme_mode = mode, cx)
+                    page.dispatch_settings(|store| store.set_theme_mode(mode), cx)
                 });
                 apply_theme(mode, window, cx);
             },
@@ -1653,8 +1650,8 @@ impl SettingsPage {
             ],
             |language, page, _, cx| {
                 page.update(cx, |page, cx| {
-                    page.update_settings(
-                        |settings| settings.language = language.map(str::to_owned),
+                    page.dispatch_settings(
+                        |store| store.set_language(language.map(str::to_owned)),
                         cx,
                     )
                 })

--- a/crates/ui/src/store/intents.rs
+++ b/crates/ui/src/store/intents.rs
@@ -6,7 +6,10 @@ use tcode_core::{
     acp::AcpAgentPatch,
     git::GitAction,
     session::ReviewComment,
-    settings::{ProfileSettingsPatch, Settings, SidebarLayout, ThemeMode},
+    settings::{
+        ChildApprovalMode, ImageMode, OrchestrateChildModel, OrchestratorIdentity,
+        ProfileSettingsPatch, SidebarLayout, ThemeMode,
+    },
     ui::{TerminalSplitDirection, WorkspaceMode},
 };
 use tcode_protocol::{Command, CommandResponse, ProtocolError, SettingsPatch};
@@ -38,72 +41,10 @@ impl WorkspaceStore {
     }
 }
 
-// Settings intents (15).
+// Settings intents (26).
 impl WorkspaceStore {
     fn patch_settings(&mut self, patch: SettingsPatch) {
         self.dispatch(Command::PatchSettings { patch });
-    }
-
-    /// Convert a view-level edit into only the changed field patches.
-    pub fn update_settings(&mut self, mutate: impl FnOnce(&mut Settings)) {
-        let before = self.settings_replica.clone();
-        let mut after = before.clone();
-        mutate(&mut after);
-        if before.language != after.language {
-            self.set_language(after.language);
-        }
-        if before.theme_mode != after.theme_mode {
-            self.set_theme_mode(after.theme_mode);
-        }
-        if before.word_wrap_diffs != after.word_wrap_diffs {
-            self.set_word_wrap_diffs(after.word_wrap_diffs);
-        }
-        if before.skip_delete_confirmation != after.skip_delete_confirmation {
-            self.set_skip_delete_confirmation(after.skip_delete_confirmation);
-        }
-        if before.auto_open_task_panel != after.auto_open_task_panel {
-            self.set_auto_open_task_panel(after.auto_open_task_panel);
-        }
-        if before.provider_update_checks_disabled != after.provider_update_checks_disabled {
-            self.set_provider_update_checks_disabled(after.provider_update_checks_disabled);
-        }
-        if before.auto_archive_disabled != after.auto_archive_disabled {
-            self.set_auto_archive_disabled(after.auto_archive_disabled);
-        }
-        if before.auto_archive_max_idle_days != after.auto_archive_max_idle_days {
-            self.set_auto_archive_max_idle_days(after.auto_archive_max_idle_days);
-        }
-        if before.auto_archive_keep_count != after.auto_archive_keep_count {
-            self.set_auto_archive_keep_count(after.auto_archive_keep_count);
-        }
-        if before.auto_archive_notice_shown != after.auto_archive_notice_shown {
-            self.set_auto_archive_notice_shown(after.auto_archive_notice_shown);
-        }
-        if before.orchestrate != after.orchestrate {
-            let mut before_without_child_worktrees = before.orchestrate.clone();
-            let mut after_without_child_worktrees = after.orchestrate.clone();
-            before_without_child_worktrees.child_worktrees = false;
-            after_without_child_worktrees.child_worktrees = false;
-            if before_without_child_worktrees == after_without_child_worktrees {
-                self.patch_settings(SettingsPatch::OrchestrateChildWorktrees(
-                    after.orchestrate.child_worktrees,
-                ));
-            } else {
-                self.patch_settings(SettingsPatch::Orchestrate(after.orchestrate));
-            }
-        }
-        if before.computer_use != after.computer_use {
-            self.patch_settings(SettingsPatch::ComputerUse(after.computer_use));
-        }
-        if before.browser != after.browser {
-            self.patch_settings(SettingsPatch::Browser(after.browser));
-        }
-        if before.title_generation != after.title_generation {
-            self.patch_settings(SettingsPatch::TitleGeneration(after.title_generation));
-        }
-        if before.sidebar_layout != after.sidebar_layout {
-            self.set_sidebar_layout(after.sidebar_layout);
-        }
     }
 
     pub fn set_language(&mut self, value: Option<String>) {
@@ -135,6 +76,51 @@ impl WorkspaceStore {
     }
     pub fn set_auto_archive_notice_shown(&mut self, value: bool) {
         self.patch_settings(SettingsPatch::AutoArchiveNoticeShown(value));
+    }
+    pub fn set_orchestrate_generic_identity(&mut self, value: String) {
+        self.patch_settings(SettingsPatch::OrchestrateGenericIdentity(value));
+    }
+    pub fn set_orchestrate_model_identities(&mut self, value: Vec<OrchestratorIdentity>) {
+        self.patch_settings(SettingsPatch::OrchestrateModelIdentities(value));
+    }
+    pub fn set_orchestrate_child_models(&mut self, value: Vec<OrchestrateChildModel>) {
+        self.patch_settings(SettingsPatch::OrchestrateChildModels(value));
+    }
+    pub fn set_orchestrate_child_approval(&mut self, value: ChildApprovalMode) {
+        self.patch_settings(SettingsPatch::OrchestrateChildApproval(value));
+    }
+    pub fn set_orchestrate_child_worktrees(&mut self, value: bool) {
+        self.patch_settings(SettingsPatch::OrchestrateChildWorktrees(value));
+    }
+    pub fn set_orchestrate_archive_on_complete(&mut self, value: bool) {
+        self.patch_settings(SettingsPatch::OrchestrateArchiveOnComplete(value));
+    }
+    pub fn set_computer_use_enabled(&mut self, value: bool) {
+        self.patch_settings(SettingsPatch::ComputerUseEnabled(value));
+    }
+    pub fn set_computer_use_image_mode(&mut self, value: ImageMode) {
+        self.patch_settings(SettingsPatch::ComputerUseImageMode(value));
+    }
+    pub fn set_computer_use_allow_input(&mut self, value: bool) {
+        self.patch_settings(SettingsPatch::ComputerUseAllowInput(value));
+    }
+    pub fn set_browser_enabled(&mut self, value: bool) {
+        self.patch_settings(SettingsPatch::BrowserEnabled(value));
+    }
+    pub fn set_browser_home_url(&mut self, value: Option<String>) {
+        self.patch_settings(SettingsPatch::BrowserHomeUrl(value));
+    }
+    pub fn set_browser_allow_evaluate(&mut self, value: bool) {
+        self.patch_settings(SettingsPatch::BrowserAllowEvaluate(value));
+    }
+    pub fn set_title_generation_provider(&mut self, value: ProviderKind) {
+        self.patch_settings(SettingsPatch::TitleGenerationProvider(value));
+    }
+    pub fn set_title_generation_model(&mut self, value: String) {
+        self.patch_settings(SettingsPatch::TitleGenerationModel(value));
+    }
+    pub fn set_title_generation_profile_id(&mut self, value: Option<String>) {
+        self.patch_settings(SettingsPatch::TitleGenerationProfileId(value));
     }
     pub fn set_sidebar_layout(&mut self, value: SidebarLayout) {
         self.patch_settings(SettingsPatch::SidebarLayout(value));


### PR DESCRIPTION
Architecture round, candidate C3.

**Problem** — `SettingsPatch` mixed field-scoped variants with whole-sub-struct replacements, and the pipeline was mirrored three times: a 16-variant enum, 16 runtime assignment arms, and a 62-line UI clone/diff (which hand-masked `child_worktrees` to dodge the atomicity mismatch). Whole-struct replacement leaked concurrency semantics: a patch built from a stale replica overwrote sibling fields.

**Change**
- All 26 variants are field-scoped (browser, orchestrate, computer-use, title-generation, and top-level fields enumerated individually).
- `Settings::apply(patch)` in core is the single home of apply semantics — the patch type moved to core and is re-exported as `tcode_protocol::SettingsPatch` (dependency direction is protocol → core; the alternative was a cycle). Runtime's match collapses to `settings.apply` + its existing persist/broadcast/side-effects.
- UI dispatches the field it owns directly; the clone/diff/mask machinery is deleted.
- On-disk `Settings` serde unchanged; the patch enum is process-internal wire (both ends ship in one binary), round-tripped for all 26 variants in protocol tests.

**Concurrency win proven** — new test: `BrowserHomeUrl` and `BrowserAllowEvaluate` patches built from the same stale snapshot, applied sequentially, both survive (previously the second replacement clobbered the first).

**Wins** — interface shrinks to one `apply`; two 16-arm mirrors deleted; the stale-replica overwrite class disappears.

Gates: fmt / clippy -D warnings / full workspace tests — green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)