### PR TITLE
feat(ui): live command mini-terminal panel + auto-expand setting

### DIFF
--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -582,6 +582,7 @@ pub enum SettingsPatch {
     WordWrapDiffs(bool),
     SkipDeleteConfirmation(bool),
     AutoOpenTaskPanel(bool),
+    LiveCommandPanelDisabled(bool),
     ProviderUpdateChecksDisabled(bool),
     InactiveFrameThrottleDisabled(bool),
     AutoArchiveDisabled(bool),
@@ -665,6 +666,10 @@ pub struct Settings {
     /// Absent in legacy files (defaults to off).
     #[serde(default)]
     pub auto_open_task_panel: bool,
+    /// Whether the live command panel is DISABLED. Stored inverted so absent
+    /// legacy settings keep the feature enabled.
+    #[serde(default)]
+    pub live_command_panel_disabled: bool,
     /// Whether the on-launch provider version check is DISABLED. Stored inverted
     /// so the feature defaults to on (s3 §6: "Provider update checks", default
     /// on) even for legacy settings files that lack the field.
@@ -755,6 +760,7 @@ impl Default for Settings {
             word_wrap_diffs: false,
             skip_delete_confirmation: false,
             auto_open_task_panel: false,
+            live_command_panel_disabled: false,
             provider_update_checks_disabled: false,
             inactive_frame_throttle_disabled: false,
             auto_archive_disabled: false,
@@ -787,6 +793,9 @@ impl Settings {
                 self.skip_delete_confirmation = value;
             }
             SettingsPatch::AutoOpenTaskPanel(value) => self.auto_open_task_panel = value,
+            SettingsPatch::LiveCommandPanelDisabled(value) => {
+                self.live_command_panel_disabled = value;
+            }
             SettingsPatch::ProviderUpdateChecksDisabled(value) => {
                 self.provider_update_checks_disabled = value;
             }

--- a/crates/protocol/src/tests.rs
+++ b/crates/protocol/src/tests.rs
@@ -237,6 +237,7 @@ fn settings_patches_round_trip() {
         SettingsPatch::WordWrapDiffs(true),
         SettingsPatch::SkipDeleteConfirmation(true),
         SettingsPatch::AutoOpenTaskPanel(true),
+        SettingsPatch::LiveCommandPanelDisabled(true),
         SettingsPatch::ProviderUpdateChecksDisabled(true),
         SettingsPatch::InactiveFrameThrottleDisabled(true),
         SettingsPatch::AutoArchiveDisabled(true),

--- a/crates/services/src/settings.rs
+++ b/crates/services/src/settings.rs
@@ -181,6 +181,7 @@ mod tests {
             word_wrap_diffs: true,
             skip_delete_confirmation: true,
             auto_open_task_panel: true,
+            live_command_panel_disabled: true,
             provider_update_checks_disabled: true,
             inactive_frame_throttle_disabled: true,
             auto_archive_disabled: false,

--- a/crates/term/src/grid_emulator.rs
+++ b/crates/term/src/grid_emulator.rs
@@ -60,7 +60,7 @@ pub(crate) enum GridEvent {
 /// This type accepts raw output bytes and owns all terminal grid state. It has
 /// no PTY, child-process, or platform process types in its public API.
 #[derive(Clone)]
-pub(crate) struct GridEmulator {
+pub struct GridEmulator {
     core: Arc<GridCore>,
     events: async_channel::Receiver<GridEvent>,
 }
@@ -266,12 +266,11 @@ impl GridSize {
 impl GridEmulator {
     /// Create an 80×24 emulator with 1,000 lines of scrollback.
     #[cfg(test)]
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::with_size(DEFAULT_COLS, DEFAULT_ROWS)
     }
 
     /// Create an emulator with an explicit initial grid size.
-    #[cfg(test)]
     pub fn with_size(cols: usize, rows: usize) -> Self {
         Self::with_size_and_title(cols, rows, String::new())
     }
@@ -362,7 +361,7 @@ impl GridEmulator {
     ///
     /// Cloned receivers compete for events. Install one draining task and fan
     /// out from there when multiple consumers are needed.
-    pub fn events(&self) -> async_channel::Receiver<GridEvent> {
+    pub(crate) fn events(&self) -> async_channel::Receiver<GridEvent> {
         self.events.clone()
     }
 

--- a/crates/term/src/lib.rs
+++ b/crates/term/src/lib.rs
@@ -47,7 +47,8 @@ pub mod graphics {
     };
 }
 
-use grid_emulator::{GridEmulator, GridEvent};
+pub use grid_emulator::GridEmulator;
+use grid_emulator::GridEvent;
 use pty::{PtyEvent, PtyHandle};
 
 const DEFAULT_COLS: usize = 80;

--- a/crates/ui/src/chat/components/activity.rs
+++ b/crates/ui/src/chat/components/activity.rs
@@ -14,10 +14,9 @@ use gpui_base::{StyledExt as _, h_flex, v_flex};
 use agent::{ItemContent, ItemStatus};
 use tcode_core::session::{EntryContent, TimelineEntry};
 
-use super::super::model::{one_line, one_line_with_break_markers, output_tail, tool_brief};
+use super::super::model::{one_line, one_line_with_break_markers, tool_brief};
+use super::command_panel::CommandPanelCache;
 use super::indicator;
-
-const ACTIVITY_OUTPUT_TAIL_LINES: usize = 20;
 
 /// One Work Log activity row: a muted status icon + a one-line summary.
 pub(crate) fn activity_row(
@@ -25,6 +24,26 @@ pub(crate) fn activity_row(
     compact: bool,
     live_reasoning: bool,
     expanded: bool,
+    on_toggle: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    cx: &App,
+) -> AnyElement {
+    activity_row_with_command_detail(
+        entry,
+        compact,
+        live_reasoning,
+        expanded,
+        None,
+        on_toggle,
+        cx,
+    )
+}
+
+pub(crate) fn activity_row_with_command_detail(
+    entry: &TimelineEntry,
+    compact: bool,
+    live_reasoning: bool,
+    expanded: bool,
+    command_detail: Option<AnyElement>,
     on_toggle: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
     cx: &App,
 ) -> AnyElement {
@@ -154,7 +173,7 @@ pub(crate) fn activity_row(
 
     let mut block = v_flex().w_full().gap_1().child(row);
     if expanded && expandable {
-        block = block.child(activity_detail(entry, cx));
+        block = block.child(activity_detail(entry, command_detail, cx));
     }
     block.into_any_element()
 }
@@ -210,32 +229,18 @@ fn argument(text: String) -> Option<AnyElement> {
     (!text.is_empty()).then(|| text.into_any_element())
 }
 
-fn activity_detail(entry: &TimelineEntry, cx: &App) -> AnyElement {
+fn activity_detail(
+    entry: &TimelineEntry,
+    command_detail: Option<AnyElement>,
+    cx: &App,
+) -> AnyElement {
     let muted = cx.theme().muted_foreground;
     let mono = cx.theme().mono_font_family.clone();
     let detail = match &entry.content {
         EntryContent::Item(ItemContent::CommandExecution {
             command, output, ..
-        }) => v_flex()
-            .w_full()
-            .gap_2()
-            .child(activity_detail_section(
-                crate::tr!("chat.command").into_owned(),
-                command.clone(),
-                true,
-                mono.clone(),
-                muted,
-            ))
-            .when(!output.is_empty(), |detail| {
-                detail.child(activity_detail_section(
-                    crate::tr!("chat.output").into_owned(),
-                    output_tail(output, ACTIVITY_OUTPUT_TAIL_LINES),
-                    true,
-                    mono.clone(),
-                    muted,
-                ))
-            })
-            .into_any_element(),
+        }) => command_detail
+            .unwrap_or_else(|| CommandPanelCache::new().render(&entry.id, command, output, cx)),
         EntryContent::Item(ItemContent::ToolCall { input, output, .. }) => {
             let mut input_brief = tool_brief(input);
             if input_brief.is_empty() {

--- a/crates/ui/src/chat/components/command_panel.rs
+++ b/crates/ui/src/chat/components/command_panel.rs
@@ -1,0 +1,266 @@
+use std::collections::HashMap;
+
+use gpui::{
+    AnyElement, App, ContentMask, IntoElement as _, ParentElement as _, Styled as _, canvas, div,
+    px,
+};
+use term::{GridEmulator, TermSnapshot};
+
+use crate::terminal_drawer::{
+    TERMINAL_CELL_HEIGHT, TERMINAL_CELL_WIDTH, TerminalPalette, layout_grid, paint_terminal_grid,
+};
+use crate::theme::ActiveTheme as _;
+
+const COLS: usize = 80;
+const MAX_ROWS: usize = 16;
+const MAX_COMMAND_ROWS: usize = 4;
+const OUTPUT_TAIL_BYTES: usize = 32 * 1024;
+
+pub(crate) struct CommandPanelCache {
+    entries: HashMap<String, CachedPanel>,
+}
+
+impl CommandPanelCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    pub(crate) fn render(&mut self, id: &str, command: &str, output: &str, cx: &App) -> AnyElement {
+        let panel = self
+            .entries
+            .entry(id.to_string())
+            .or_insert_with(|| CachedPanel::new(command, output));
+        panel.update(command, output);
+        panel.render(cx)
+    }
+}
+
+struct CachedPanel {
+    command: String,
+    command_snapshot: TermSnapshot,
+    command_rows: usize,
+    output_emulator: GridEmulator,
+    output: Vec<u8>,
+    fed_start: usize,
+    output_snapshot: TermSnapshot,
+    output_rows: usize,
+}
+
+impl CachedPanel {
+    fn new(command: &str, output: &str) -> Self {
+        let (command_snapshot, command_rows) = command_snapshot(command);
+        let output_emulator = GridEmulator::with_size(COLS, MAX_ROWS - command_rows);
+        let output_snapshot = output_emulator.snapshot();
+        let mut panel = Self {
+            command: command.to_string(),
+            command_snapshot,
+            command_rows,
+            output_emulator,
+            output: Vec::new(),
+            fed_start: 0,
+            output_snapshot,
+            output_rows: 0,
+        };
+        panel.rebuild_output(output.as_bytes());
+        panel
+    }
+
+    fn update(&mut self, command: &str, output: &str) {
+        if self.command != command {
+            self.command = command.to_string();
+            (self.command_snapshot, self.command_rows) = command_snapshot(command);
+            self.rebuild_output(output.as_bytes());
+            return;
+        }
+
+        let bytes = output.as_bytes();
+        if bytes == self.output {
+            return;
+        }
+        let append_only = bytes.starts_with(&self.output);
+        if append_only && bytes.len().saturating_sub(self.fed_start) <= OUTPUT_TAIL_BYTES {
+            self.output_emulator.feed(&bytes[self.output.len()..]);
+            self.output = bytes.to_vec();
+            self.refresh_output_snapshot();
+        } else {
+            self.rebuild_output(bytes);
+        }
+    }
+
+    fn rebuild_output(&mut self, bytes: &[u8]) {
+        self.output_emulator = GridEmulator::with_size(COLS, MAX_ROWS - self.command_rows);
+        self.fed_start = bytes.len().saturating_sub(OUTPUT_TAIL_BYTES);
+        self.output_emulator.feed(&bytes[self.fed_start..]);
+        self.output = bytes.to_vec();
+        self.refresh_output_snapshot();
+    }
+
+    fn refresh_output_snapshot(&mut self) {
+        self.output_snapshot = self.output_emulator.snapshot();
+        self.output_rows =
+            trim_snapshot(&mut self.output_snapshot, MAX_ROWS - self.command_rows, 0);
+    }
+
+    fn render(&self, cx: &App) -> AnyElement {
+        let palette = TerminalPalette {
+            foreground: cx.theme().foreground,
+            background: cx.theme().background,
+            selection: cx.theme().primary.opacity(0.28),
+        };
+        let command = grid_element(&self.command_snapshot, self.command_rows, palette);
+        let output = (self.output_rows > 0)
+            .then(|| grid_element(&self.output_snapshot, self.output_rows, palette));
+        div()
+            .w(px(COLS as f32 * TERMINAL_CELL_WIDTH))
+            .max_w_full()
+            .overflow_hidden()
+            .bg(palette.background)
+            .child(command)
+            .children(output)
+            .into_any_element()
+    }
+}
+
+fn grid_element(snapshot: &TermSnapshot, rows: usize, palette: TerminalPalette) -> AnyElement {
+    let paint_data = layout_grid(snapshot, palette, false, None, false, false);
+    canvas(
+        |_bounds, _window, _cx| (),
+        move |bounds, (), window, cx| {
+            window.with_content_mask(Some(ContentMask { bounds }), |window| {
+                paint_terminal_grid(
+                    bounds,
+                    window,
+                    cx,
+                    &paint_data,
+                    palette,
+                    TERMINAL_CELL_WIDTH,
+                    TERMINAL_CELL_HEIGHT,
+                    false,
+                    |_origin, _scale_factor, _window| (),
+                );
+            });
+        },
+    )
+    .w(px(COLS as f32 * TERMINAL_CELL_WIDTH))
+    .h(px(rows as f32 * TERMINAL_CELL_HEIGHT))
+    .into_any_element()
+}
+
+fn command_snapshot(command: &str) -> (TermSnapshot, usize) {
+    let emulator = GridEmulator::with_size(COLS, MAX_COMMAND_ROWS);
+    emulator.feed(clamp_command(command).as_bytes());
+    let mut snapshot = emulator.snapshot();
+    let rows = trim_snapshot(&mut snapshot, MAX_COMMAND_ROWS, 1);
+    (snapshot, rows)
+}
+
+fn clamp_command(command: &str) -> String {
+    let mut result = String::new();
+    let mut row = 0;
+    let mut col = 0;
+    let mut chars = command.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\n' {
+            if row + 1 == MAX_COMMAND_ROWS && chars.peek().is_some() {
+                result.push('…');
+                break;
+            }
+            result.push_str("\r\n");
+            row += 1;
+            col = 0;
+            continue;
+        }
+        if ch == '\r' {
+            continue;
+        }
+        if col == COLS {
+            row += 1;
+            col = 0;
+        }
+        if row == MAX_COMMAND_ROWS {
+            result.push('…');
+            break;
+        }
+        if row + 1 == MAX_COMMAND_ROWS && col + 1 == COLS && chars.peek().is_some() {
+            result.push('…');
+            break;
+        }
+        result.push(ch);
+        col += 1;
+    }
+    result
+}
+
+fn trim_snapshot(snapshot: &mut TermSnapshot, max_rows: usize, minimum: usize) -> usize {
+    let rows = (0..max_rows.min(snapshot.screen_lines))
+        .rfind(|&row| {
+            (0..snapshot.cols).any(|col| {
+                snapshot
+                    .cell_text(row, col)
+                    .is_some_and(|text| text.chars().any(|ch| ch != ' ' && ch != '\0'))
+            })
+        })
+        .map_or(minimum, |row| row + 1)
+        .max(minimum);
+    snapshot.screen_lines = rows;
+    snapshot.visible_rows.truncate(rows);
+    snapshot.row_damage.truncate(rows);
+    snapshot.cursor = None;
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use gpui::rgb;
+    use term::rio_vt::config::colors::AnsiColor;
+
+    use super::*;
+    use crate::terminal_drawer::terminal_color;
+
+    fn palette() -> TerminalPalette {
+        TerminalPalette {
+            foreground: rgb(0xffffff).into(),
+            background: rgb(0x000000).into(),
+            selection: rgb(0x333333).into(),
+        }
+    }
+
+    #[test]
+    fn ansi_output_uses_terminal_green() {
+        let panel = CachedPanel::new("echo green", "\x1b[32mgreen\x1b[0m");
+        let paint = layout_grid(&panel.output_snapshot, palette(), false, None, false, false);
+        let green = paint
+            .text_runs
+            .iter()
+            .find(|run| run.text.contains("green"))
+            .expect("green output run");
+        assert_eq!(
+            terminal_color(green.style.fg, palette()),
+            terminal_color(AnsiColor::Indexed(2), palette())
+        );
+    }
+
+    #[test]
+    fn command_is_clamped_to_four_rows() {
+        let panel = CachedPanel::new(&"x".repeat(COLS * MAX_COMMAND_ROWS + 1), "");
+        assert_eq!(panel.command_rows, MAX_COMMAND_ROWS);
+        assert!(
+            panel
+                .command_snapshot
+                .cell_text(MAX_COMMAND_ROWS - 1, COLS - 1)
+                .is_some_and(|text| text == "…")
+        );
+    }
+
+    #[test]
+    fn trailing_blank_output_rows_are_trimmed() {
+        let panel = CachedPanel::new("printf one", "one\n\n");
+        assert_eq!(panel.output_rows, 1);
+    }
+}

--- a/crates/ui/src/chat/components/mod.rs
+++ b/crates/ui/src/chat/components/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod activity;
 pub(crate) mod assistant;
 pub(crate) mod bubble;
 pub(crate) mod changed_files;
+pub(crate) mod command_panel;
 pub(crate) mod disclosure;
 pub(crate) mod dividers;
 pub(crate) mod error_card;

--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::sync::Arc;
@@ -44,6 +45,7 @@ use crate::window_drag_area;
 use crate::window_state::WindowState;
 
 use self::components::assistant::MdState;
+use self::components::command_panel::CommandPanelCache;
 use self::model::{
     ListSync, Segment, TurnListItem, TurnRenderArgs, activity_run_duration_ms, auto_expanded,
     displayed_error_text, divergent_served_model, format_compact_span, format_span, index_turns,
@@ -77,6 +79,7 @@ pub struct ChatView {
     markdown_scroll_top: Option<usize>,
     /// Open/closed keys for collapsibles (work logs, activity rows, cards, files).
     expanded: HashSet<String>,
+    command_panels: RefCell<CommandPanelCache>,
     session_key: Option<String>,
     /// Turn selected from a command-palette content hit.
     highlighted_turn: Option<usize>,
@@ -139,6 +142,7 @@ impl ChatView {
             markdown_visible_turns: 0..0,
             markdown_scroll_top: None,
             expanded: HashSet::new(),
+            command_panels: RefCell::new(CommandPanelCache::new()),
             session_key: None,
             highlighted_turn: None,
             _tick: None,
@@ -180,6 +184,7 @@ impl ChatView {
         if session_changed {
             self.md_states.clear();
             self.expanded.clear();
+            self.command_panels.borrow_mut().clear();
             self.highlighted_turn = None;
             self.session_key = session_key;
             self.markdown_visible_turns = tail_turn_window(turn_items.len());
@@ -947,14 +952,37 @@ impl ChatView {
             return self.compose_subagent_row(entry, cx);
         }
         let key = format!("activity-{}", entry.id);
-        let expanded = self.expanded.contains(&key);
+        let automatic = self.workspace_store.read(cx).live_command_panel()
+            && matches!(
+                &entry.content,
+                EntryContent::Item(ItemContent::CommandExecution {
+                    status: ItemStatus::InProgress,
+                    ..
+                })
+            );
+        let expanded = automatic || self.expanded.contains(&key);
+        let command_detail = if expanded {
+            match &entry.content {
+                EntryContent::Item(ItemContent::CommandExecution {
+                    command, output, ..
+                }) => Some(
+                    self.command_panels
+                        .borrow_mut()
+                        .render(&entry.id, command, output, cx),
+                ),
+                _ => None,
+            }
+        } else {
+            None
+        };
         let turn = entry.turn;
         let click_key = key;
-        components::activity::activity_row(
+        components::activity::activity_row_with_command_detail(
             entry,
             compact,
             live_reasoning,
             expanded,
+            command_detail,
             cx.listener(move |this, _, _, cx| {
                 this.toggle_expanded(turn, &click_key, cx);
             }),

--- a/crates/ui/src/chat/model.rs
+++ b/crates/ui/src/chat/model.rs
@@ -355,11 +355,6 @@ pub(crate) fn tool_brief(input: &serde_json::Value) -> String {
     }
 }
 
-pub(crate) fn output_tail(output: &str, max_lines: usize) -> String {
-    let lines: Vec<&str> = output.lines().collect();
-    lines[lines.len().saturating_sub(max_lines)..].join("\n")
-}
-
 /// Wall-clock duration formatted as "XmYYs" / "YYs".
 pub(crate) fn format_duration(secs: u64) -> String {
     if secs >= 60 {

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -684,6 +684,14 @@ impl SettingsPage {
                 cx,
                 WorkspaceStore::set_auto_open_task_panel,
             ),
+            self.toggle_row(
+                "live-command-panel",
+                crate::tr!("settings.live_command_panel.title"),
+                crate::tr!("settings.live_command_panel.description"),
+                !settings.live_command_panel_disabled,
+                cx,
+                |store, checked| store.set_live_command_panel_disabled(!checked),
+            ),
         ];
         let workspace = vec![
             self.toggle_row(

--- a/crates/ui/src/store/intents.rs
+++ b/crates/ui/src/store/intents.rs
@@ -62,6 +62,9 @@ impl WorkspaceStore {
     pub fn set_auto_open_task_panel(&mut self, value: bool) {
         self.patch_settings(SettingsPatch::AutoOpenTaskPanel(value));
     }
+    pub fn set_live_command_panel_disabled(&mut self, value: bool) {
+        self.patch_settings(SettingsPatch::LiveCommandPanelDisabled(value));
+    }
     pub fn set_provider_update_checks_disabled(&mut self, value: bool) {
         self.patch_settings(SettingsPatch::ProviderUpdateChecksDisabled(value));
     }

--- a/crates/ui/src/store/mod.rs
+++ b/crates/ui/src/store/mod.rs
@@ -794,6 +794,10 @@ impl WorkspaceStore {
         self.settings_replica.clone()
     }
 
+    pub fn live_command_panel(&self) -> bool {
+        !self.settings_replica.live_command_panel_disabled
+    }
+
     pub fn archived_groups(&self) -> Vec<ProjectGroup> {
         let archived: Vec<_> = self
             .index_replica

--- a/crates/ui/src/terminal_drawer.rs
+++ b/crates/ui/src/terminal_drawer.rs
@@ -44,7 +44,9 @@ use crate::{
 };
 use tcode_core::ui::{MAX_TERMINALS_PER_SESSION, TerminalSplitDirection};
 
-const FONT_SIZE: f32 = 13.;
+pub(crate) const TERMINAL_FONT_SIZE: f32 = 13.;
+pub(crate) const TERMINAL_CELL_WIDTH: f32 = 7.83;
+pub(crate) const TERMINAL_CELL_HEIGHT: f32 = 17.;
 #[cfg(target_os = "macos")]
 const TERMINAL_FONT_FAMILY: &str = "Menlo";
 #[cfg(target_os = "windows")]
@@ -231,9 +233,9 @@ struct MarkedText {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct GridTextStyle {
-    fg: AnsiColor,
-    bg: AnsiColor,
+pub(crate) struct GridTextStyle {
+    pub(crate) fg: AnsiColor,
+    pub(crate) bg: AnsiColor,
     bold: bool,
     italic: bool,
     underline: bool,
@@ -243,20 +245,20 @@ struct GridTextStyle {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct BatchedTextRun {
-    row: usize,
-    start_col: usize,
-    text: String,
+pub(crate) struct BatchedTextRun {
+    pub(crate) row: usize,
+    pub(crate) start_col: usize,
+    pub(crate) text: String,
     /// The number of non-spacer grid cells, matching Zed's batching model.
     cell_count: usize,
-    style: GridTextStyle,
+    pub(crate) style: GridTextStyle,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-struct TerminalPalette {
-    foreground: Hsla,
-    background: Hsla,
-    selection: Hsla,
+pub(crate) struct TerminalPalette {
+    pub(crate) foreground: Hsla,
+    pub(crate) background: Hsla,
+    pub(crate) selection: Hsla,
 }
 
 #[derive(Clone, Copy)]
@@ -279,8 +281,8 @@ struct CursorPaint {
 }
 
 #[derive(Clone)]
-struct GridPaintData {
-    text_runs: Vec<BatchedTextRun>,
+pub(crate) struct GridPaintData {
+    pub(crate) text_runs: Vec<BatchedTextRun>,
     backgrounds: Vec<BackgroundRect>,
     selections: Vec<BackgroundRect>,
     cursor: Option<CursorPaint>,
@@ -448,8 +450,8 @@ impl TerminalDrawer {
             split_sizes: Rc::new(RefCell::new(Vec::new())),
             row_layout_cache: RefCell::new(HashMap::new()),
             image_registry: RefCell::new(HashMap::new()),
-            cell_width: 7.83,
-            cell_height: 17.,
+            cell_width: TERMINAL_CELL_WIDTH,
+            cell_height: TERMINAL_CELL_HEIGHT,
             scroll_remainder: HashMap::new(),
             selection_drag: SelectionDrag::default(),
             _focus_subscriptions: vec![focus_in, focus_out],
@@ -921,16 +923,7 @@ impl TerminalDrawer {
             move |bounds, (), window, cx| {
                 window.with_content_mask(Some(ContentMask { bounds }), |window| {
                     let scale_factor = window.scale_factor();
-                    let snap_down = |value: Pixels| {
-                        px((f32::from(value) * scale_factor).floor() / scale_factor)
-                    };
-                    let snap_up = |value: Pixels| {
-                        px((f32::from(value) * scale_factor).ceil() / scale_factor)
-                    };
-                    let origin = point(
-                        snap_down(bounds.origin.x),
-                        snap_down(bounds.origin.y),
-                    );
+                    let origin = snapped_grid_origin(bounds, scale_factor);
                     grid_bounds.borrow_mut().insert(
                         terminal_id,
                         GridGeometry {
@@ -942,139 +935,54 @@ impl TerminalDrawer {
                         },
                     );
 
-                    for background in paint_data
-                        .backgrounds
-                        .iter()
-                        .chain(&paint_data.selections)
-                    {
-                        let left = origin.x + px(background.start_col as f32 * cell_width);
-                        let right = origin.x
-                            + px(
-                                (background.start_col + background.cell_count) as f32 * cell_width,
-                            );
-                        let left = snap_down(left);
-                        let background_bounds = Bounds::new(
-                            point(
-                                left,
-                                origin.y + px(background.row as f32 * cell_height),
-                            ),
-                            size(snap_up(right) - left, px(cell_height)),
-                        );
-                        window.paint_quad(fill(background_bounds, background.color));
-                    }
-
-                    let physical_cell_width = cell_width * scale_factor;
-                    let physical_cell_height = cell_height * scale_factor;
-                    let physical_origin_x = f32::from(origin.x) * scale_factor;
-                    let physical_origin_y = f32::from(origin.y) * scale_factor;
-                    let viewport = OverlayViewport {
-                        cell_width: physical_cell_width,
-                        cell_height: physical_cell_height,
-                        origin_x: physical_origin_x,
-                        origin_y: physical_origin_y,
-                        history_size,
-                        display_offset,
-                        screen_lines: rows.min(i64::MAX as usize) as i64,
-                    };
-                    let clip = (
-                        physical_origin_x,
-                        physical_origin_y,
-                        physical_origin_x + cols as f32 * physical_cell_width,
-                        physical_origin_y + rows as f32 * physical_cell_height,
-                    );
-                    let graphic_overlays = layout_graphic_overlays(
-                        &atlas_placements,
-                        &kitty_placements,
-                        &kitty_virtual_placements,
-                        &virtual_placeholder_paints,
-                        &graphic_images,
-                        &viewport,
-                        clip,
-                    );
-                    paint_graphic_overlays(
+                    let (cursor_bounds, graphic_overlays) = paint_terminal_grid(
+                        bounds,
                         window,
-                        &graphic_overlays,
-                        &graphic_images,
-                        scale_factor,
-                        false,
+                        cx,
+                        &paint_data,
+                        palette,
+                        cell_width,
+                        cell_height,
+                        marked_text.is_none(),
+                        |origin, scale_factor, window| {
+                            let physical_cell_width = cell_width * scale_factor;
+                            let physical_cell_height = cell_height * scale_factor;
+                            let physical_origin_x = f32::from(origin.x) * scale_factor;
+                            let physical_origin_y = f32::from(origin.y) * scale_factor;
+                            let viewport = OverlayViewport {
+                                cell_width: physical_cell_width,
+                                cell_height: physical_cell_height,
+                                origin_x: physical_origin_x,
+                                origin_y: physical_origin_y,
+                                history_size,
+                                display_offset,
+                                screen_lines: rows.min(i64::MAX as usize) as i64,
+                            };
+                            let clip = (
+                                physical_origin_x,
+                                physical_origin_y,
+                                physical_origin_x + cols as f32 * physical_cell_width,
+                                physical_origin_y + rows as f32 * physical_cell_height,
+                            );
+                            let overlays = layout_graphic_overlays(
+                                &atlas_placements,
+                                &kitty_placements,
+                                &kitty_virtual_placements,
+                                &virtual_placeholder_paints,
+                                &graphic_images,
+                                &viewport,
+                                clip,
+                            );
+                            paint_graphic_overlays(
+                                window,
+                                &overlays,
+                                &graphic_images,
+                                scale_factor,
+                                false,
+                            );
+                            overlays
+                        },
                     );
-
-                    let cursor_bounds = paint_data.cursor.map(|cursor| {
-                        Bounds::new(
-                            point(
-                                origin.x + px(cursor.start_col as f32 * cell_width),
-                                origin.y + px(cursor.row as f32 * cell_height),
-                            ),
-                            size(px(cursor.cell_count as f32 * cell_width), px(cell_height)),
-                        )
-                    });
-                    if marked_text.is_none()
-                        && let Some(cursor) = paint_data.cursor.filter(|cursor| cursor.visible)
-                        && let Some(cursor_bounds) = cursor_bounds
-                    {
-                        match (cursor.focused, cursor.shape) {
-                            (false, _) => {
-                                let t = px(1.);
-                                window.paint_quad(fill(Bounds::new(cursor_bounds.origin, size(cursor_bounds.size.width, t)), cursor.color));
-                                window.paint_quad(fill(Bounds::new(point(cursor_bounds.left(), cursor_bounds.bottom() - t), size(cursor_bounds.size.width, t)), cursor.color));
-                                window.paint_quad(fill(Bounds::new(cursor_bounds.origin, size(t, cursor_bounds.size.height)), cursor.color));
-                                window.paint_quad(fill(Bounds::new(point(cursor_bounds.right() - t, cursor_bounds.top()), size(t, cursor_bounds.size.height)), cursor.color));
-                            }
-                            (_, CursorShape::Beam) => window.paint_quad(fill(Bounds::new(cursor_bounds.origin, size(px(2.), cursor_bounds.size.height)), cursor.color)),
-                            (_, CursorShape::Underline) => window.paint_quad(fill(Bounds::new(point(cursor_bounds.left(), cursor_bounds.bottom() - px(2.)), size(cursor_bounds.size.width, px(2.))), cursor.color)),
-                            (_, CursorShape::Block) => window.paint_quad(fill(cursor_bounds, cursor.color)),
-                            (_, CursorShape::Hidden) => {}
-                        }
-                    }
-
-                    for run in &paint_data.text_runs {
-                        let mut run_font = terminal_font();
-                        run_font.weight = if run.style.bold {
-                            FontWeight::BOLD
-                        } else {
-                            FontWeight::NORMAL
-                        };
-                        run_font.style = if run.style.italic {
-                            FontStyle::Italic
-                        } else {
-                            FontStyle::Normal
-                        };
-                        let foreground = if run.style.cursor {
-                            terminal_color(run.style.bg, palette)
-                        } else {
-                            terminal_color(run.style.fg, palette)
-                        };
-                        let text_run = TextRun {
-                            len: run.text.len(),
-                            font: run_font,
-                            color: foreground,
-                            background_color: None,
-                            strikethrough: None,
-                            underline: run.style.underline.then_some(UnderlineStyle {
-                                thickness: px(1.),
-                                color: Some(foreground),
-                                wavy: run.style.underline_wavy,
-                            }),
-                        };
-                        let shaped = window.text_system().shape_line(
-                            run.text.clone().into(),
-                            px(FONT_SIZE),
-                            &[text_run],
-                            Some(px(cell_width)),
-                        );
-                        let position = point(
-                            origin.x + px(run.start_col as f32 * cell_width),
-                            origin.y + px(run.row as f32 * cell_height),
-                        );
-                        let _ = shaped.paint(
-                            position,
-                            px(cell_height),
-                            TextAlign::Left,
-                            None,
-                            window,
-                            cx,
-                        );
-                    }
 
                     if let Some(marked_text) = marked_text.as_ref().filter(|text| !text.is_empty())
                         && let Some(cursor_bounds) = cursor_bounds
@@ -1093,7 +1001,7 @@ impl TerminalDrawer {
                         };
                         let shaped = window.text_system().shape_line(
                             marked_text.clone().into(),
-                            px(FONT_SIZE),
+                            px(TERMINAL_FONT_SIZE),
                             &[ime_run],
                             None,
                         );
@@ -1621,7 +1529,7 @@ impl Render for TerminalDrawer {
         // vertical metrics of the same resolved face used by StyledText.
         let shaped_cell = window.text_system().shape_line(
             "MMMMMMMMMM".into(),
-            px(FONT_SIZE),
+            px(TERMINAL_FONT_SIZE),
             &[TextRun {
                 len: 10,
                 font: terminal_font(),
@@ -1635,7 +1543,7 @@ impl Render for TerminalDrawer {
         self.cell_width = f32::from(shaped_cell.width) / 10.;
         self.cell_height = f32::from(shaped_cell.ascent + shaped_cell.descent)
             .ceil()
-            .max(FONT_SIZE + 2.);
+            .max(TERMINAL_FONT_SIZE + 2.);
         let (tabs, active_id, active_split) = self
             .workspace_store
             .read(cx)
@@ -1916,7 +1824,7 @@ impl Render for TerminalDrawer {
             .size_full()
             .min_h_0()
             .font_family(TERMINAL_FONT_FAMILY)
-            .text_size(px(FONT_SIZE))
+            .text_size(px(TERMINAL_FONT_SIZE))
             .on_action(cx.listener(Self::on_terminal_copy))
             .on_action(cx.listener(Self::on_terminal_paste))
             .on_action(cx.listener(Self::on_terminal_select_all))
@@ -2016,8 +1924,145 @@ impl Render for TerminalDrawer {
     }
 }
 
-#[cfg(test)]
-fn layout_grid(
+fn snapped_grid_origin(bounds: Bounds<Pixels>, scale_factor: f32) -> Point<Pixels> {
+    let snap_down = |value: Pixels| px((f32::from(value) * scale_factor).floor() / scale_factor);
+    point(snap_down(bounds.origin.x), snap_down(bounds.origin.y))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn paint_terminal_grid<T>(
+    bounds: Bounds<Pixels>,
+    window: &mut Window,
+    cx: &mut App,
+    paint_data: &GridPaintData,
+    palette: TerminalPalette,
+    cell_width: f32,
+    cell_height: f32,
+    show_cursor: bool,
+    paint_underlay: impl FnOnce(Point<Pixels>, f32, &mut Window) -> T,
+) -> (Option<Bounds<Pixels>>, T) {
+    let scale_factor = window.scale_factor();
+    let snap_down = |value: Pixels| px((f32::from(value) * scale_factor).floor() / scale_factor);
+    let snap_up = |value: Pixels| px((f32::from(value) * scale_factor).ceil() / scale_factor);
+    let origin = snapped_grid_origin(bounds, scale_factor);
+
+    for background in paint_data.backgrounds.iter().chain(&paint_data.selections) {
+        let left = origin.x + px(background.start_col as f32 * cell_width);
+        let right =
+            origin.x + px((background.start_col + background.cell_count) as f32 * cell_width);
+        let left = snap_down(left);
+        let background_bounds = Bounds::new(
+            point(left, origin.y + px(background.row as f32 * cell_height)),
+            size(snap_up(right) - left, px(cell_height)),
+        );
+        window.paint_quad(fill(background_bounds, background.color));
+    }
+
+    let underlay = paint_underlay(origin, scale_factor, window);
+    let cursor_bounds = paint_data.cursor.map(|cursor| {
+        Bounds::new(
+            point(
+                origin.x + px(cursor.start_col as f32 * cell_width),
+                origin.y + px(cursor.row as f32 * cell_height),
+            ),
+            size(px(cursor.cell_count as f32 * cell_width), px(cell_height)),
+        )
+    });
+    if show_cursor
+        && let Some(cursor) = paint_data.cursor.filter(|cursor| cursor.visible)
+        && let Some(cursor_bounds) = cursor_bounds
+    {
+        match (cursor.focused, cursor.shape) {
+            (false, _) => {
+                let t = px(1.);
+                window.paint_quad(fill(
+                    Bounds::new(cursor_bounds.origin, size(cursor_bounds.size.width, t)),
+                    cursor.color,
+                ));
+                window.paint_quad(fill(
+                    Bounds::new(
+                        point(cursor_bounds.left(), cursor_bounds.bottom() - t),
+                        size(cursor_bounds.size.width, t),
+                    ),
+                    cursor.color,
+                ));
+                window.paint_quad(fill(
+                    Bounds::new(cursor_bounds.origin, size(t, cursor_bounds.size.height)),
+                    cursor.color,
+                ));
+                window.paint_quad(fill(
+                    Bounds::new(
+                        point(cursor_bounds.right() - t, cursor_bounds.top()),
+                        size(t, cursor_bounds.size.height),
+                    ),
+                    cursor.color,
+                ));
+            }
+            (_, CursorShape::Beam) => window.paint_quad(fill(
+                Bounds::new(
+                    cursor_bounds.origin,
+                    size(px(2.), cursor_bounds.size.height),
+                ),
+                cursor.color,
+            )),
+            (_, CursorShape::Underline) => window.paint_quad(fill(
+                Bounds::new(
+                    point(cursor_bounds.left(), cursor_bounds.bottom() - px(2.)),
+                    size(cursor_bounds.size.width, px(2.)),
+                ),
+                cursor.color,
+            )),
+            (_, CursorShape::Block) => window.paint_quad(fill(cursor_bounds, cursor.color)),
+            (_, CursorShape::Hidden) => {}
+        }
+    }
+
+    for run in &paint_data.text_runs {
+        let mut run_font = terminal_font();
+        run_font.weight = if run.style.bold {
+            FontWeight::BOLD
+        } else {
+            FontWeight::NORMAL
+        };
+        run_font.style = if run.style.italic {
+            FontStyle::Italic
+        } else {
+            FontStyle::Normal
+        };
+        let foreground = if run.style.cursor {
+            terminal_color(run.style.bg, palette)
+        } else {
+            terminal_color(run.style.fg, palette)
+        };
+        let text_run = TextRun {
+            len: run.text.len(),
+            font: run_font,
+            color: foreground,
+            background_color: None,
+            strikethrough: None,
+            underline: run.style.underline.then_some(UnderlineStyle {
+                thickness: px(1.),
+                color: Some(foreground),
+                wavy: run.style.underline_wavy,
+            }),
+        };
+        let shaped = window.text_system().shape_line(
+            run.text.clone().into(),
+            px(TERMINAL_FONT_SIZE),
+            &[text_run],
+            Some(px(cell_width)),
+        );
+        let position = point(
+            origin.x + px(run.start_col as f32 * cell_width),
+            origin.y + px(run.row as f32 * cell_height),
+        );
+        let _ = shaped.paint(position, px(cell_height), TextAlign::Left, None, window, cx);
+    }
+
+    (cursor_bounds, underlay)
+}
+
+pub(crate) fn layout_grid(
     state: &TermSnapshot,
     palette: TerminalPalette,
     composing: bool,
@@ -2876,13 +2921,13 @@ fn paint_graphic_overlay(
     );
 }
 
-fn terminal_font() -> gpui::Font {
+pub(crate) fn terminal_font() -> gpui::Font {
     let mut terminal_font = font(TERMINAL_FONT_FAMILY);
     terminal_font.features = FontFeatures::disable_ligatures();
     terminal_font
 }
 
-fn terminal_color(color: AnsiColor, palette: TerminalPalette) -> Hsla {
+pub(crate) fn terminal_color(color: AnsiColor, palette: TerminalPalette) -> Hsla {
     match color {
         AnsiColor::Named(
             NamedColor::Foreground | NamedColor::LightForeground | NamedColor::DimForeground,

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -222,6 +222,9 @@ settings:
   auto_open_task_panel:
     title: "Auto-open task panel"
     description: "Open the right-side plan and task panel automatically when steps appear."
+  live_command_panel:
+    title: "Live command panel"
+    description: "Automatically show command output while it runs, then hide the panel when it finishes."
   provider_updates:
     title: "Provider update checks"
     description: "Check for newer tcode and provider CLI versions on launch."

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -222,6 +222,9 @@ settings:
   auto_open_task_panel:
     title: "自动打开任务面板"
     description: "当出现步骤时自动打开右侧的计划和任务面板。"
+  live_command_panel:
+    title: "实时命令面板"
+    description: "命令执行时自动展开其面板并实时显示输出，完成后自动收起。"
   provider_updates:
     title: "提供方更新检查"
     description: "启动时检查 tcode 和提供方 CLI 的新版本。"


### PR DESCRIPTION
## Summary
- New setting **Live command panel** (default ON, stored inverted as `live_command_panel_disabled` so legacy settings files keep it enabled): while a command execution is running, its activity row auto-expands to show the live detail panel, and auto-collapses on completion. Manual expand/collapse for settled commands is unchanged.
- The command detail panel is now an embedded read-only mini terminal rendered by the same cell renderer as the terminal drawer: one seamless fixed-width (80-col, ≤16-row) panel — command pinned at the top (clamped to 4 rows with `…`), output tail filling the rest via natural terminal scrolling. Raw ANSI colors/styles now render properly instead of showing as literal escape text.

## Implementation notes
- `term`: minimally exposed the headless `GridEmulator` (`with_size`/`feed`/`snapshot`) — no PTY involved.
- `terminal_drawer`: extracted the cell-painting closure into a shared `paint_terminal_grid` (single copy of the paint logic); the drawer keeps input registration, IME, cursor, and graphics overlays exactly as before.
- `command_panel`: per-entry emulator cache — append-only output feeds only the new bytes; rewrites/shrinks rebuild from the last 32 KiB tail; trailing blank rows are trimmed so short commands stay short.
- Settings follow the existing inverted-boolean convention; en + zh-CN locale keys added (key-parity test covers both).

## Testing
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked` — all pass locally after rebasing onto main (includes new unit tests: ANSI green run color, 4-row command clamp, blank-row trimming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)