### PR TITLE
ci: Developer ID sign + notarize macOS release builds when configured

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,10 +156,12 @@ jobs:
           PLIST
           plutil -lint "$app/Contents/Info.plist"
 
-      # Signs and notarizes the app when the Developer ID secrets are configured
-      # (see docs/release-signing.md). Absent secrets → the step no-ops and the
-      # release ships unsigned, exactly as before, so tags never fail to publish.
-      - name: Sign and notarize macOS app
+      # Signs, notarizes, and packages the macOS build. When the Developer ID
+      # secrets are configured (see docs/release-signing.md) the app AND the DMG
+      # are each signed, notarized, and stapled — a DMG carries its own ticket,
+      # separate from the app inside it. Absent the secrets the step ships
+      # unsigned .zip/.dmg exactly as before, so tags never fail to publish.
+      - name: Sign, notarize, and package macOS
         id: macos_sign
         if: matrix.platform == 'macos'
         shell: bash
@@ -173,70 +175,105 @@ jobs:
         run: |
           set -euo pipefail
           app="dist/Tcode.app"
-          if [[ -z "${MACOS_CERTIFICATE:-}" || -z "${MACOS_SIGN_IDENTITY:-}" ]]; then
+          zip="dist/tcode-${VERSION}-macos-${{ matrix.arch }}.zip"
+          dmg="dist/tcode-${VERSION}-macos-${{ matrix.arch }}.dmg"
+
+          # All-or-nothing on the six secrets: none → unsigned build; a partial
+          # set is a misconfiguration we fail loudly on rather than 20 minutes
+          # later inside notarytool.
+          missing=()
+          for var in MACOS_CERTIFICATE MACOS_CERTIFICATE_PASSWORD MACOS_SIGN_IDENTITY \
+                     MACOS_NOTARY_APPLE_ID MACOS_NOTARY_TEAM_ID MACOS_NOTARY_PASSWORD; do
+            [[ -n "${!var:-}" ]] || missing+=("$var")
+          done
+          signed=false
+          if (( ${#missing[@]} == 0 )); then
+            signed=true
+          elif (( ${#missing[@]} < 6 )); then
+            echo "::error::macOS signing partially configured; missing: ${missing[*]}" >&2
+            exit 1
+          else
             echo "::notice::macOS signing secrets not configured — shipping an unsigned build."
-            echo "signed=false" >> "$GITHUB_OUTPUT"
-            exit 0
           fi
 
-          # Import the Developer ID Application cert into an ephemeral keychain.
-          keychain="$RUNNER_TEMP/tcode-signing.keychain-db"
-          keychain_password="$(openssl rand -base64 24)"
-          cert_path="$RUNNER_TEMP/developer_id.p12"
-          echo "$MACOS_CERTIFICATE" | base64 --decode > "$cert_path"
-          security create-keychain -p "$keychain_password" "$keychain"
-          security set-keychain-settings -lut 21600 "$keychain"
-          security unlock-keychain -p "$keychain_password" "$keychain"
-          security import "$cert_path" -P "$MACOS_CERTIFICATE_PASSWORD" \
-            -A -t cert -f pkcs12 -k "$keychain"
-          security set-key-partition-list -S apple-tool:,apple: \
-            -k "$keychain_password" "$keychain" >/dev/null
-          security list-keychain -d user -s "$keychain" login.keychain-db
-          rm -f "$cert_path"
+          notarize() { # notarize() <path>: submit, surface the log on rejection, wait
+            local out status id
+            out="$(xcrun notarytool submit "$1" \
+              --apple-id "$MACOS_NOTARY_APPLE_ID" --team-id "$MACOS_NOTARY_TEAM_ID" \
+              --password "$MACOS_NOTARY_PASSWORD" --wait --output-format json)"
+            status="$(printf '%s' "$out" | plutil -extract status raw -)"
+            id="$(printf '%s' "$out" | plutil -extract id raw -)"
+            if [[ "$status" != "Accepted" ]]; then
+              echo "::error::notarization $status for $1" >&2
+              xcrun notarytool log "$id" --apple-id "$MACOS_NOTARY_APPLE_ID" \
+                --team-id "$MACOS_NOTARY_TEAM_ID" --password "$MACOS_NOTARY_PASSWORD" >&2 || true
+              exit 1
+            fi
+          }
 
-          # Hardened runtime + entitlements, required for notarization.
-          codesign --force --timestamp --options runtime \
-            --entitlements assets/macos/tcode.entitlements \
-            --sign "$MACOS_SIGN_IDENTITY" "$app/Contents/MacOS/tcode"
-          codesign --force --timestamp --options runtime \
-            --entitlements assets/macos/tcode.entitlements \
-            --sign "$MACOS_SIGN_IDENTITY" "$app"
-          codesign --verify --deep --strict --verbose=2 "$app"
+          if [[ "$signed" == "true" ]]; then
+            # Ephemeral keychain; the trap guarantees teardown + temp cleanup on
+            # every exit path, so a mid-run failure can't leak the private key or
+            # leave the user search list rewritten (matters on self-hosted runners).
+            keychain="$RUNNER_TEMP/tcode-signing.keychain-db"
+            cert_path="$RUNNER_TEMP/developer_id.p12"
+            trap 'security delete-keychain "$keychain" 2>/dev/null || true; rm -f "$cert_path"' EXIT
+            keychain_password="$(openssl rand -base64 24)"
+            echo "$MACOS_CERTIFICATE" | base64 --decode > "$cert_path"
+            security create-keychain -p "$keychain_password" "$keychain"
+            security set-keychain-settings -lut 21600 "$keychain"
+            security unlock-keychain -p "$keychain_password" "$keychain"
+            security import "$cert_path" -P "$MACOS_CERTIFICATE_PASSWORD" \
+              -t cert -f pkcs12 -k "$keychain" -T /usr/bin/codesign -T /usr/bin/security
+            security set-key-partition-list -S apple-tool:,apple: \
+              -k "$keychain_password" "$keychain" >/dev/null
+            security list-keychain -d user -s "$keychain" login.keychain-db
+            rm -f "$cert_path"
 
-          # Notarize the app (submitted as a zip) and staple the ticket so
-          # Gatekeeper accepts it offline. The zip below is only for submission.
-          notarize_zip="$RUNNER_TEMP/tcode-notarize.zip"
-          ditto -c -k --sequesterRsrc --keepParent "$app" "$notarize_zip"
-          xcrun notarytool submit "$notarize_zip" \
-            --apple-id "$MACOS_NOTARY_APPLE_ID" \
-            --team-id "$MACOS_NOTARY_TEAM_ID" \
-            --password "$MACOS_NOTARY_PASSWORD" \
-            --wait
-          xcrun stapler staple "$app"
-          rm -f "$notarize_zip"
-          security delete-keychain "$keychain" || true
-          echo "signed=true" >> "$GITHUB_OUTPUT"
-          echo "::notice::macOS build signed and notarized."
+            # Sign the app with the hardened runtime + entitlements (required for
+            # notarization). One Mach-O, no nested code, so the bundle sign covers it.
+            codesign --force --timestamp --options runtime \
+              --entitlements assets/macos/tcode.entitlements \
+              --sign "$MACOS_SIGN_IDENTITY" "$app"
+            codesign --verify --strict --verbose=2 "$app"
 
-      - name: Package macOS zip and DMG
-        if: matrix.platform == 'macos'
-        shell: bash
-        run: |
-          set -euo pipefail
-          app="dist/Tcode.app"
+            # Notarize + staple the app, so the .zip (built next) carries its ticket.
+            notarize_zip="$RUNNER_TEMP/tcode-notarize.zip"
+            ditto -c -k --sequesterRsrc --keepParent "$app" "$notarize_zip"
+            notarize "$notarize_zip"
+            xcrun stapler staple "$app"
+            rm -f "$notarize_zip"
+
+            # Assert the result is actually Gatekeeper-acceptable — the only
+            # end-to-end check available for a workflow that can't be dry-run.
+            codesign -dv --verbose=4 "$app" 2>&1 | grep -q 'flags=.*runtime' \
+              || { echo "::error::hardened runtime flag missing on the app" >&2; exit 1; }
+            spctl -a -vvv -t exec "$app"
+          fi
+
+          # Distribution zip (from the stapled app when signed).
+          ditto -c -k --sequesterRsrc --keepParent "$app" "$zip"
+
+          # DMG from the same app.
           mkdir -p dmg-root
-          ditto -c -k --sequesterRsrc --keepParent "$app" \
-            "dist/tcode-${VERSION}-macos-${{ matrix.arch }}.zip"
-          cp -R "$app" dmg-root/
+          ditto "$app" "dmg-root/Tcode.app"
           ln -s /Applications dmg-root/Applications
           hdiutil create -volname Tcode -srcfolder "$PWD/dmg-root" -ov \
-            -fs HFS+ -format UDZO \
-            "$PWD/dist/tcode-${VERSION}-macos-${{ matrix.arch }}.dmg"
-          # Staple the notarization ticket to the DMG too, when signed.
-          if [[ "${{ steps.macos_sign.outputs.signed }}" == "true" ]]; then
-            xcrun stapler staple "dist/tcode-${VERSION}-macos-${{ matrix.arch }}.dmg" || true
+            -fs HFS+ -format UDZO "$PWD/$dmg"
+
+          if [[ "$signed" == "true" ]]; then
+            # The DMG is its own container: sign (no runtime/entitlements — it
+            # isn't executable code), notarize, and staple it too, or Gatekeeper
+            # rejects it at mount time before the stapled app inside is reached.
+            codesign --force --timestamp --sign "$MACOS_SIGN_IDENTITY" "$dmg"
+            notarize "$dmg"
+            xcrun stapler staple "$dmg"
+            spctl -a -vvv -t open --context context:primary-signature "$dmg"
+            echo "::notice::macOS build signed and notarized (app + DMG)."
           fi
-          rm -rf "dist/Tcode.app" dmg-root
+
+          echo "signed=$signed" >> "$GITHUB_OUTPUT"
+          rm -rf "$app" dmg-root
 
       - name: Package Windows zip
         if: matrix.platform == 'windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
           elapsed=$((SECONDS - start))
           echo "### ${{ matrix.label }} build: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Package macOS app, zip, and DMG
+      - name: Assemble macOS app bundle
         if: matrix.platform == 'macos'
         shell: bash
         run: |
@@ -130,8 +130,7 @@ jobs:
           app="dist/Tcode.app"
           mkdir -p \
             "$app/Contents/MacOS" \
-            "$app/Contents/Resources" \
-            dmg-root
+            "$app/Contents/Resources"
           cp "target/${{ matrix.target }}/release/tcode" "$app/Contents/MacOS/tcode"
           cp assets/icons/app/tcode.icns "$app/Contents/Resources/tcode.icns"
           chmod +x "$app/Contents/MacOS/tcode"
@@ -156,6 +155,76 @@ jobs:
           </dict></plist>
           PLIST
           plutil -lint "$app/Contents/Info.plist"
+
+      # Signs and notarizes the app when the Developer ID secrets are configured
+      # (see docs/release-signing.md). Absent secrets → the step no-ops and the
+      # release ships unsigned, exactly as before, so tags never fail to publish.
+      - name: Sign and notarize macOS app
+        id: macos_sign
+        if: matrix.platform == 'macos'
+        shell: bash
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+          MACOS_NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
+          MACOS_NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
+          MACOS_NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          app="dist/Tcode.app"
+          if [[ -z "${MACOS_CERTIFICATE:-}" || -z "${MACOS_SIGN_IDENTITY:-}" ]]; then
+            echo "::notice::macOS signing secrets not configured — shipping an unsigned build."
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Import the Developer ID Application cert into an ephemeral keychain.
+          keychain="$RUNNER_TEMP/tcode-signing.keychain-db"
+          keychain_password="$(openssl rand -base64 24)"
+          cert_path="$RUNNER_TEMP/developer_id.p12"
+          echo "$MACOS_CERTIFICATE" | base64 --decode > "$cert_path"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$cert_path" -P "$MACOS_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$keychain"
+          security set-key-partition-list -S apple-tool:,apple: \
+            -k "$keychain_password" "$keychain" >/dev/null
+          security list-keychain -d user -s "$keychain" login.keychain-db
+          rm -f "$cert_path"
+
+          # Hardened runtime + entitlements, required for notarization.
+          codesign --force --timestamp --options runtime \
+            --entitlements assets/macos/tcode.entitlements \
+            --sign "$MACOS_SIGN_IDENTITY" "$app/Contents/MacOS/tcode"
+          codesign --force --timestamp --options runtime \
+            --entitlements assets/macos/tcode.entitlements \
+            --sign "$MACOS_SIGN_IDENTITY" "$app"
+          codesign --verify --deep --strict --verbose=2 "$app"
+
+          # Notarize the app (submitted as a zip) and staple the ticket so
+          # Gatekeeper accepts it offline. The zip below is only for submission.
+          notarize_zip="$RUNNER_TEMP/tcode-notarize.zip"
+          ditto -c -k --sequesterRsrc --keepParent "$app" "$notarize_zip"
+          xcrun notarytool submit "$notarize_zip" \
+            --apple-id "$MACOS_NOTARY_APPLE_ID" \
+            --team-id "$MACOS_NOTARY_TEAM_ID" \
+            --password "$MACOS_NOTARY_PASSWORD" \
+            --wait
+          xcrun stapler staple "$app"
+          rm -f "$notarize_zip"
+          security delete-keychain "$keychain" || true
+          echo "signed=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::macOS build signed and notarized."
+
+      - name: Package macOS zip and DMG
+        if: matrix.platform == 'macos'
+        shell: bash
+        run: |
+          set -euo pipefail
+          app="dist/Tcode.app"
+          mkdir -p dmg-root
           ditto -c -k --sequesterRsrc --keepParent "$app" \
             "dist/tcode-${VERSION}-macos-${{ matrix.arch }}.zip"
           cp -R "$app" dmg-root/
@@ -163,6 +232,10 @@ jobs:
           hdiutil create -volname Tcode -srcfolder "$PWD/dmg-root" -ov \
             -fs HFS+ -format UDZO \
             "$PWD/dist/tcode-${VERSION}-macos-${{ matrix.arch }}.dmg"
+          # Staple the notarization ticket to the DMG too, when signed.
+          if [[ "${{ steps.macos_sign.outputs.signed }}" == "true" ]]; then
+            xcrun stapler staple "dist/tcode-${VERSION}-macos-${{ matrix.arch }}.dmg" || true
+          fi
           rm -rf "dist/Tcode.app" dmg-root
 
       - name: Package Windows zip
@@ -233,7 +306,7 @@ jobs:
           cat > "$notes_file" <<'NOTES'
           ## Platform notes
 
-          - **macOS 12+**: these test builds are not signed or notarized. After moving the app to Applications, clear Gatekeeper quarantine with:
+          - **macOS 12+**: release builds are Developer ID signed and notarized when the maintainer has configured signing credentials. If you downloaded an unsigned build, clear Gatekeeper quarantine after moving the app to Applications with:
 
             `xattr -dr com.apple.quarantine /Applications/Tcode.app`
 

--- a/assets/macos/tcode.entitlements
+++ b/assets/macos/tcode.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Hardened runtime is required for notarization. The app records audio for
+       voice input (NSMicrophoneUsageDescription) and transcribes on-device
+       (NSSpeechRecognitionUsageDescription), so it must declare those. -->
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+</dict>
+</plist>

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -24,7 +24,7 @@ New repository secret**:
 
 | Secret | What it is | How to get it |
 | --- | --- | --- |
-| `MACOS_CERTIFICATE` | base64 of your Developer ID `.p12` | Export the cert **with its private key** from Keychain Access as `cert.p12`, then `base64 -i cert.p12 \| pbcopy` |
+| `MACOS_CERTIFICATE` | base64 of your Developer ID `.p12` | In Keychain Access, **My Certificates** category (not *Certificates* — that omits the private key) → right-click the *Developer ID Application* row → Export → Personal Information Exchange (`.p12`), then `base64 -i cert.p12 \| pbcopy` |
 | `MACOS_CERTIFICATE_PASSWORD` | the password you set on that `.p12` export | you chose it during export |
 | `MACOS_SIGN_IDENTITY` | the exact identity string | `security find-identity -v -p codesigning` → e.g. `Developer ID Application: Your Name (ABCDE12345)` |
 | `MACOS_NOTARY_APPLE_ID` | the Apple ID email for notarization | your developer-account email |
@@ -35,11 +35,15 @@ New repository secret**:
 
 Cut a prerelease tag (e.g. `v0.0.0-signtest`) and watch the **Sign and
 notarize macOS app** step: it should print `macOS build signed and notarized`.
-Download the `.dmg`, then locally:
+Download the `.dmg` and the `.zip`, then locally:
 
 ```sh
-spctl -a -vvv -t install /Applications/Tcode.app   # → "accepted, source=Notarized Developer ID"
-xcrun stapler validate /Applications/Tcode.app      # → "The validate action worked!"
+# The DMG container (must pass before you even mount it)
+spctl -a -vvv -t open --context context:primary-signature ~/Downloads/tcode-*.dmg
+xcrun stapler validate ~/Downloads/tcode-*.dmg
+# The app itself (unzip or drag from the DMG to /Applications first)
+spctl -a -vvv -t exec /Applications/Tcode.app     # → "accepted  source=Notarized Developer ID"
+xcrun stapler validate /Applications/Tcode.app    # → "The validate action worked!"
 ```
 
 ## Not covered

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -1,0 +1,50 @@
+# macOS release signing & notarization
+
+The release workflow (`.github/workflows/release.yml`) signs and notarizes the
+macOS app **only when the six secrets below are present**. Until you add them,
+tagged releases keep publishing unsigned builds — nothing breaks, the signing
+step just no-ops. Once the secrets exist, every `v*` tag ships a Developer ID
+signed, notarized, and stapled `Tcode.app` (in both the `.zip` and `.dmg`), so
+users no longer need `xattr -dr com.apple.quarantine`.
+
+Everything here needs your Apple Developer account; it cannot be automated.
+
+## What you need first
+
+- An **Apple Developer Program** membership ($99/yr).
+- A **Developer ID Application** certificate (Xcode → Settings → Accounts →
+  Manage Certificates → `+` → *Developer ID Application*, or create it at
+  <https://developer.apple.com/account/resources/certificates>).
+- Your 10-character **Team ID** (Apple Developer → Membership).
+
+## Secrets to add
+
+Add these under **GitHub → repo → Settings → Secrets and variables → Actions →
+New repository secret**:
+
+| Secret | What it is | How to get it |
+| --- | --- | --- |
+| `MACOS_CERTIFICATE` | base64 of your Developer ID `.p12` | Export the cert **with its private key** from Keychain Access as `cert.p12`, then `base64 -i cert.p12 \| pbcopy` |
+| `MACOS_CERTIFICATE_PASSWORD` | the password you set on that `.p12` export | you chose it during export |
+| `MACOS_SIGN_IDENTITY` | the exact identity string | `security find-identity -v -p codesigning` → e.g. `Developer ID Application: Your Name (ABCDE12345)` |
+| `MACOS_NOTARY_APPLE_ID` | the Apple ID email for notarization | your developer-account email |
+| `MACOS_NOTARY_TEAM_ID` | your 10-char Team ID | Apple Developer → Membership |
+| `MACOS_NOTARY_PASSWORD` | an **app-specific password** (not your Apple ID password) | <https://account.apple.com> → Sign-In and Security → App-Specific Passwords → generate one labeled e.g. `tcode-notary` |
+
+## Verify after adding
+
+Cut a prerelease tag (e.g. `v0.0.0-signtest`) and watch the **Sign and
+notarize macOS app** step: it should print `macOS build signed and notarized`.
+Download the `.dmg`, then locally:
+
+```sh
+spctl -a -vvv -t install /Applications/Tcode.app   # → "accepted, source=Notarized Developer ID"
+xcrun stapler validate /Applications/Tcode.app      # → "The validate action worked!"
+```
+
+## Not covered
+
+- **Windows code signing** (an OV/EV certificate would remove SmartScreen
+  friction) — the workflow ships unsigned Windows zips today.
+- **A self-updating installer** (Sparkle appcast, etc.) — deliberately deferred
+  until signed builds exist; the in-app update-available check is already live.


### PR DESCRIPTION
Completes the automatable half of #120 (the update-available check shipped in #255).

The release workflow now, **only when the `MACOS_*` secrets are configured**, signs the app with a hardened runtime + entitlements and notarizes+staples it — so signed releases no longer need `xattr -dr com.apple.quarantine`, and both the `.zip` and `.dmg` carry the stapled app.

**Safe by default**: with no secrets set, the `Sign and notarize macOS app` step prints a notice and no-ops (`signed=false`); the zip/DMG packaging skips stapling; unsigned builds publish exactly as before. Tags never fail to publish for lack of credentials.

- New `assets/macos/tcode.entitlements` (`com.apple.security.device.audio-input` for the hardened runtime, since the app records audio for voice input).
- The macOS packaging step is split into *assemble bundle* → *sign & notarize* → *zip & DMG* so signing lands on the app before artifacts are built from it.
- `docs/release-signing.md`: exact six secrets, how to obtain each (Developer ID `.p12` → base64, app-specific password, Team ID, identity string), and post-tag verification (`spctl`/`stapler validate`).
- Release notes reworded to be accurate signed-or-not.

**Left in #120** (needs credentials I can't provide): the actual secret entry is yours; Windows code signing and a self-updating installer stay deferred.

Because `release.yml` only runs on `v*` tags, this can't be exercised by CI — YAML validated, signing logic reviewed. Verify by cutting a `v0.0.0-signtest` prerelease after adding the secrets (steps in the doc).

Part of #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)