### PR TITLE
feat(settings): toggle to disable the unfocused ~2 FPS frame throttle

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -346,7 +346,9 @@ fn main() {
                 // Throttle background redraws (spinners, streaming output) to
                 // ~2 FPS while the window is inactive; gpui lifts the cap the
                 // moment the window is active or receiving high-rate input.
-                inactive_frame_interval: Some(Duration::from_millis(500)),
+                // This setting is captured at window creation and requires a restart.
+                inactive_frame_interval: (!initial_settings.inactive_frame_throttle_disabled)
+                    .then(|| Duration::from_millis(500)),
                 ..Default::default()
             };
 

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -583,6 +583,7 @@ pub enum SettingsPatch {
     SkipDeleteConfirmation(bool),
     AutoOpenTaskPanel(bool),
     ProviderUpdateChecksDisabled(bool),
+    InactiveFrameThrottleDisabled(bool),
     AutoArchiveDisabled(bool),
     AutoArchiveMaxIdleDays(u32),
     AutoArchiveKeepCount(usize),
@@ -669,6 +670,10 @@ pub struct Settings {
     /// on) even for legacy settings files that lack the field.
     #[serde(default)]
     pub provider_update_checks_disabled: bool,
+    /// Whether inactive-window frame throttling is DISABLED. Stored inverted so
+    /// the throttle defaults to on even for legacy settings files that lack the field.
+    #[serde(default)]
+    pub inactive_frame_throttle_disabled: bool,
     /// Whether automatic archiving is DISABLED. Stored inverted so the feature
     /// defaults to on even for legacy settings files that lack the field.
     #[serde(default)]
@@ -751,6 +756,7 @@ impl Default for Settings {
             skip_delete_confirmation: false,
             auto_open_task_panel: false,
             provider_update_checks_disabled: false,
+            inactive_frame_throttle_disabled: false,
             auto_archive_disabled: false,
             auto_archive_max_idle_days: default_auto_archive_max_idle_days(),
             auto_archive_keep_count: default_auto_archive_keep_count(),
@@ -783,6 +789,9 @@ impl Settings {
             SettingsPatch::AutoOpenTaskPanel(value) => self.auto_open_task_panel = value,
             SettingsPatch::ProviderUpdateChecksDisabled(value) => {
                 self.provider_update_checks_disabled = value;
+            }
+            SettingsPatch::InactiveFrameThrottleDisabled(value) => {
+                self.inactive_frame_throttle_disabled = value;
             }
             SettingsPatch::AutoArchiveDisabled(value) => self.auto_archive_disabled = value,
             SettingsPatch::AutoArchiveMaxIdleDays(value) => {

--- a/crates/protocol/src/tests.rs
+++ b/crates/protocol/src/tests.rs
@@ -238,6 +238,7 @@ fn settings_patches_round_trip() {
         SettingsPatch::SkipDeleteConfirmation(true),
         SettingsPatch::AutoOpenTaskPanel(true),
         SettingsPatch::ProviderUpdateChecksDisabled(true),
+        SettingsPatch::InactiveFrameThrottleDisabled(true),
         SettingsPatch::AutoArchiveDisabled(true),
         SettingsPatch::AutoArchiveMaxIdleDays(14),
         SettingsPatch::AutoArchiveKeepCount(42),

--- a/crates/services/src/settings.rs
+++ b/crates/services/src/settings.rs
@@ -182,6 +182,7 @@ mod tests {
             skip_delete_confirmation: true,
             auto_open_task_panel: true,
             provider_update_checks_disabled: true,
+            inactive_frame_throttle_disabled: true,
             auto_archive_disabled: false,
             auto_archive_max_idle_days: 7,
             auto_archive_keep_count: 30,

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -703,6 +703,15 @@ impl SettingsPage {
                 cx,
                 |store, checked| store.set_provider_update_checks_disabled(!checked),
             ),
+            self.toggle_row(
+                "inactive-frame-throttle",
+                crate::tr!("settings.inactive_frame_throttle.title"),
+                crate::tr!("settings.inactive_frame_throttle.description"),
+                // Stored inverted: checked = enabled.
+                !settings.inactive_frame_throttle_disabled,
+                cx,
+                |store, checked| store.set_inactive_frame_throttle_disabled(!checked),
+            ),
         ];
         v_flex()
             .gap(px(24.))

--- a/crates/ui/src/store/intents.rs
+++ b/crates/ui/src/store/intents.rs
@@ -41,7 +41,7 @@ impl WorkspaceStore {
     }
 }
 
-// Settings intents (26).
+// Settings intents (27).
 impl WorkspaceStore {
     fn patch_settings(&mut self, patch: SettingsPatch) {
         self.dispatch(Command::PatchSettings { patch });
@@ -64,6 +64,9 @@ impl WorkspaceStore {
     }
     pub fn set_provider_update_checks_disabled(&mut self, value: bool) {
         self.patch_settings(SettingsPatch::ProviderUpdateChecksDisabled(value));
+    }
+    pub fn set_inactive_frame_throttle_disabled(&mut self, value: bool) {
+        self.patch_settings(SettingsPatch::InactiveFrameThrottleDisabled(value));
     }
     pub fn set_auto_archive_disabled(&mut self, value: bool) {
         self.patch_settings(SettingsPatch::AutoArchiveDisabled(value));

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -225,6 +225,9 @@ settings:
   provider_updates:
     title: "Provider update checks"
     description: "Check for newer tcode and provider CLI versions on launch."
+  inactive_frame_throttle:
+    title: "Background frame throttle"
+    description: "Drop to ~2 FPS while the window is unfocused to save energy. Takes effect after restart."
   title_generation:
     title: "Thread title model"
     description: "Choose the provider and model used to name new threads. Title requests always use low reasoning effort."

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -225,6 +225,9 @@ settings:
   provider_updates:
     title: "提供方更新检查"
     description: "启动时检查 tcode 和提供方 CLI 的新版本。"
+  inactive_frame_throttle:
+    title: "后台帧率限制"
+    description: "窗口失焦时将刷新率降至约 2 FPS 以节省能耗。重启后生效。"
   title_generation:
     title: "对话命名模型"
     description: "选择负责为新对话命名的提供方和模型。命名请求始终使用 low 推理强度。"


### PR DESCRIPTION
## Summary
- New **Background frame throttle** toggle in Settings → General (workspace group), **on by default**: drops redraws to ~2 FPS while the window is unfocused to save energy.
- Stored inverted as `inactive_frame_throttle_disabled` (`#[serde(default)]`, default `false`), mirroring `provider_update_checks_disabled`, so legacy settings files keep today's behavior.
- `main.rs` passes `None` for `inactive_frame_interval` when disabled. gpui captures this at window creation with no runtime setter, so the toggle takes effect after restart — the setting description states this (en + zh-CN).

## Testing
- `cargo check --workspace` ✓
- `cargo test -p tcode-core -p tcode-protocol -p tcode-services` ✓ (patch round-trip and settings-literal tests extended)
- `cargo fmt --all -- --check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)