### PR TITLE
fix(agent): exempt tcode MCP servers from codex tool-call approval

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -485,10 +485,16 @@ impl McpRegistration {
     /// server. Codex rejects a literal `bearer_token` for HTTP, so the token
     /// rides in `http_headers.Authorization` instead (verified against
     /// codex `config/src/mcp_types.rs`). Returns the full `key=value` argument.
+    ///
+    /// `default_tools_approval_mode = "approve"` exempts tcode's own servers
+    /// from codex's MCP tool-call approval (added in codex 0.149): these
+    /// servers are trusted by construction, and the prompt otherwise surfaces
+    /// as an `mcpServer/elicitation/request` whose form schema tcode cannot
+    /// render, so it auto-declines and the tool call fails.
     pub fn codex_config_override(&self) -> String {
         // TOML basic strings; our url/token are ASCII with no quotes/backslashes.
         format!(
-            "mcp_servers.{name}={{url=\"{url}\",http_headers={{Authorization=\"Bearer {token}\"}}}}",
+            "mcp_servers.{name}={{url=\"{url}\",http_headers={{Authorization=\"Bearer {token}\"}},default_tools_approval_mode=\"approve\"}}",
             name = self.name,
             url = self.url,
             token = self.bearer_token,
@@ -1575,6 +1581,11 @@ mod mcp_registration_tests {
             Some("Bearer abc123")
         );
         assert!(table.get("bearer_token").is_none());
+        // tcode's own servers are exempt from codex's MCP tool-call approval.
+        assert_eq!(
+            table["default_tools_approval_mode"].as_str(),
+            Some("approve")
+        );
     }
 }
 


### PR DESCRIPTION
Follow-up to #270. The screenshot failure `codex: MCP server tcode_report sent an elicitation with no supported fields; declined` traced to codex 0.149's new MCP tool-call approval: with the `ToolCallMcpElicitation` feature, codex surfaces the approval as an `mcpServer/elicitation/request` attributed to the server, with a form schema tcode's elicitation parser has no supported fields for — so tcode auto-declines and the tool call fails. That killed `report_result` (and any other tcode-server tool) on codex children outside `full` access.

## Fix

`McpRegistration::codex_config_override()` now includes `default_tools_approval_mode="approve"` in the inline server table. Verified against codex `rust-v0.149.1`:

- `custom_mcp_tool_approval_mode` reads `mcp_servers.<name>.default_tools_approval_mode` first,
- `mcp_permission_prompt_is_auto_approved` returns true immediately for `AppToolApproval::Approve`, so no prompt and no elicitation.

This is the codex mirror of #270's claude-side auto-approve: tcode's own servers (report, preview, orchestrate, computer-use) are trusted by construction. The field exists in codex config since ~0.116, far older than the app-server v2 protocol tcode already requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)