### PR TITLE
fix(runtime): make the plan-save async assertion race-free

### DIFF
--- a/crates/runtime/src/app/tests.rs
+++ b/crates/runtime/src/app/tests.rs
@@ -5080,18 +5080,28 @@ fn plan_workspace_save_completes_after_background_executor_runs() {
     state.host_update(cx, |state, cx| {
         state.start_draft("plan-project".into(), cwd.clone(), cx);
         state.save_plan_to_workspace("# Saved plan".into(), cx);
+        // Race-free observation point: the blocking pool cannot have run yet
+        // inside this update, so a synchronous write would be visible here.
+        // Checking after host_update returns raced the real thread (flaked
+        // on fast Windows runners).
+        assert!(
+            !cwd.join("PLAN-1.md").exists(),
+            "the GPUI update must not perform the write synchronously"
+        );
     });
-    assert!(
-        !cwd.join("PLAN-1.md").exists(),
-        "the GPUI update must not perform the write synchronously"
-    );
 
-    cx.run_until_parked();
-
-    assert_eq!(
-        std::fs::read_to_string(cwd.join("PLAN-1.md")).unwrap(),
-        "# Saved plan"
-    );
+    // The write lands on a real blocking thread that run_until_parked does
+    // not wait for; poll with a bounded budget.
+    let mut contents = None;
+    for _ in 0..500 {
+        cx.run_until_parked();
+        if let Ok(text) = std::fs::read_to_string(cwd.join("PLAN-1.md")) {
+            contents = Some(text);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert_eq!(contents.as_deref(), Some("# Saved plan"));
     let _ = std::fs::remove_dir_all(&cwd);
 }
 


### PR DESCRIPTION
`plan_workspace_save_completes_after_background_executor_runs` failed twice on Windows CI (#259 first run, #265). The 'no synchronous write' assertion ran *after* `host_update` returned — racing the real blocking thread that performs the write; fast runners occasionally completed the write first. The assertion now lives inside the update closure (the blocking pool cannot have run there, so it is the race-free observation point), and the final read polls with a bounded budget because `run_until_parked` does not wait for real threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)