### PR TITLE
feat(computer-use): restore focus and cursor around synthetic input; true per-window capture on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,6 +1398,7 @@ dependencies = [
  "base64 0.23.1",
  "core-foundation 0.10.1",
  "core-graphics 0.25.0",
+ "image",
  "log",
  "mcp-host",
  "rmcp",

--- a/crates/computer-use-mcp/Cargo.toml
+++ b/crates/computer-use-mcp/Cargo.toml
@@ -28,6 +28,7 @@ core-foundation = "0.10"
 core-graphics = { version = "0.25", features = ["highsierra"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
+image = { version = "0.25.10", default-features = false, features = ["png"] }
 uiautomation = { version = "0.25", default-features = false, features = [
     "control",
     "input",
@@ -37,5 +38,8 @@ uiautomation = { version = "0.25", default-features = false, features = [
 ] }
 windows = { version = "=0.62.2", features = [
     "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+    "Win32_Storage_Xps",
     "Win32_System_Threading",
+    "Win32_UI_WindowsAndMessaging",
 ] }

--- a/crates/computer-use-mcp/src/backend/macos/ax.rs
+++ b/crates/computer-use-mcp/src/backend/macos/ax.rs
@@ -206,6 +206,67 @@ fn running_application_identifier(pid: u32) -> Option<String> {
     }
 }
 
+pub(super) fn frontmost_application_pid() -> Option<u32> {
+    // SAFETY: all selectors and return types below are stable AppKit APIs. The
+    // autorelease pool bounds temporary Objective-C objects on this thread.
+    unsafe {
+        let pool_class = objc_getClass(c"NSAutoreleasePool".as_ptr());
+        let workspace_class = objc_getClass(c"NSWorkspace".as_ptr());
+        if pool_class.is_null() || workspace_class.is_null() {
+            return None;
+        }
+        let pool = send_id(pool_class, c"new");
+        let workspace = send_id(workspace_class, c"sharedWorkspace");
+        let application = send_id(workspace, c"frontmostApplication");
+        let pid = (!application.is_null()).then(|| send_i32(application, c"processIdentifier"));
+        send_void(pool, c"drain");
+        pid.filter(|pid| *pid > 0)
+            .and_then(|pid| u32::try_from(pid).ok())
+    }
+}
+
+pub(super) fn activate_application(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
+    // SAFETY: all selectors and return types below are stable AppKit APIs. The
+    // autorelease pool bounds temporary Objective-C objects on this thread.
+    unsafe {
+        let pool_class = objc_getClass(c"NSAutoreleasePool".as_ptr());
+        let application_class = objc_getClass(c"NSRunningApplication".as_ptr());
+        if pool_class.is_null() || application_class.is_null() {
+            return false;
+        }
+        let pool = send_id(pool_class, c"new");
+        let application = send_id_i32(
+            application_class,
+            c"runningApplicationWithProcessIdentifier:",
+            pid,
+        );
+        let activated =
+            !application.is_null() && send_bool_usize(application, c"activateWithOptions:", 0);
+        send_void(pool, c"drain");
+        activated
+    }
+}
+
+pub(super) fn raise_window(root: &RootInfo) -> Result<(), String> {
+    let (_application, window) = locate_window(root).map_err(|error| error.to_string())?;
+    let action = CFString::new("AXRaise");
+    let code = unsafe { AXUIElementPerformAction(window.as_ax(), action.as_concrete_TypeRef()) };
+    ax_result("AXRaise", code).map_err(|error| error.to_string())?;
+
+    let attribute = CFString::new("AXMain");
+    let code = unsafe {
+        AXUIElementSetAttributeValue(
+            window.as_ax(),
+            attribute.as_concrete_TypeRef(),
+            CFBoolean::true_value().as_CFTypeRef(),
+        )
+    };
+    ax_result("setting AXMain", code).map_err(|error| error.to_string())
+}
+
 unsafe fn send_id(receiver: *mut c_void, selector: &std::ffi::CStr) -> *mut c_void {
     let send: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void =
         unsafe { std::mem::transmute(objc_msgSend as unsafe extern "C" fn()) };
@@ -216,6 +277,18 @@ unsafe fn send_id_i32(receiver: *mut c_void, selector: &std::ffi::CStr, value: i
     let send: unsafe extern "C" fn(*mut c_void, *mut c_void, i32) -> *mut c_void =
         unsafe { std::mem::transmute(objc_msgSend as unsafe extern "C" fn()) };
     unsafe { send(receiver, sel_registerName(selector.as_ptr()), value) }
+}
+
+unsafe fn send_i32(receiver: *mut c_void, selector: &std::ffi::CStr) -> i32 {
+    let send: unsafe extern "C" fn(*mut c_void, *mut c_void) -> i32 =
+        unsafe { std::mem::transmute(objc_msgSend as unsafe extern "C" fn()) };
+    unsafe { send(receiver, sel_registerName(selector.as_ptr())) }
+}
+
+unsafe fn send_bool_usize(receiver: *mut c_void, selector: &std::ffi::CStr, value: usize) -> bool {
+    let send: unsafe extern "C" fn(*mut c_void, *mut c_void, usize) -> i8 =
+        unsafe { std::mem::transmute(objc_msgSend as unsafe extern "C" fn()) };
+    unsafe { send(receiver, sel_registerName(selector.as_ptr()), value) != 0 }
 }
 
 unsafe fn send_void(receiver: *mut c_void, selector: &std::ffi::CStr) {

--- a/crates/computer-use-mcp/src/backend/macos/focus.rs
+++ b/crates/computer-use-mcp/src/backend/macos/focus.rs
@@ -1,0 +1,123 @@
+use std::time::{Duration, Instant};
+
+use core_graphics::display::CGDisplay;
+use core_graphics::event::CGEvent;
+use core_graphics::geometry::CGPoint;
+
+use super::super::RootInfo;
+use super::{ax, input};
+
+pub(super) struct FocusGuard {
+    previous_pid: Option<u32>,
+}
+
+impl FocusGuard {
+    pub(super) fn acquire(root: &RootInfo) -> Self {
+        let Some(previous_pid) = ax::frontmost_application_pid() else {
+            log::debug!(
+                "could not determine the frontmost macOS application; skipping focus guard"
+            );
+            return Self::noop();
+        };
+        if previous_pid == root.pid {
+            return Self::noop();
+        }
+        if !ax::activate_application(root.pid) {
+            log::debug!(
+                "could not activate target macOS application pid {}; skipping focus guard",
+                root.pid
+            );
+            return Self::noop();
+        }
+        if let Err(error) = ax::raise_window(root) {
+            log::debug!("could not raise target macOS window: {error}; skipping focus guard");
+            Self::restore_after_failed_acquire(previous_pid);
+            return Self::noop();
+        }
+
+        let deadline = Instant::now() + Duration::from_millis(500);
+        loop {
+            match ax::frontmost_application_pid() {
+                Some(pid) if pid == root.pid => {
+                    return Self {
+                        previous_pid: Some(previous_pid),
+                    };
+                }
+                Some(_) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Some(_) => {
+                    log::debug!(
+                        "target macOS application pid {} did not become frontmost within 500ms; skipping focus guard",
+                        root.pid
+                    );
+                    Self::restore_after_failed_acquire(previous_pid);
+                    return Self::noop();
+                }
+                None => {
+                    log::debug!(
+                        "could not poll the frontmost macOS application; skipping focus guard"
+                    );
+                    Self::restore_after_failed_acquire(previous_pid);
+                    return Self::noop();
+                }
+            }
+        }
+    }
+
+    fn noop() -> Self {
+        Self { previous_pid: None }
+    }
+
+    fn restore_after_failed_acquire(previous_pid: u32) {
+        if !ax::activate_application(previous_pid) {
+            log::debug!(
+                "could not restore macOS application pid {previous_pid} after focus acquisition failed"
+            );
+        }
+    }
+}
+
+impl Drop for FocusGuard {
+    fn drop(&mut self) {
+        if let Some(previous_pid) = self.previous_pid
+            && !ax::activate_application(previous_pid)
+        {
+            log::debug!("could not restore previous macOS application pid {previous_pid}");
+        }
+    }
+}
+
+pub(super) struct CursorGuard {
+    saved_point: Option<CGPoint>,
+}
+
+impl CursorGuard {
+    pub(super) fn acquire() -> Self {
+        let saved_point = match input::event_source().and_then(|source| {
+            CGEvent::new(source).map_err(|()| {
+                super::super::BackendError::new(
+                    super::super::BackendErrorCode::OperationFailed,
+                    "CoreGraphics could not create an event to read the cursor position",
+                )
+            })
+        }) {
+            Ok(event) => Some(event.location()),
+            Err(error) => {
+                log::debug!("could not save the macOS cursor position: {error}");
+                None
+            }
+        };
+        Self { saved_point }
+    }
+}
+
+impl Drop for CursorGuard {
+    fn drop(&mut self) {
+        if let Some(point) = self.saved_point
+            && let Err(error) = CGDisplay::warp_mouse_cursor_position(point)
+        {
+            log::debug!("could not restore the macOS cursor position: {error:?}");
+        }
+    }
+}

--- a/crates/computer-use-mcp/src/backend/macos/input.rs
+++ b/crates/computer-use-mcp/src/backend/macos/input.rs
@@ -152,7 +152,7 @@ fn unicode_chunks(text: &str, maximum_units: usize) -> Vec<Vec<u16>> {
     chunks
 }
 
-fn event_source() -> Result<CGEventSource, BackendError> {
+pub(super) fn event_source() -> Result<CGEventSource, BackendError> {
     CGEventSource::new(CGEventSourceStateID::HIDSystemState)
         .map_err(|()| operation("CoreGraphics could not create an event source"))
 }

--- a/crates/computer-use-mcp/src/backend/macos/mod.rs
+++ b/crates/computer-use-mcp/src/backend/macos/mod.rs
@@ -1,5 +1,6 @@
 mod ax;
 mod capture;
+mod focus;
 mod input;
 
 use std::collections::HashMap;
@@ -21,6 +22,8 @@ use super::{
     RootFilters, RootInfo, RootObservation, matches_root_filters,
 };
 use crate::outline::{UiNode, is_text_sparse};
+
+use self::focus::{CursorGuard, FocusGuard};
 
 pub(super) struct MacosBackend;
 
@@ -143,12 +146,16 @@ impl MacosBackend {
                         return Ok(ActionResult::worked("AXPress completed for click target"));
                     }
                     let (x, y) = target.frame().center();
+                    let _cursor_guard = CursorGuard::acquire();
+                    let _focus_guard = FocusGuard::acquire(root);
                     input::click(x, y, request.button, request.click_count)?;
                     return Ok(ActionResult::unknown(
                         "AXPress was rejected; physical click events were posted",
                     ));
                 }
                 let (x, y) = action_point(root, request)?;
+                let _cursor_guard = CursorGuard::acquire();
+                let _focus_guard = FocusGuard::acquire(root);
                 input::click(x, y, request.button, request.click_count)?;
                 Ok(ActionResult::unknown("physical click events were posted"))
             }
@@ -160,14 +167,20 @@ impl MacosBackend {
                 match target.set_text(text) {
                     Ok(()) => Ok(ActionResult::worked("AXValue was set")),
                     Err(ax_error) => {
-                        if target.focus().is_err() {
+                        let click_point = if target.focus().is_err() {
                             let frame = target.frame();
                             if !frame.has_area() {
                                 return Ok(ActionResult::didnt(format!(
                                     "{ax_error}; the target also rejected focus and has no clickable frame"
                                 )));
                             }
-                            let (x, y) = frame.center();
+                            Some(frame.center())
+                        } else {
+                            None
+                        };
+                        let _cursor_guard = click_point.map(|_| CursorGuard::acquire());
+                        let _focus_guard = FocusGuard::acquire(root);
+                        if let Some((x, y)) = click_point {
                             input::click(x, y, super::MouseButton::Left, 1)?;
                         }
                         input::keypress(&["cmd+a".into()])?;
@@ -182,7 +195,7 @@ impl MacosBackend {
                 let text = request.text.as_deref().ok_or_else(|| {
                     BackendError::new(BackendErrorCode::InvalidAction, "type_text requires text")
                 })?;
-                if request.target_path.is_some() {
+                let click_point = if request.target_path.is_some() {
                     let target = target(root, request)?;
                     if target.focus().is_err() {
                         let frame = target.frame();
@@ -191,15 +204,26 @@ impl MacosBackend {
                                 "target rejected focus and has no clickable frame",
                             ));
                         }
-                        let (x, y) = frame.center();
-                        input::click(x, y, super::MouseButton::Left, 1)?;
+                        Some(frame.center())
+                    } else {
+                        None
                     }
+                } else {
+                    None
+                };
+                let _cursor_guard = click_point.map(|_| CursorGuard::acquire());
+                let _focus_guard = FocusGuard::acquire(root);
+                if let Some((x, y)) = click_point {
+                    input::click(x, y, super::MouseButton::Left, 1)?;
                 }
                 input::type_text(text)?;
                 Ok(ActionResult::unknown("Unicode keyboard events were posted"))
             }
             ActionKind::Keypress => {
-                if request.target_path.is_some() {
+                let keys = request.keys.as_deref().ok_or_else(|| {
+                    BackendError::new(BackendErrorCode::InvalidAction, "keypress requires keys")
+                })?;
+                let click_point = if request.target_path.is_some() {
                     let target = target(root, request)?;
                     if target.focus().is_err() {
                         let frame = target.frame();
@@ -208,19 +232,32 @@ impl MacosBackend {
                                 "keypress target rejected focus and has no clickable frame",
                             ));
                         }
-                        let (x, y) = frame.center();
-                        input::click(x, y, super::MouseButton::Left, 1)?;
+                        Some(frame.center())
+                    } else {
+                        None
                     }
+                } else {
+                    None
+                };
+                let _cursor_guard = click_point.map(|_| CursorGuard::acquire());
+                let _focus_guard = FocusGuard::acquire(root);
+                if let Some((x, y)) = click_point {
+                    input::click(x, y, super::MouseButton::Left, 1)?;
                 }
-                let keys = request.keys.as_deref().ok_or_else(|| {
-                    BackendError::new(BackendErrorCode::InvalidAction, "keypress requires keys")
-                })?;
                 input::keypress(keys)?;
                 Ok(ActionResult::unknown("keyboard events were posted"))
             }
             ActionKind::Scroll => {
-                if request.target_path.is_some() || (request.x.is_some() && request.y.is_some()) {
-                    let (x, y) = action_point(root, request)?;
+                let action_point = if request.target_path.is_some()
+                    || (request.x.is_some() && request.y.is_some())
+                {
+                    Some(action_point(root, request)?)
+                } else {
+                    None
+                };
+                let _cursor_guard = CursorGuard::acquire();
+                let _focus_guard = FocusGuard::acquire(root);
+                if let Some((x, y)) = action_point {
                     input::move_mouse(x, y)?;
                 }
                 input::scroll(
@@ -233,11 +270,14 @@ impl MacosBackend {
                 let path = request.path.as_deref().ok_or_else(|| {
                     BackendError::new(BackendErrorCode::InvalidAction, "drag requires a path")
                 })?;
+                let _cursor_guard = CursorGuard::acquire();
+                let _focus_guard = FocusGuard::acquire(root);
                 input::drag(path, request.button)?;
                 Ok(ActionResult::unknown("drag events were posted"))
             }
             ActionKind::MoveMouse => {
                 let (x, y) = action_point(root, request)?;
+                let _focus_guard = FocusGuard::acquire(root);
                 input::move_mouse(x, y)?;
                 Ok(ActionResult::unknown("mouse-move event was posted"))
             }

--- a/crates/computer-use-mcp/src/backend/windows/capture.rs
+++ b/crates/computer-use-mcp/src/backend/windows/capture.rs
@@ -2,11 +2,184 @@ use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use image::ImageEncoder;
 use uiautomation::UIElement;
+use windows::Win32::Foundation::{HWND, RECT};
+use windows::Win32::Graphics::Gdi::{
+    BI_RGB, BITMAPINFO, BITMAPINFOHEADER, CreateCompatibleDC, CreateDIBSection, DIB_RGB_COLORS,
+    DeleteDC, DeleteObject, GetDC, HBITMAP, HDC, HGDIOBJ, ReleaseDC, SelectObject,
+};
+use windows::Win32::Storage::Xps::{PRINT_WINDOW_FLAGS, PrintWindow};
+use windows::Win32::UI::WindowsAndMessaging::{GetWindowRect, IsWindow};
 
-use super::super::{BackendError, BackendErrorCode};
+use super::super::{BackendError, BackendErrorCode, RootInfo};
 
 static NEXT_CAPTURE_ID: AtomicU64 = AtomicU64::new(1);
+
+pub(super) fn capture_window(root: &RootInfo) -> Result<Vec<u8>, BackendError> {
+    let hwnd = HWND(root.window_id as usize as *mut _);
+    if hwnd.is_invalid() {
+        return Err(capture_error("the root HWND is null"));
+    }
+    // SAFETY: The HWND is validated before use, and the capture resources own all GDI cleanup.
+    unsafe {
+        if !IsWindow(Some(hwnd)).as_bool() {
+            return Err(capture_error("the root HWND is no longer valid"));
+        }
+        capture_window_inner(hwnd)
+    }
+}
+
+unsafe fn capture_window_inner(hwnd: HWND) -> Result<Vec<u8>, BackendError> {
+    let mut rect = RECT::default();
+    unsafe { GetWindowRect(hwnd, &mut rect) }
+        .map_err(|error| capture_error(format!("GetWindowRect failed: {error}")))?;
+    let width = rect.right - rect.left;
+    let height = rect.bottom - rect.top;
+    if width <= 0 || height <= 0 {
+        return Err(capture_error(format!(
+            "the window has invalid capture dimensions {width}x{height}"
+        )));
+    }
+    let width_u32 = u32::try_from(width)
+        .map_err(|error| capture_error(format!("window width is out of range: {error}")))?;
+    let height_u32 = u32::try_from(height)
+        .map_err(|error| capture_error(format!("window height is out of range: {error}")))?;
+    let byte_len = usize::try_from(width_u32)
+        .ok()
+        .zip(usize::try_from(height_u32).ok())
+        .and_then(|(width, height)| width.checked_mul(height))
+        .and_then(|pixels| pixels.checked_mul(4))
+        .ok_or_else(|| capture_error("window capture buffer size overflowed"))?;
+
+    let window_dc = unsafe { WindowDc::new(hwnd) }?;
+    let memory_dc = unsafe { MemoryDc::new(window_dc.hdc) }?;
+    let surface = unsafe { DibSurface::new(memory_dc.hdc, width, height) }?;
+
+    if !unsafe { PrintWindow(hwnd, memory_dc.hdc, PRINT_WINDOW_FLAGS(2)) }.as_bool() {
+        return Err(capture_error("PrintWindow returned FALSE"));
+    }
+
+    // DIB sections are tightly packed at 32 bpp. PrintWindow commonly leaves alpha at zero, so
+    // normalize the BGRA pixels to opaque RGBA for a portable PNG.
+    let bgra = unsafe { std::slice::from_raw_parts(surface.bits.cast::<u8>(), byte_len) };
+    let mut rgba = Vec::with_capacity(byte_len);
+    for pixel in bgra.chunks_exact(4) {
+        rgba.extend_from_slice(&[pixel[2], pixel[1], pixel[0], u8::MAX]);
+    }
+    let mut png = Vec::new();
+    image::codecs::png::PngEncoder::new(&mut png)
+        .write_image(
+            &rgba,
+            width_u32,
+            height_u32,
+            image::ExtendedColorType::Rgba8,
+        )
+        .map_err(|error| capture_error(format!("PrintWindow PNG encoding failed: {error}")))?;
+    Ok(png)
+}
+
+struct WindowDc {
+    hwnd: HWND,
+    hdc: HDC,
+}
+
+impl WindowDc {
+    unsafe fn new(hwnd: HWND) -> Result<Self, BackendError> {
+        let hdc = unsafe { GetDC(Some(hwnd)) };
+        if hdc.is_invalid() {
+            Err(capture_error("GetDC returned a null device context"))
+        } else {
+            Ok(Self { hwnd, hdc })
+        }
+    }
+}
+
+impl Drop for WindowDc {
+    fn drop(&mut self) {
+        // SAFETY: `hdc` was returned by GetDC for this HWND and is released exactly once.
+        let _ = unsafe { ReleaseDC(Some(self.hwnd), self.hdc) };
+    }
+}
+
+struct MemoryDc {
+    hdc: HDC,
+}
+
+impl MemoryDc {
+    unsafe fn new(compatible_with: HDC) -> Result<Self, BackendError> {
+        let hdc = unsafe { CreateCompatibleDC(Some(compatible_with)) };
+        if hdc.is_invalid() {
+            Err(capture_error(
+                "CreateCompatibleDC returned a null device context",
+            ))
+        } else {
+            Ok(Self { hdc })
+        }
+    }
+}
+
+impl Drop for MemoryDc {
+    fn drop(&mut self) {
+        // SAFETY: `hdc` was created by CreateCompatibleDC and is deleted exactly once.
+        let _ = unsafe { DeleteDC(self.hdc) };
+    }
+}
+
+struct DibSurface {
+    hdc: HDC,
+    bitmap: HBITMAP,
+    previous: HGDIOBJ,
+    bits: *mut std::ffi::c_void,
+}
+
+impl DibSurface {
+    unsafe fn new(hdc: HDC, width: i32, height: i32) -> Result<Self, BackendError> {
+        let info = BITMAPINFO {
+            bmiHeader: BITMAPINFOHEADER {
+                biSize: u32::try_from(std::mem::size_of::<BITMAPINFOHEADER>()).unwrap_or_default(),
+                biWidth: width,
+                biHeight: -height,
+                biPlanes: 1,
+                biBitCount: 32,
+                biCompression: BI_RGB.0,
+                ..BITMAPINFOHEADER::default()
+            },
+            ..BITMAPINFO::default()
+        };
+        let mut bits = std::ptr::null_mut();
+        let bitmap =
+            unsafe { CreateDIBSection(Some(hdc), &info, DIB_RGB_COLORS, &mut bits, None, 0) }
+                .map_err(|error| capture_error(format!("CreateDIBSection failed: {error}")))?;
+        if bits.is_null() {
+            let _ = unsafe { DeleteObject(bitmap.into()) };
+            return Err(capture_error(
+                "CreateDIBSection returned a null pixel buffer",
+            ));
+        }
+        let previous = unsafe { SelectObject(hdc, bitmap.into()) };
+        if previous.is_invalid() {
+            let _ = unsafe { DeleteObject(bitmap.into()) };
+            return Err(capture_error("SelectObject failed for the capture bitmap"));
+        }
+        Ok(Self {
+            hdc,
+            bitmap,
+            previous,
+            bits,
+        })
+    }
+}
+
+impl Drop for DibSurface {
+    fn drop(&mut self) {
+        // SAFETY: Restore the previously selected object before deleting the owned bitmap.
+        unsafe {
+            let _ = SelectObject(self.hdc, self.previous);
+            let _ = DeleteObject(self.bitmap.into());
+        }
+    }
+}
 
 pub(super) fn capture_element(element: &UIElement) -> Result<Vec<u8>, BackendError> {
     let screenshot = element.screenshot().map_err(|error| {

--- a/crates/computer-use-mcp/src/backend/windows/capture.rs
+++ b/crates/computer-use-mcp/src/backend/windows/capture.rs
@@ -64,7 +64,7 @@ unsafe fn capture_window_inner(hwnd: HWND) -> Result<Vec<u8>, BackendError> {
     // normalize the BGRA pixels to opaque RGBA for a portable PNG.
     let bgra = unsafe { std::slice::from_raw_parts(surface.bits.cast::<u8>(), byte_len) };
     let mut rgba = Vec::with_capacity(byte_len);
-    for pixel in bgra.chunks_exact(4) {
+    for pixel in bgra.as_chunks::<4>().0 {
         rgba.extend_from_slice(&[pixel[2], pixel[1], pixel[0], u8::MAX]);
     }
     let mut png = Vec::new();

--- a/crates/computer-use-mcp/src/backend/windows/focus.rs
+++ b/crates/computer-use-mcp/src/backend/windows/focus.rs
@@ -1,0 +1,166 @@
+use std::thread;
+use std::time::{Duration, Instant};
+
+use windows::Win32::Foundation::{HWND, POINT};
+use windows::Win32::System::Threading::{AttachThreadInput, GetCurrentThreadId};
+use windows::Win32::UI::WindowsAndMessaging::{
+    BringWindowToTop, GetCursorPos, GetForegroundWindow, GetWindowThreadProcessId, IsIconic,
+    IsWindow, SW_RESTORE, SetCursorPos, SetForegroundWindow, ShowWindow,
+};
+
+use super::RootInfo;
+
+const FOCUS_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const FOCUS_TIMEOUT: Duration = Duration::from_millis(500);
+
+pub(super) struct ForegroundGuard {
+    previous: Option<HWND>,
+}
+
+impl ForegroundGuard {
+    pub(super) fn acquire(root: &RootInfo) -> Self {
+        let target = hwnd(root.window_id);
+        if target.is_invalid() {
+            log::debug!("cannot foreground root {}: its HWND is null", root.ref_id);
+            return Self::noop();
+        }
+
+        // SAFETY: These calls only inspect/manipulate HWND values supplied by root enumeration.
+        unsafe {
+            if !IsWindow(Some(target)).as_bool() {
+                log::debug!(
+                    "cannot foreground root {}: HWND is no longer valid",
+                    root.ref_id
+                );
+                return Self::noop();
+            }
+            let previous = GetForegroundWindow();
+            if previous == target {
+                return Self::noop();
+            }
+            if IsIconic(target).as_bool() {
+                let _ = ShowWindow(target, SW_RESTORE);
+            }
+            if switch_foreground(target) {
+                Self {
+                    previous: (!previous.is_invalid()).then_some(previous),
+                }
+            } else {
+                log::debug!(
+                    "could not foreground root {} within {}ms",
+                    root.ref_id,
+                    FOCUS_TIMEOUT.as_millis()
+                );
+                Self::noop()
+            }
+        }
+    }
+
+    fn noop() -> Self {
+        Self { previous: None }
+    }
+}
+
+impl Drop for ForegroundGuard {
+    fn drop(&mut self) {
+        let Some(previous) = self.previous else {
+            return;
+        };
+        // SAFETY: The handle is checked immediately before the best-effort restoration.
+        unsafe {
+            if IsWindow(Some(previous)).as_bool() && !switch_foreground(previous) {
+                log::debug!("could not restore the previous foreground window");
+            }
+        }
+    }
+}
+
+pub(super) struct CursorGuard {
+    position: Option<POINT>,
+}
+
+impl CursorGuard {
+    pub(super) fn acquire() -> Self {
+        let mut position = POINT::default();
+        // SAFETY: `position` points to initialized, writable memory.
+        match unsafe { GetCursorPos(&mut position) } {
+            Ok(()) => Self {
+                position: Some(position),
+            },
+            Err(error) => {
+                log::debug!("could not save the cursor position: {error}");
+                Self { position: None }
+            }
+        }
+    }
+}
+
+impl Drop for CursorGuard {
+    fn drop(&mut self) {
+        if let Some(position) = self.position {
+            // SAFETY: Restoring a previously returned cursor coordinate has no memory-safety
+            // requirements. Failure is intentionally best-effort.
+            if let Err(error) = unsafe { SetCursorPos(position.x, position.y) } {
+                log::debug!("could not restore the cursor position: {error}");
+            }
+        }
+    }
+}
+
+fn hwnd(window_id: u32) -> HWND {
+    HWND(window_id as usize as *mut _)
+}
+
+// SAFETY: The caller must provide a live top-level HWND. All attachment state is detached before
+// returning, including when a foreground operation fails.
+unsafe fn switch_foreground(target: HWND) -> bool {
+    let _ = unsafe { SetForegroundWindow(target) };
+    if unsafe { wait_for_foreground(target) } {
+        return true;
+    }
+
+    let foreground = unsafe { GetForegroundWindow() };
+    if foreground.is_invalid() {
+        return false;
+    }
+    let foreground_thread = unsafe { GetWindowThreadProcessId(foreground, None) };
+    let current_thread = unsafe { GetCurrentThreadId() };
+    if foreground_thread == 0 || foreground_thread == current_thread {
+        return false;
+    }
+    if !unsafe { AttachThreadInput(current_thread, foreground_thread, true) }.as_bool() {
+        return false;
+    }
+    let _attachment = ThreadInputAttachment {
+        current_thread,
+        foreground_thread,
+    };
+    let _ = unsafe { SetForegroundWindow(target) };
+    let _ = unsafe { BringWindowToTop(target) };
+    unsafe { wait_for_foreground(target) }
+}
+
+unsafe fn wait_for_foreground(target: HWND) -> bool {
+    let deadline = Instant::now() + FOCUS_TIMEOUT;
+    loop {
+        if unsafe { GetForegroundWindow() } == target {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        thread::sleep(FOCUS_POLL_INTERVAL);
+    }
+}
+
+struct ThreadInputAttachment {
+    current_thread: u32,
+    foreground_thread: u32,
+}
+
+impl Drop for ThreadInputAttachment {
+    fn drop(&mut self) {
+        // SAFETY: This exactly reverses the successful attachment that created this guard.
+        let _ = unsafe { AttachThreadInput(self.current_thread, self.foreground_thread, false) };
+    }
+}

--- a/crates/computer-use-mcp/src/backend/windows/mod.rs
+++ b/crates/computer-use-mcp/src/backend/windows/mod.rs
@@ -1,4 +1,5 @@
 mod capture;
+mod focus;
 mod input;
 mod map;
 
@@ -32,6 +33,7 @@ use self::map::{
     PatternSupport, actions_for_patterns, frame_from_uia_rect, role_for_control_type,
     root_kind_for_control_type,
 };
+use focus::{CursorGuard, ForegroundGuard};
 
 const MAX_DEPTH: usize = 18;
 const MAX_NODES: usize = 3_000;
@@ -75,20 +77,29 @@ impl WindowsBackend {
         };
         let text_sparse = is_text_sparse(&tree);
         let screenshot_png = if request.capture.should_capture(text_sparse) {
-            if live_root.is_none() {
-                live_root = Some(open_root(
-                    root,
-                    BackendErrorCode::CaptureFailed,
-                    "opening the UIAutomation root for capture",
-                )?);
-            }
-            let opened = live_root.as_ref().ok_or_else(|| {
-                backend_error(
-                    BackendErrorCode::CaptureFailed,
-                    "the UIAutomation capture root was unexpectedly unavailable",
-                )
-            })?;
-            Some(capture::capture_element(&opened.element)?)
+            Some(match capture::capture_window(root) {
+                Ok(png) => png,
+                Err(error) => {
+                    log::debug!(
+                        "PrintWindow capture failed for root {}; falling back to UIAutomation: {error}",
+                        root.ref_id
+                    );
+                    if live_root.is_none() {
+                        live_root = Some(open_root(
+                            root,
+                            BackendErrorCode::CaptureFailed,
+                            "opening the UIAutomation root for capture",
+                        )?);
+                    }
+                    let opened = live_root.as_ref().ok_or_else(|| {
+                        backend_error(
+                            BackendErrorCode::CaptureFailed,
+                            "the UIAutomation capture root was unexpectedly unavailable",
+                        )
+                    })?;
+                    capture::capture_element(&opened.element)?
+                }
+            })
         } else {
             None
         };
@@ -122,6 +133,8 @@ impl WindowsBackend {
                             )));
                         };
                         let (x, y) = frame.center();
+                        let _cursor_guard = CursorGuard::acquire();
+                        let _foreground_guard = ForegroundGuard::acquire(root);
                         input::click(x, y, super::MouseButton::Left, 1)?;
                         ActionResult::unknown(format!(
                             "{uia_error}; uiautomation mouse events were posted instead"
@@ -149,6 +162,8 @@ impl WindowsBackend {
                                 )));
                             };
                             let (x, y) = frame.center();
+                            let _cursor_guard = CursorGuard::acquire();
+                            let _foreground_guard = ForegroundGuard::acquire(root);
                             input::click(x, y, request.button, request.click_count)?;
                             return Ok(ActionResult::unknown(format!(
                                 "{uia_error}; uiautomation mouse events were posted instead"
@@ -157,6 +172,8 @@ impl WindowsBackend {
                     }
                 }
                 let (x, y) = action_point(root, request)?;
+                let _cursor_guard = CursorGuard::acquire();
+                let _foreground_guard = ForegroundGuard::acquire(root);
                 input::click(x, y, request.button, request.click_count)?;
                 Ok(ActionResult::unknown(
                     "uiautomation mouse events were posted",
@@ -170,14 +187,21 @@ impl WindowsBackend {
                 match target.set_text(text) {
                     Ok(message) => Ok(ActionResult::worked(message)),
                     Err(uia_error) => {
-                        if target.focus().is_err() {
+                        let focus_failed = target.focus().is_err();
+                        let click_point = if focus_failed {
                             let frame = target.frame();
                             if !frame.has_area() {
                                 return Ok(ActionResult::didnt(format!(
                                     "{uia_error}; the target also rejected focus and has no clickable frame"
                                 )));
                             }
-                            let (x, y) = frame.center();
+                            Some(frame.center())
+                        } else {
+                            None
+                        };
+                        let _cursor_guard = click_point.map(|_| CursorGuard::acquire());
+                        let _foreground_guard = ForegroundGuard::acquire(root);
+                        if let Some((x, y)) = click_point {
                             input::click(x, y, super::MouseButton::Left, 1)?;
                         }
                         input::keypress(&["ctrl+a".into()])?;
@@ -192,7 +216,7 @@ impl WindowsBackend {
                 let text = request.text.as_deref().ok_or_else(|| {
                     BackendError::new(BackendErrorCode::InvalidAction, "type_text requires text")
                 })?;
-                if request.target_path.is_some() {
+                let click_point = if request.target_path.is_some() {
                     let target = target(root, request)?;
                     if target.focus().is_err() {
                         let frame = target.frame();
@@ -201,9 +225,17 @@ impl WindowsBackend {
                                 "target rejected focus and has no clickable frame",
                             ));
                         }
-                        let (x, y) = frame.center();
-                        input::click(x, y, super::MouseButton::Left, 1)?;
+                        Some(frame.center())
+                    } else {
+                        None
                     }
+                } else {
+                    None
+                };
+                let _cursor_guard = click_point.map(|_| CursorGuard::acquire());
+                let _foreground_guard = ForegroundGuard::acquire(root);
+                if let Some((x, y)) = click_point {
+                    input::click(x, y, super::MouseButton::Left, 1)?;
                 }
                 input::type_text(text)?;
                 Ok(ActionResult::unknown(
@@ -211,7 +243,10 @@ impl WindowsBackend {
                 ))
             }
             ActionKind::Keypress => {
-                if request.target_path.is_some() {
+                let keys = request.keys.as_deref().ok_or_else(|| {
+                    BackendError::new(BackendErrorCode::InvalidAction, "keypress requires keys")
+                })?;
+                let click_point = if request.target_path.is_some() {
                     let target = target(root, request)?;
                     if target.focus().is_err() {
                         let frame = target.frame();
@@ -220,13 +255,18 @@ impl WindowsBackend {
                                 "keypress target rejected focus and has no clickable frame",
                             ));
                         }
-                        let (x, y) = frame.center();
-                        input::click(x, y, super::MouseButton::Left, 1)?;
+                        Some(frame.center())
+                    } else {
+                        None
                     }
+                } else {
+                    None
+                };
+                let _cursor_guard = click_point.map(|_| CursorGuard::acquire());
+                let _foreground_guard = ForegroundGuard::acquire(root);
+                if let Some((x, y)) = click_point {
+                    input::click(x, y, super::MouseButton::Left, 1)?;
                 }
-                let keys = request.keys.as_deref().ok_or_else(|| {
-                    BackendError::new(BackendErrorCode::InvalidAction, "keypress requires keys")
-                })?;
                 input::keypress(keys)?;
                 Ok(ActionResult::unknown(
                     "uiautomation keyboard events were posted",
@@ -246,17 +286,27 @@ impl WindowsBackend {
                     Ok(message) => Ok(ActionResult::worked(message)),
                     Err(uia_error) => {
                         let frame = target.frame();
-                        if target.focus().is_err() {
+                        let focus_failed = target.focus().is_err();
+                        let mouse_action = if focus_failed {
                             if !frame.has_area() {
                                 return Ok(ActionResult::didnt(format!(
                                     "{uia_error}; the target rejected focus and has no frame for keyboard fallback"
                                 )));
                             }
-                            let (x, y) = frame.center();
-                            input::click(x, y, super::MouseButton::Left, 1)?;
+                            Some((frame.center(), true))
                         } else if frame.has_area() {
-                            let (x, y) = frame.center();
-                            input::move_mouse(x, y)?;
+                            Some((frame.center(), false))
+                        } else {
+                            None
+                        };
+                        let _cursor_guard = mouse_action.map(|_| CursorGuard::acquire());
+                        let _foreground_guard = ForegroundGuard::acquire(root);
+                        if let Some(((x, y), should_click)) = mouse_action {
+                            if should_click {
+                                input::click(x, y, super::MouseButton::Left, 1)?;
+                            } else {
+                                input::move_mouse(x, y)?;
+                            }
                         }
                         input::scroll_with_keyboard(scroll_x, scroll_y)?;
                         Ok(ActionResult::unknown(format!(
@@ -269,6 +319,8 @@ impl WindowsBackend {
                 let path = request.path.as_deref().ok_or_else(|| {
                     BackendError::new(BackendErrorCode::InvalidAction, "drag requires a path")
                 })?;
+                let _cursor_guard = CursorGuard::acquire();
+                let _foreground_guard = ForegroundGuard::acquire(root);
                 input::drag(path, request.button)?;
                 Ok(ActionResult::unknown(
                     "uiautomation mouse drag events were posted",
@@ -276,6 +328,7 @@ impl WindowsBackend {
             }
             ActionKind::MoveMouse => {
                 let (x, y) = action_point(root, request)?;
+                let _foreground_guard = ForegroundGuard::acquire(root);
                 input::move_mouse(x, y)?;
                 Ok(ActionResult::unknown(
                     "a uiautomation mouse-move event was posted",


### PR DESCRIPTION
## Summary

Mimics Codex computer-use input hygiene: when the target window is not frontmost, synthetic input actions instantly switch focus to it, act, and switch back; the user's cursor position is saved and restored after pointer actions. Windows screenshots now capture the window's own content instead of the screen region under it.

### Behavior
- **Focus guard** (both platforms): clicks, keyboard input, scroll, and drag briefly activate + raise the target window when needed, then re-activate the previously frontmost app. Best-effort with a ≤500 ms activation poll — a guard failure never turns a working action into an error.
- **Cursor guard** (both platforms): pointer actions save the user's cursor position and warp it back afterwards. Explicit `move_mouse` is exempt so hover persists.
- **No flicker on accessibility paths**: successful AXPress / AXValue (macOS) and UIA pattern actions (Windows) acquire no guards; guards are acquired lazily only on synthetic-input fallbacks, after input validation.

### Platform notes
- **macOS**: `FocusGuard` reads the frontmost pid via NSWorkspace, activates via `NSRunningApplication activateWithOptions:`, and raises the specific window via AXRaise + AXMain (reusing existing objc/AX helpers in `ax.rs`). `CursorGuard` restores via `CGDisplay::warp_mouse_cursor_position` (no synthetic events). Screenshots were already true per-window (`screencapture -l`), unchanged.
- **Windows**: `ForegroundGuard` uses `SetForegroundWindow` with the `AttachThreadInput` fallback (and `SW_RESTORE` for minimized windows); `CursorGuard` uses `Get/SetCursorPos`. Capture now prefers **`PrintWindow` + `PW_RENDERFULLCONTENT`** (32-bit top-down DIB → PNG via the `image` crate already in the tree), which renders the window's own content even when occluded or backgrounded, falling back to the existing UIA screen-region grab on failure. All GDI objects are released via RAII.

### Known tradeoff
Restoring the previous app right after a click can dismiss transient UI (menus/popovers) the click just opened in the target app — inherent to the switch-back approach; unchanged from the Codex scheme being mirrored.

## Testing
- `cargo fmt --all --check` ✓
- `cargo clippy -p computer-use-mcp --all-targets -- -D warnings` ✓ (host)
- `cargo clippy -p computer-use-mcp --target x86_64-pc-windows-gnu --all-targets -- -D warnings` ✓ (cross-compiles the real Windows backend)
- `cargo test -p computer-use-mcp` ✓ 25/25
- CI's windows-2022 job is the authoritative Windows gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)