### PR TITLE
fix(orchestrate): make child report_result reliable and substantive

### DIFF
--- a/crates/orchestrate-mcp/src/tools.rs
+++ b/crates/orchestrate-mcp/src/tools.rs
@@ -232,7 +232,7 @@ impl ChildReportTools {
     }
 
     #[tool(
-        description = "Deliver the full text of your final report (RESULT) to the orchestrator that dispatched this thread. Call it once when your work is complete, before ending your turn; calling again replaces the previous report (last call wins). The text reaches the orchestrator verbatim and in full when this turn ends. If you never call this, only your final assistant message is sent back — truncated when long."
+        description = "Deliver the full text of your final report (RESULT) to the orchestrator that dispatched this thread. The orchestrator receives ONLY this text — it cannot see your transcript — so make it self-contained and complete: what you did, files changed, every command you ran with its outcome, and your findings or conclusions in full. One or two summary sentences is not an acceptable report. Call it once when your work is complete, before ending your turn; calling again replaces the previous report (last call wins). If you never call this, only your final assistant message is sent back — truncated when long."
     )]
     async fn report_result(
         &self,

--- a/crates/orchestrate-mcp/src/tools.rs
+++ b/crates/orchestrate-mcp/src/tools.rs
@@ -232,7 +232,7 @@ impl ChildReportTools {
     }
 
     #[tool(
-        description = "Deliver the full text of your final report (RESULT) to the orchestrator that dispatched this thread. The orchestrator receives ONLY this text — it cannot see your transcript — so make it self-contained and complete: what you did, files changed, every command you ran with its outcome, and your findings or conclusions in full. One or two summary sentences is not an acceptable report. Call it once when your work is complete, before ending your turn; calling again replaces the previous report (last call wins). If you never call this, only your final assistant message is sent back — truncated when long."
+        description = "Send your complete final report (RESULT) to the orchestrator that dispatched this thread. This is the orchestrator's only view of your work — it cannot see your transcript — so make the report self-contained: what you did, files changed, every command you ran with its outcome, and your findings or conclusions in full. Call it once when your work is complete, before ending your turn; calling again replaces the previous report (last call wins). Only if this call fails, write the same complete report as your final message instead — it is sent back as the fallback, truncated when long."
     )]
     async fn report_result(
         &self,

--- a/crates/runtime/src/app/orchestrate.rs
+++ b/crates/runtime/src/app/orchestrate.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+/// Appended to every dispatched brief so the report contract reaches the child
+/// regardless of what the orchestrator wrote.
+pub(super) const CHILD_REPORT_FOOTER: &str = "\n\n---\nWhen your work is complete, call the tcode_report report_result tool with your full final report, then end your turn. The orchestrator that dispatched you receives ONLY that text — it cannot see your transcript — so make the report self-contained: what you did, files changed, every command you ran with its outcome, and your findings or conclusions in full. One or two summary sentences is not an acceptable report.";
+
 #[derive(Default)]
 pub(super) struct McpWiring {
     pub(super) preview_url: Option<String>,
@@ -261,6 +265,15 @@ impl AppState {
         brief: String,
         cx: &mut HostCx,
     ) -> Result<String, String> {
+        // The report contract rides with every brief: the child sees nothing
+        // of the orchestration, and the tool description alone yields missing
+        // or one-line reports. Skipped for providers without MCP attachment
+        // (pi), where the tool does not exist.
+        let brief = if meta.provider.caps().mcp_servers {
+            format!("{brief}{CHILD_REPORT_FOOTER}")
+        } else {
+            brief
+        };
         self.enqueue_store_write(
             StoreWrite::UpsertMeta {
                 meta: Box::new(meta.clone()),
@@ -936,6 +949,22 @@ impl AppState {
         else {
             return;
         };
+        // tcode's own reporting channel is never a permission question, in any
+        // access mode: providers that gate MCP tools (Claude Code prompts for
+        // them outside bypassPermissions) would otherwise stall or fail every
+        // report_result call from a read_only or workspace_write child.
+        if let agent::ApprovalKind::ToolUse { name, .. } = &request.kind
+            && name.contains(agent::McpRegistration::SERVER_NAME_ORCHESTRATE_REPORT)
+        {
+            if let Err(err) = self.respond_session_approval(
+                child_id,
+                request.id.clone(),
+                ApprovalDecision::ApproveForSession,
+            ) {
+                log::warn!("failed to auto-approve report_result for child {child_id}: {err}");
+            }
+            return;
+        }
         if self.settings.orchestrate.child_approval == ChildApprovalMode::AlwaysAllow {
             if let Err(err) = self.respond_session_approval(
                 child_id,
@@ -1417,13 +1446,10 @@ pub(super) fn assemble_callback_text(
     } else {
         format!(" tokens: {}.", token_parts.join(", "))
     };
-    let body = if let Some(report) = reported.filter(|report| !report.trim().is_empty()) {
-        // The child chose this text deliberately via report_result, so it is
-        // delivered verbatim and never truncated.
-        format!("Result (reported via report_result):\n{report}")
-    } else if final_message.is_empty() {
-        "(no assistant output)".to_string()
-    } else {
+    let digest = || {
+        if final_message.is_empty() {
+            return "(no assistant output)".to_string();
+        }
         let count = final_message.chars().count();
         let cap = max_chars.unwrap_or(1200) as usize;
         if cap == 0 || count <= cap {
@@ -1434,6 +1460,21 @@ pub(super) fn assemble_callback_text(
                 tail_chars(final_message, 600.min(cap))
             )
         }
+    };
+    let body = if let Some(report) = reported.filter(|report| !report.trim().is_empty()) {
+        // The child chose this text deliberately via report_result, so it is
+        // delivered verbatim and never truncated.
+        let mut body = format!("Result (reported via report_result):\n{report}");
+        // ponytail: fixed 200-char floor; a one-line "done" report would
+        // otherwise hide a substantive final message and force the
+        // orchestrator back to status/result.
+        if report.chars().count() < 200 && final_message.chars().count() > report.chars().count() {
+            body.push_str("\n\nThe report is brief; the final assistant message follows:\n");
+            body.push_str(&digest());
+        }
+        body
+    } else {
+        digest()
     };
     format!("[orchestrate] thread {child_id} (\"{title}\") {state}.{token_segment}\n{body}")
 }

--- a/crates/runtime/src/app/orchestrate.rs
+++ b/crates/runtime/src/app/orchestrate.rs
@@ -2,7 +2,7 @@ use super::*;
 
 /// Appended to every dispatched brief so the report contract reaches the child
 /// regardless of what the orchestrator wrote.
-pub(super) const CHILD_REPORT_FOOTER: &str = "\n\n---\nWhen your work is complete, call the tcode_report report_result tool with your full final report, then end your turn. The orchestrator that dispatched you receives ONLY that text — it cannot see your transcript — so make the report self-contained: what you did, files changed, every command you ran with its outcome, and your findings or conclusions in full. One or two summary sentences is not an acceptable report.";
+pub(super) const CHILD_REPORT_FOOTER: &str = "\n\n---\nThe tcode_report report_result tool is the only channel through which your work reaches the orchestrator that dispatched you; it cannot see your transcript. When your work is complete, send your complete final report through it, then end your turn. Make the report self-contained: what you did, files changed, every command you ran with its outcome, and your findings or conclusions in full. Only if the tool call fails, write that same complete report as your final message instead — it is sent back as the fallback, truncated when long.";
 
 #[derive(Default)]
 pub(super) struct McpWiring {

--- a/crates/runtime/src/app/tests.rs
+++ b/crates/runtime/src/app/tests.rs
@@ -2002,6 +2002,71 @@ fn callback_prefers_reported_result_in_full() {
 }
 
 #[test]
+fn short_report_appends_final_message_digest() {
+    let final_message = "f".repeat(3000);
+    let text = assemble_callback_text(
+        "child",
+        "Title",
+        TurnStatus::Completed,
+        &final_message,
+        Some("done."),
+        None,
+        None,
+        false,
+    );
+    assert!(text.contains("Result (reported via report_result):\ndone."));
+    assert!(text.contains("The report is brief; the final assistant message follows:"));
+    assert!(text.contains("Final output tail (3000 chars total"));
+
+    // A substantive report stands alone.
+    let report = "R".repeat(400);
+    let alone = assemble_callback_text(
+        "child",
+        "Title",
+        TurnStatus::Completed,
+        &final_message,
+        Some(&report),
+        None,
+        None,
+        false,
+    );
+    assert!(alone.ends_with(&report));
+    assert!(!alone.contains("The report is brief"));
+}
+
+#[test]
+fn dispatched_brief_carries_report_contract_footer() {
+    let cx = &mut TestAppContext::default();
+    let test_store = TestStore::new("tcode-orchestrate-brief-footer-test");
+    let store = (*test_store).clone();
+    let state = cx.new_entity(|_| AppState::new(store));
+    state.host_update(cx, |state, cx| {
+        let parent = SessionMeta::new(ProviderKind::Codex, PathBuf::from("/tmp/project"), None);
+        let parent_id = parent.id.clone();
+        state.sessions.push(parent);
+        let child_id = state
+            .create_child_session(
+                &parent_id,
+                ProviderKind::Codex,
+                Some("gpt-test".into()),
+                None,
+                None,
+                ApprovalMode::FullAccess,
+                "Child".into(),
+                None,
+                "Inspect the workspace".into(),
+                true,
+                None,
+                cx,
+            )
+            .unwrap();
+        let queued = state.resident(&child_id).unwrap().queue[0].text.clone();
+        assert!(queued.starts_with("Inspect the workspace"));
+        assert!(queued.contains("report_result"), "brief: {queued}");
+    });
+}
+
+#[test]
 fn terminal_callback_archives_only_when_requested() {
     let cx = &mut TestAppContext::default();
     let test_store = TestStore::new("tcode-orchestrate-callback-archive-test");
@@ -2361,6 +2426,60 @@ fn child_approval_always_allow_responds_without_parent_callback() {
         assert!(
             parent_receiver.try_recv().is_err(),
             "always-allow must not notify the parent"
+        );
+    });
+}
+
+#[test]
+fn child_report_result_approval_is_auto_approved_in_every_mode() {
+    let cx = &mut TestAppContext::default();
+    let test_store = TestStore::new("tcode-orchestrate-approval-report-test");
+    let store = (*test_store).clone();
+    let state = cx.new_entity(|_| AppState::new(store));
+    let (parent_commands, parent_receiver) = smol::channel::unbounded();
+    let (child_commands, child_receiver) = smol::channel::unbounded();
+
+    state.host_update(cx, |state, cx| {
+        // Default routing (Orchestrator) — the report tool must never reach it.
+        let mut parent = live_session(ProviderKind::Codex, parent_commands);
+        parent.meta.id = "parent".into();
+        parent.turn_in_flight = true;
+        state
+            .residents
+            .parked
+            .insert(parent.meta.id.clone(), parent);
+
+        let mut child = live_session(ProviderKind::ClaudeCode, child_commands);
+        child.meta.id = "child".into();
+        child.meta.parent_session_id = Some("parent".into());
+        state.sessions.push(child.meta.clone());
+        state.residents.parked.insert(child.meta.id.clone(), child);
+
+        state.on_event(
+            "child",
+            AgentEvent::ApprovalRequested(agent::ApprovalRequest {
+                id: "approval-report".into(),
+                turn_id: None,
+                kind: agent::ApprovalKind::ToolUse {
+                    name: "mcp__tcode_report__report_result".into(),
+                    input: serde_json::json!({ "text": "full report" }),
+                    detail: "mcp__tcode_report__report_result".into(),
+                },
+                options: Vec::new(),
+            }),
+            cx,
+        );
+
+        assert!(matches!(
+            child_receiver.try_recv(),
+            Ok(SessionCommand::RespondApproval {
+                request_id,
+                decision: ApprovalDecision::ApproveForSession,
+            }) if request_id == "approval-report"
+        ));
+        assert!(
+            parent_receiver.try_recv().is_err(),
+            "the report tool must not surface an approval to the orchestrator"
         );
     });
 }


### PR DESCRIPTION
Follow-up to #232, which added the child-side `report_result` tool. In practice children often failed to call it, or called it with a vague sentence or two, forcing the orchestrator back to `status`/`result`.

## Root causes

1. **Hard failure path (confirmed):** Claude-provider children in any non-`full` access mode classify `mcp__tcode_report__report_result` as a generic ToolUse and prompt for permission. The prompt routes to the orchestrator (or stalls in Manual mode) — so exactly the common `read_only` review children got blocked on every report.
2. **Vague reports:** the child's only knowledge of the reporting contract was a one-line tool description; the brief was passed through verbatim and the runtime injected nothing.

## Changes

- **Auto-approve the report tool at the child-approval choke point** (`deliver_child_approval_callback`): a `tcode_report` ToolUse request is approved for session in every mode, before any routing. One guard covers all providers that surface approvals to tcode.
- **Ride the report contract on every dispatched brief** (`install_child_session`, the shared entry for both dispatch paths): a fixed footer states that the orchestrator sees ONLY the reported text, and what a self-contained report must include. Skipped for providers without MCP attachment (pi).
- **Strengthen the tool description** with the same contract.
- **Short-report fallback in the callback**: when a report is under 200 chars and shorter than the final assistant message, the callback appends the ordinary final-message digest so the orchestrator never needs a follow-up `status`.

## Tests

- `child_report_result_approval_is_auto_approved_in_every_mode`
- `dispatched_brief_carries_report_contract_footer`
- `short_report_appends_final_message_digest` (plus: substantive reports still stand alone)

Full workspace `cargo test`, `cargo clippy --all-targets`, and `cargo fmt --check` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)