### PR TITLE
feat(subagents): mirror provider-native subagents as read-only sidebar child threads

### DIFF
--- a/crates/core/src/project.rs
+++ b/crates/core/src/project.rs
@@ -114,6 +114,11 @@ pub struct SessionMeta {
     /// Parent orchestrator thread for native child sessions.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_session_id: Option<String>,
+    /// Set when this session mirrors a provider-native subagent transcript.
+    /// Value is the parent-timeline Subagent item id (reattach key). Mirror
+    /// sessions are read-only: no composer, no provider process.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native_subagent: Option<String>,
     /// Whether this session receives the tcode_orchestrate MCP registration.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub orchestrate_enabled: bool,
@@ -148,6 +153,7 @@ impl SessionMeta {
             interaction_mode: InteractionMode::default(),
             acp_agent_id: None,
             parent_session_id: None,
+            native_subagent: None,
             orchestrate_enabled: false,
             archive_on_complete: false,
             result_max_chars: None,

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -456,10 +456,6 @@ pub struct Timeline {
     /// diff payloads. Updates use [`Arc::make_mut`], preserving the value
     /// semantics of a cloned [`Timeline`] while keeping read snapshots cheap.
     pub entries: Vec<Arc<TimelineEntry>>,
-    /// Child activity grouped by the top-level subagent spawn item id.
-    pub children: HashMap<String, Vec<Arc<TimelineEntry>>>,
-    /// Parent ids whose child activity exceeded the in-memory progress cap.
-    truncated_children: HashSet<String>,
     /// One entry per turn ("Work Log" section), in order.
     pub turns: Vec<TurnMeta>,
     pub turn_running: bool,
@@ -498,14 +494,6 @@ pub struct Timeline {
 }
 
 impl Timeline {
-    pub fn children(&self, parent_id: &str) -> &[Arc<TimelineEntry>] {
-        self.children.get(parent_id).map_or(&[], Vec::as_slice)
-    }
-
-    pub fn children_truncated(&self, parent_id: &str) -> bool {
-        self.truncated_children.contains(parent_id)
-    }
-
     /// Fold a whole event sequence (replay path). Accepts either bare
     /// [`AgentEvent`]s (ts unknown) or timestamped [`StoredEvent`]s.
     pub fn fold_events(events: impl IntoIterator<Item = impl Into<StoredEvent>>) -> Self {
@@ -947,12 +935,6 @@ impl Timeline {
         };
 
         self.entries.retain(|entry| entry.turn < target_turn);
-        self.children.retain(|_, entries| {
-            entries.retain(|entry| entry.turn < target_turn);
-            !entries.is_empty()
-        });
-        self.truncated_children
-            .retain(|parent_id| self.children.contains_key(parent_id));
         self.turns.truncate(target_turn);
         self.current_turn = self.turns.len().checked_sub(1);
         self.tool_clock = ToolClock::default();
@@ -969,12 +951,8 @@ impl Timeline {
         self.plan_explanation = None;
         self.usage = None;
         self.last_turn_status = self.turns.last().and_then(|turn| turn.status);
-        self.committed_file_change_items.retain(|item_id| {
-            self.entries
-                .iter()
-                .chain(self.children.values().flatten())
-                .any(|entry| entry.id == *item_id)
-        });
+        self.committed_file_change_items
+            .retain(|item_id| self.entries.iter().any(|entry| entry.id == *item_id));
     }
 
     /// The current open turn, creating one if none exists.
@@ -1012,8 +990,7 @@ impl Timeline {
         {
             return;
         }
-        let entries = self.entries.iter().chain(self.children.values().flatten());
-        let fragments = entries.filter_map(|entry| {
+        let fragments = self.entries.iter().filter_map(|entry| {
             if entry.turn != turn || !self.committed_file_change_items.contains(&entry.id) {
                 return None;
             }
@@ -1034,36 +1011,17 @@ impl Timeline {
     fn item_turn(&self, item_id: &str) -> Option<usize> {
         self.entries
             .iter()
-            .chain(self.children.values().flatten())
             .find(|entry| entry.id == item_id)
             .map(|entry| entry.turn)
     }
 
     fn upsert_item(&mut self, ts: Option<u64>, item: &ThreadItem) {
-        let mut incoming = EntryContent::Item(item.content.clone());
-        if let Some(parent_id) = &item.parent_item_id {
-            let turn = self.ensure_turn(ts);
-            let children = self.children.entry(parent_id.clone()).or_default();
-            if let Some(entry) = children.iter_mut().find(|entry| entry.id == item.id) {
-                let entry = Arc::make_mut(entry);
-                entry.content = merge_content(
-                    std::mem::replace(&mut entry.content, incoming.clone()),
-                    incoming,
-                );
-            } else {
-                children.push(Arc::new(TimelineEntry {
-                    id: item.id.clone(),
-                    content: incoming,
-                    ts,
-                    turn,
-                }));
-                if children.len() > 200 {
-                    children.remove(0);
-                    self.truncated_children.insert(parent_id.clone());
-                }
-            }
+        // Runtime reroutes native-subagent child items into mirror sessions;
+        // legacy logs still contain them inline — drop, never render.
+        if item.parent_item_id.is_some() {
             return;
         }
+        let mut incoming = EntryContent::Item(item.content.clone());
         if let Some(entry) = self.entries.iter_mut().find(|e| e.id == item.id) {
             let entry = Arc::make_mut(entry);
             entry.content = merge_content(
@@ -1598,9 +1556,8 @@ mod tests {
 
         let change_set = timeline.turns[0].changes.as_ref().unwrap();
         assert_eq!(change_set.completeness, ChangeCompleteness::Partial);
-        assert_eq!(change_set.changes.len(), 2);
+        assert_eq!(change_set.changes.len(), 1);
         assert_eq!(change_set.changes[0].path, "src/lib.rs");
-        assert_eq!(change_set.changes[1].path, "src/child.rs");
     }
 
     #[test]
@@ -2653,7 +2610,7 @@ mod tests {
     }
 
     #[test]
-    fn subagent_children_fold_below_spawn_only() {
+    fn parented_items_are_dropped_while_subagent_spawn_status_merges() {
         let spawn = ThreadItem {
             id: "spawn".into(),
             parent_item_id: None,
@@ -2694,31 +2651,12 @@ mod tests {
             EntryContent::Item(ItemContent::Subagent { status: ItemStatus::Completed, summary: Some(summary), .. })
                 if summary == "pong"
         ));
-        assert_eq!(timeline.children("spawn").len(), 1);
-        assert!(matches!(
-            &timeline.children("spawn")[0].content,
-            EntryContent::Item(ItemContent::UserMessage { text, .. }) if text == "ping"
-        ));
-    }
-
-    #[test]
-    fn subagent_child_cap_records_actual_truncation() {
-        let mut timeline = Timeline::default();
-        for index in 0..=200 {
-            timeline.apply_at(
-                None,
-                &AgentEvent::ItemCompleted(ThreadItem {
-                    id: format!("spawn:child-{index}"),
-                    parent_item_id: Some("spawn".into()),
-                    content: ItemContent::AssistantMessage {
-                        text: index.to_string(),
-                    },
-                }),
-            );
-        }
-        assert_eq!(timeline.children("spawn").len(), 200);
-        assert!(timeline.children_truncated("spawn"));
-        assert_eq!(timeline.children("spawn")[0].id, "spawn:child-1");
+        assert!(
+            timeline
+                .entries
+                .iter()
+                .all(|entry| entry.id != "spawn:user-1")
+        );
     }
 
     #[test]

--- a/crates/runtime/src/app/events.rs
+++ b/crates/runtime/src/app/events.rs
@@ -8,6 +8,10 @@ impl AppState {
             serde_json::to_string(&event).unwrap_or_else(|_| "<unserializable>".into())
         );
 
+        if self.reroute_native_subagent_event(session_id, &event, cx) {
+            return;
+        }
+
         match &event {
             AgentEvent::RewindFailed { error, .. } => {
                 self.pending_native_rewinds.remove(session_id);
@@ -39,6 +43,7 @@ impl AppState {
             AgentEvent::SessionClosed { reason } => {
                 self.pending_native_rewinds.remove(session_id);
                 self.clear_approvals(session_id);
+                self.clear_native_subagent_work(session_id, cx);
                 self.close_orchestrator_children(session_id, cx);
                 let is_active = self.active_session_id() == Some(session_id);
                 if !is_active {

--- a/crates/runtime/src/app/mod.rs
+++ b/crates/runtime/src/app/mod.rs
@@ -10,9 +10,9 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use agent::{
     AgentError, AgentEvent, ApprovalDecision, ApprovalMode, Attachment, InteractionMode,
-    ItemContent, LaunchEnv, ModelSpec, OptionDescriptor, OptionDescriptors, OptionSelection,
-    PlanResolution, ProviderCommand, ProviderKind, RewindMode, SessionCommand, SessionHandle,
-    SessionOptions, ThreadItem, TurnOptions, TurnStatus, list_models,
+    ItemContent, ItemStatus, LaunchEnv, ModelSpec, OptionDescriptor, OptionDescriptors,
+    OptionSelection, PlanResolution, ProviderCommand, ProviderKind, RewindMode, SessionCommand,
+    SessionHandle, SessionOptions, ThreadItem, TurnOptions, TurnStatus, list_models,
 };
 use base64::Engine as _;
 use serde::{Deserialize, Serialize};
@@ -251,6 +251,7 @@ mod send;
 mod sessions;
 mod snapshots;
 mod store_write;
+mod subagents;
 mod terminals;
 
 #[cfg(test)]
@@ -332,6 +333,8 @@ pub struct AppState {
     /// Kept here (rather than in persisted session metadata) because the
     /// provider response is the only authority that can complete it.
     pending_native_rewinds: HashMap<String, (String, RewindMode)>,
+    /// Provider-native subagent item ids mapped to their read-only mirror sessions.
+    native_subagent_sessions: HashMap<(String, String), String>,
     pub settings: Settings,
     pub providers: ProviderCatalog,
     terminal_preferences_path: PathBuf,
@@ -457,6 +460,7 @@ impl AppState {
             terminal_workspaces: HashMap::new(),
             terminal_registry,
             pending_native_rewinds: HashMap::new(),
+            native_subagent_sessions: HashMap::new(),
             settings,
             providers: ProviderCatalog::new(model_catalogs, provider_secret_names),
             terminal_preferences_path,

--- a/crates/runtime/src/app/orchestrate.rs
+++ b/crates/runtime/src/app/orchestrate.rs
@@ -630,7 +630,9 @@ impl AppState {
         self.sessions
             .iter()
             .find(|meta| {
-                meta.id == thread_id && meta.parent_session_id.as_deref() == Some(parent_id)
+                meta.id == thread_id
+                    && meta.parent_session_id.as_deref() == Some(parent_id)
+                    && meta.native_subagent.is_none()
             })
             .ok_or_else(|| "unknown thread or not a child of this parent".into())
     }
@@ -688,6 +690,7 @@ impl AppState {
             .sessions
             .iter()
             .filter(|meta| meta.parent_session_id.as_deref() == Some(&parent_id))
+            .filter(|meta| meta.native_subagent.is_none())
             .filter(|meta| thread_id.as_ref().is_none_or(|id| id == &meta.id))
             .cloned()
             .collect();

--- a/crates/runtime/src/app/send.rs
+++ b/crates/runtime/src/app/send.rs
@@ -198,6 +198,15 @@ impl AppState {
         attachments: Vec<Attachment>,
         cx: &mut HostCx,
     ) {
+        if self
+            .residents
+            .active
+            .as_ref()
+            .is_some_and(|active| active.meta.native_subagent.is_some())
+        {
+            log::warn!("refusing to send to a read-only native subagent mirror session");
+            return;
+        }
         if self.relay_confirmation().is_some() {
             log::warn!("send deferred until the pending conversation relay is confirmed");
             return;

--- a/crates/runtime/src/app/subagents.rs
+++ b/crates/runtime/src/app/subagents.rs
@@ -1,0 +1,196 @@
+use super::*;
+
+impl AppState {
+    /// Reroute provider-native subagent transcript items into read-only mirror
+    /// sessions. Returns true when the event was consumed instead of entering
+    /// the parent session's ordinary event path.
+    pub(super) fn reroute_native_subagent_event(
+        &mut self,
+        parent_session_id: &str,
+        event: &AgentEvent,
+        cx: &mut HostCx,
+    ) -> bool {
+        let Some(item) = lifecycle_item(event) else {
+            return false;
+        };
+
+        // Check child ownership before content: Codex child transcript items can
+        // themselves be Subagent-shaped, but they remain plain mirror content.
+        if let Some(parent_item_id) = item.parent_item_id.as_deref() {
+            let mirror_id =
+                self.ensure_native_subagent_mirror(parent_session_id, parent_item_id, None, cx);
+            let Some(mirror_id) = mirror_id else {
+                log::warn!(
+                    "dropping native subagent child item {}: parent session {} is missing",
+                    item.id,
+                    parent_session_id
+                );
+                return true;
+            };
+            self.record_event(&mirror_id, &strip_parent_item_id(event), cx);
+            return true;
+        }
+
+        let ItemContent::Subagent {
+            agent_type,
+            description,
+            status,
+            ..
+        } = &item.content
+        else {
+            return false;
+        };
+        let details = (agent_type.as_str(), description.as_str());
+        if let Some(mirror_id) =
+            self.ensure_native_subagent_mirror(parent_session_id, &item.id, Some(details), cx)
+        {
+            let in_progress = matches!(status, ItemStatus::InProgress);
+            let title = mirror_title(agent_type, description);
+            let meta = self.resident_mut(&mirror_id).map(|mirror| {
+                mirror.turn_in_flight = in_progress;
+                let title_changed = mirror.meta.title == "subagent" && mirror.meta.title != title;
+                if title_changed {
+                    mirror.meta.title = title;
+                }
+                if !in_progress || title_changed {
+                    mirror.meta.updated_at = now_secs();
+                    Some(mirror.meta.clone())
+                } else {
+                    None
+                }
+            });
+            if let Some(meta) = meta.flatten() {
+                self.persist_meta(&meta, cx);
+            }
+        }
+        false
+    }
+
+    fn ensure_native_subagent_mirror(
+        &mut self,
+        parent_session_id: &str,
+        subagent_item_id: &str,
+        details: Option<(&str, &str)>,
+        cx: &mut HostCx,
+    ) -> Option<String> {
+        let key = (parent_session_id.to_string(), subagent_item_id.to_string());
+        if let Some(id) = self.native_subagent_sessions.get(&key).cloned() {
+            return Some(id);
+        }
+
+        if let Some(meta) = self
+            .sessions
+            .iter()
+            .find(|meta| {
+                meta.parent_session_id.as_deref() == Some(parent_session_id)
+                    && meta.native_subagent.as_deref() == Some(subagent_item_id)
+            })
+            .cloned()
+        {
+            let id = meta.id.clone();
+            if self.resident(&id).is_none() {
+                self.load_background_session(meta, cx);
+            }
+            self.native_subagent_sessions.insert(key, id.clone());
+            return Some(id);
+        }
+
+        let parent = self.find_meta(parent_session_id)?.clone();
+        let mut meta = SessionMeta::new(parent.provider, parent.cwd.clone(), parent.model.clone());
+        meta.project_id = parent.project_id.clone();
+        meta.profile_id = parent.profile_id.clone();
+        meta.acp_agent_id = parent.acp_agent_id.clone();
+        meta.parent_session_id = Some(parent.id.clone());
+        meta.native_subagent = Some(subagent_item_id.to_string());
+        meta.title = details.map_or_else(
+            || "subagent".to_string(),
+            |(agent_type, description)| mirror_title(agent_type, description),
+        );
+
+        self.enqueue_store_write(
+            StoreWrite::UpsertMeta {
+                meta: Box::new(meta.clone()),
+                initial: true,
+            },
+            cx,
+        );
+        self.upsert_session_in_memory(meta.clone());
+
+        let id = meta.id.clone();
+        let commands = self.cached_provider_commands(meta.provider, meta.acp_agent_id.as_deref());
+        let mut mirror = Self::build_draft_session(
+            meta.project_id.clone().unwrap_or_default(),
+            meta.cwd.clone(),
+            meta.provider,
+            meta.model.clone(),
+            meta.acp_agent_id.clone(),
+            commands,
+        );
+        mirror.meta = meta;
+        mirror.draft = false;
+        mirror.turn_in_flight = true;
+        self.residents.parked.insert(id.clone(), mirror);
+        self.native_subagent_sessions.insert(key, id.clone());
+        Some(id)
+    }
+
+    pub(super) fn clear_native_subagent_work(&mut self, parent_session_id: &str, cx: &mut HostCx) {
+        let mirror_ids: Vec<_> = self
+            .sessions
+            .iter()
+            .filter(|meta| {
+                meta.parent_session_id.as_deref() == Some(parent_session_id)
+                    && meta.native_subagent.is_some()
+            })
+            .map(|meta| meta.id.clone())
+            .collect();
+        for mirror_id in mirror_ids {
+            let meta = self.resident_mut(&mirror_id).and_then(|mirror| {
+                if !mirror.turn_in_flight {
+                    return None;
+                }
+                mirror.turn_in_flight = false;
+                mirror.meta.updated_at = now_secs();
+                Some(mirror.meta.clone())
+            });
+            if let Some(meta) = meta {
+                self.persist_meta(&meta, cx);
+            }
+        }
+    }
+}
+
+fn lifecycle_item(event: &AgentEvent) -> Option<&ThreadItem> {
+    match event {
+        AgentEvent::ItemStarted(item)
+        | AgentEvent::ItemUpdated(item)
+        | AgentEvent::ItemCompleted(item) => Some(item),
+        _ => None,
+    }
+}
+
+fn strip_parent_item_id(event: &AgentEvent) -> AgentEvent {
+    let strip = |item: &ThreadItem| {
+        let mut item = item.clone();
+        item.parent_item_id = None;
+        item
+    };
+    match event {
+        AgentEvent::ItemStarted(item) => AgentEvent::ItemStarted(strip(item)),
+        AgentEvent::ItemUpdated(item) => AgentEvent::ItemUpdated(strip(item)),
+        AgentEvent::ItemCompleted(item) => AgentEvent::ItemCompleted(strip(item)),
+        _ => unreachable!("only lifecycle events are rerouted"),
+    }
+}
+
+fn mirror_title(agent_type: &str, description: &str) -> String {
+    let first_line = description.lines().next().unwrap_or_default().trim();
+    let title = format!("{agent_type}: {first_line}");
+    let mut chars = title.chars();
+    let truncated: String = chars.by_ref().take(60).collect();
+    if chars.next().is_some() {
+        format!("{}…", truncated.trim_end())
+    } else {
+        truncated
+    }
+}

--- a/crates/runtime/src/app/tests.rs
+++ b/crates/runtime/src/app/tests.rs
@@ -7,6 +7,132 @@ use tcode_core::settings::{SettingsPatch, ThemeMode};
 use tcode_protocol::{Command, CommandResponse, HostMessage};
 
 #[test]
+fn provider_native_subagent_events_create_and_feed_read_only_mirror_session() {
+    let cx = &mut TestAppContext::default();
+    let test_store = TestStore::new("tcode-native-subagent-mirror-test");
+    let state = cx.new_entity(|_| AppState::new((*test_store).clone()));
+
+    state.update(cx, |state, cx| {
+        let mut parent_meta = SessionMeta::new(
+            ProviderKind::Codex,
+            PathBuf::from("/tmp/native-subagent-parent"),
+            Some("gpt-test".into()),
+        );
+        parent_meta.id = "parent".into();
+        parent_meta.project_id = Some("project".into());
+        state.sessions.push(parent_meta.clone());
+        state.residents.active = Some(ActiveSession::new(parent_meta, false, Vec::new()));
+
+        state.on_event(
+            "parent",
+            AgentEvent::ItemStarted(ThreadItem {
+                id: "spawn-1".into(),
+                parent_item_id: None,
+                content: ItemContent::Subagent {
+                    agent_type: "explorer".into(),
+                    description: "Inspect event routing\nand report".into(),
+                    status: ItemStatus::InProgress,
+                    summary: None,
+                },
+            }),
+            cx,
+        );
+
+        let mirror = state
+            .sessions
+            .iter()
+            .find(|meta| meta.native_subagent.as_deref() == Some("spawn-1"))
+            .cloned()
+            .expect("native subagent mirror metadata");
+        assert_eq!(mirror.parent_session_id.as_deref(), Some("parent"));
+        assert_eq!(mirror.title, "explorer: Inspect event routing");
+        assert!(state.resident(&mirror.id).unwrap().has_work());
+
+        state.on_event(
+            "parent",
+            AgentEvent::ItemCompleted(ThreadItem {
+                id: "child-answer".into(),
+                parent_item_id: Some("spawn-1".into()),
+                content: ItemContent::AssistantMessage {
+                    text: "routed transcript".into(),
+                },
+            }),
+            cx,
+        );
+        let mirror_timeline = &state.resident(&mirror.id).unwrap().timeline;
+        assert!(mirror_timeline.entries.iter().any(|entry| {
+            matches!(
+                &entry.content,
+                EntryContent::Item(ItemContent::AssistantMessage { text })
+                    if entry.id == "child-answer" && text == "routed transcript"
+            )
+        }));
+        assert_eq!(state.resident("parent").unwrap().timeline.entries.len(), 1);
+
+        state.on_event(
+            "parent",
+            AgentEvent::ItemCompleted(ThreadItem {
+                id: "spawn-1".into(),
+                parent_item_id: None,
+                content: ItemContent::Subagent {
+                    agent_type: "explorer".into(),
+                    description: "Inspect event routing\nand report".into(),
+                    status: ItemStatus::Completed,
+                    summary: Some("routing verified".into()),
+                },
+            }),
+            cx,
+        );
+        assert!(!state.resident(&mirror.id).unwrap().has_work());
+        assert!(matches!(
+            &state.resident("parent").unwrap().timeline.entries[0].content,
+            EntryContent::Item(ItemContent::Subagent {
+                status: ItemStatus::Completed,
+                summary: Some(summary),
+                ..
+            }) if summary == "routing verified"
+        ));
+
+        let (reply, response) = smol::channel::bounded(1);
+        state.handle_orchestrate_status("parent".into(), None, reply, cx);
+        assert_eq!(response.try_recv().unwrap().unwrap(), serde_json::json!([]));
+    });
+    cx.run_until_parked();
+
+    state.update(cx, |state, _| {
+        let mirror = state
+            .sessions
+            .iter()
+            .find(|meta| meta.native_subagent.as_deref() == Some("spawn-1"))
+            .unwrap();
+        let mirror_events = state.store.read_events(&mirror.id);
+        assert!(mirror_events.iter().any(|stored| matches!(
+            &stored.event,
+            AgentEvent::ItemCompleted(ThreadItem {
+                id,
+                parent_item_id: None,
+                ..
+            }) if id == "child-answer"
+        )));
+        let parent_events = state.store.read_events("parent");
+        assert!(parent_events.iter().any(|stored| matches!(
+            &stored.event,
+            AgentEvent::ItemCompleted(ThreadItem {
+                id,
+                parent_item_id: None,
+                content: ItemContent::Subagent { .. },
+            }) if id == "spawn-1"
+        )));
+        assert!(parent_events.iter().all(|stored| match &stored.event {
+            AgentEvent::ItemStarted(item)
+            | AgentEvent::ItemUpdated(item)
+            | AgentEvent::ItemCompleted(item) => item.parent_item_id.is_none(),
+            _ => true,
+        }));
+    });
+}
+
+#[test]
 fn settings_patch_preserves_concurrently_changed_other_field() {
     let cx = &mut TestAppContext::default();
     let test_store = TestStore::new("tcode-dispatch-settings-seam-test");

--- a/crates/services/src/session_search.rs
+++ b/crates/services/src/session_search.rs
@@ -140,11 +140,7 @@ impl SessionSearch {
 pub fn extract_searchable_entries(events: &[StoredEvent]) -> Vec<SearchableEntry> {
     let timeline = Timeline::fold_events(events.iter().cloned());
     let mut entries = Vec::new();
-    for entry in timeline
-        .entries
-        .iter()
-        .chain(timeline.children.values().flatten())
-    {
+    for entry in &timeline.entries {
         let text = match &entry.content {
             EntryContent::Item(content) => searchable_item_text(content),
             EntryContent::Steer {

--- a/crates/services/src/store.rs
+++ b/crates/services/src/store.rs
@@ -688,17 +688,21 @@ mod tests {
         });
         let meta: SessionMeta = serde_json::from_value(legacy).unwrap();
         assert_eq!(meta.parent_session_id, None);
+        assert_eq!(meta.native_subagent, None);
         assert!(!meta.orchestrate_enabled);
         let json = serde_json::to_string(&meta).unwrap();
         assert!(!json.contains("parent_session_id"));
+        assert!(!json.contains("native_subagent"));
         assert!(!json.contains("orchestrate_enabled"));
 
         let mut meta = meta;
         meta.parent_session_id = Some("parent".into());
+        meta.native_subagent = Some("spawn-1".into());
         meta.orchestrate_enabled = true;
         let back: SessionMeta =
             serde_json::from_str(&serde_json::to_string(&meta).unwrap()).unwrap();
         assert_eq!(back.parent_session_id.as_deref(), Some("parent"));
+        assert_eq!(back.native_subagent.as_deref(), Some("spawn-1"));
         assert!(back.orchestrate_enabled);
     }
 

--- a/crates/ui/src/chat/components/subagent.rs
+++ b/crates/ui/src/chat/components/subagent.rs
@@ -9,24 +9,18 @@ use gpui::{
     Role, SharedString, StatefulInteractiveElement as _, Styled as _, Window, div,
     prelude::FluentBuilder as _, px,
 };
-use gpui_base::{StyledExt as _, h_flex, v_flex};
+use gpui_base::{StyledExt as _, h_flex};
 
 use agent::{ItemContent, ItemStatus};
 use tcode_core::session::{EntryContent, TimelineEntry};
 
-use super::super::model::{displayed_error_text, one_line};
+use super::super::model::one_line;
 
-pub(crate) struct SubagentState {
-    pub(crate) expanded: bool,
-    pub(crate) truncated: bool,
-    pub(crate) duration: Option<String>,
-}
+pub(crate) type ClickHandler = Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>;
 
 pub(crate) fn subagent_row(
     entry: &TimelineEntry,
-    state: SubagentState,
-    children: Vec<AnyElement>,
-    on_toggle: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    on_open: Option<ClickHandler>,
     cx: &App,
 ) -> AnyElement {
     let EntryContent::Item(ItemContent::Subagent {
@@ -43,13 +37,7 @@ pub(crate) fn subagent_row(
         debug_assert!(false, "subagent row requires subagent timeline content");
         return div().into_any_element();
     };
-    let SubagentState {
-        expanded,
-        truncated,
-        duration,
-    } = state;
     let muted = cx.theme().muted_foreground;
-    let finished = !matches!(status, ItemStatus::InProgress);
     let row_label = crate::tr!(
         "chat.subagent_row",
         agent = agent_type.clone(),
@@ -61,8 +49,6 @@ pub(crate) fn subagent_row(
             .xsmall()
             .color(cx.theme().primary)
             .into_any_element(),
-        // The row is a surface, not a trace, so its outcome may carry color:
-        // green settled, red failed — the task-row badge pair.
         ItemStatus::Completed => h_flex()
             .h(px(22.))
             .px_2()
@@ -92,143 +78,59 @@ pub(crate) fn subagent_row(
             .child(crate::tr!("chat.subagent_failed"))
             .into_any_element(),
     };
-    let mut row = crate::material::accessible_clickable(
-        h_flex(),
-        SharedString::from(format!("subagent-row-{}", entry.id)),
-        Role::Button,
-        row_label,
-        cx,
-    )
-    .aria_expanded(expanded)
-    .w_full()
-    .h(px(44.))
-    .min_w_0()
-    .gap_2()
-    .items_center()
-    .px_3()
-    .rounded_full()
-    .border_1()
-    .border_color(cx.theme().border)
-    .bg(crate::material::content_surface(cx))
-    .text_size(px(13.))
-    .cursor_pointer()
-    .hover(|row| row.bg(cx.theme().accent))
-    .on_click(on_toggle)
-    .child(lifecycle)
-    .child(div().flex_none().font_medium().child(agent_type.clone()))
-    .child(
-        div()
-            .min_w_0()
-            .flex_1()
-            .overflow_hidden()
-            .text_ellipsis()
-            .text_color(muted)
-            .child(one_line(description)),
-    )
-    .when_some(duration, |row, duration| {
-        row.child(
+    let row = h_flex()
+        .w_full()
+        .h(px(44.))
+        .min_w_0()
+        .gap_2()
+        .items_center()
+        .px_3()
+        .rounded_full()
+        .border_1()
+        .border_color(cx.theme().border)
+        .bg(crate::material::content_surface(cx))
+        .text_size(px(13.))
+        .child(lifecycle)
+        .child(div().flex_none().font_medium().child(agent_type.clone()))
+        .child(
             div()
-                .flex_none()
-                .font_family(cx.theme().mono_font_family.clone())
-                .text_size(px(11.))
-                .text_color(muted)
-                // Baseline compensation beside the 13px row text (see
-                // work_log.rs — flex can't baseline-align text boxes).
-                .relative()
-                .top(px(1.))
-                .child(duration),
-        )
-    });
-    if finished && let Some(summary) = summary.as_deref().filter(|summary| !summary.is_empty()) {
-        row = row.child(
-            div()
-                .max_w(px(180.))
                 .min_w_0()
+                .flex_1()
                 .overflow_hidden()
                 .text_ellipsis()
                 .text_color(muted)
-                .font_family(cx.theme().mono_font_family.clone())
-                .text_size(px(11.5))
-                .child(one_line(summary)),
+                .child(one_line(description)),
+        )
+        .when_some(
+            summary.as_deref().filter(|summary| !summary.is_empty()),
+            |row, summary| {
+                row.child(
+                    div()
+                        .max_w(px(180.))
+                        .min_w_0()
+                        .overflow_hidden()
+                        .text_ellipsis()
+                        .text_color(muted)
+                        .font_family(cx.theme().mono_font_family.clone())
+                        .text_size(px(11.5))
+                        .child(one_line(summary)),
+                )
+            },
         );
-    }
-    row = row.child(Icon::new(chevron(expanded)).xsmall().text_color(muted));
 
-    let mut block = v_flex().w_full().gap_1().child(row);
-    if expanded {
-        // The same hairline rail the activity drill-downs hang on.
-        let mut nested = v_flex()
-            .w_full()
-            .gap_1()
-            .ml_2()
-            .pl(px(14.))
-            .py_0p5()
-            .border_l_1()
-            .border_color(cx.theme().border);
-        if truncated {
-            nested = nested.child(
-                div()
-                    .text_size(px(11.))
-                    .text_color(muted)
-                    .child(crate::tr!("chat.earlier_steps_truncated")),
-            );
-        }
-        nested = nested.children(children);
-        block = block.child(nested);
-    }
-    block.into_any_element()
-}
-
-pub(crate) fn subagent_child(
-    entry: &TimelineEntry,
-    fallback: Option<AnyElement>,
-    cx: &App,
-) -> AnyElement {
-    let muted = cx.theme().muted_foreground;
-    match &entry.content {
-        EntryContent::Item(ItemContent::UserMessage { text, .. })
-        | EntryContent::Steer { text, .. } => h_flex()
-            .w_full()
-            .justify_end()
-            .child(
-                div()
-                    .max_w_3_4()
-                    .px(px(10.))
-                    .py(px(6.))
-                    .rounded_lg()
-                    .bg(cx.theme().muted)
-                    .text_size(px(13.))
-                    .line_height(px(18.2))
-                    .text_color(cx.theme().foreground)
-                    .child(text.clone()),
-            )
-            .into_any_element(),
-        EntryContent::Item(ItemContent::AssistantMessage { text }) => div()
-            .w_full()
-            .text_size(px(13.5))
-            .line_height(px(21.))
-            .text_color(cx.theme().foreground)
-            .child(text.clone())
-            .into_any_element(),
-        EntryContent::Error { .. } | EntryContent::ProviderStartError { .. } => div()
-            .w_full()
-            .text_size(px(13.))
-            .text_color(cx.theme().danger)
-            .child(displayed_error_text(&entry.content).into_owned())
-            .into_any_element(),
-        EntryContent::Item(ItemContent::FileChange { changes, .. }) => div()
-            .text_size(px(13.))
-            .text_color(muted)
-            .child(crate::tr!("chat.changed_files", count = changes.len()))
-            .into_any_element(),
-        _ => fallback.expect("activity child requires a fallback component"),
-    }
-}
-
-fn chevron(open: bool) -> IconName {
-    if open {
-        IconName::ChevronDown
+    if let Some(on_open) = on_open {
+        crate::material::accessible_clickable(
+            row,
+            SharedString::from(format!("subagent-row-{}", entry.id)),
+            Role::Button,
+            row_label,
+            cx,
+        )
+        .cursor_pointer()
+        .hover(|row| row.bg(cx.theme().accent))
+        .on_click(on_open)
+        .into_any_element()
     } else {
-        IconName::ChevronRight
+        row.into_any_element()
     }
 }

--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -17,12 +17,12 @@ use crate::{
     icon::{Icon, IconName},
     sizing::Sizable as _,
 };
-use agent::{ItemContent, ItemStatus, RewindMode};
+use agent::{ItemContent, RewindMode};
 use gpui::{
-    Anchor, AnyElement, App, AppContext as _, ClipboardItem, Context, Entity, FollowMode,
-    InteractiveElement as _, IntoElement, ListAlignment, ListOffset, ListState, ParentElement as _,
-    Render, Role, SharedString, StatefulInteractiveElement as _, Styled as _, Subscription, Task,
-    Window, div, list, prelude::FluentBuilder as _, px,
+    Anchor, AnyElement, App, AppContext as _, ClickEvent, ClipboardItem, Context, Entity,
+    FollowMode, InteractiveElement as _, IntoElement, ListAlignment, ListOffset, ListState,
+    ParentElement as _, Render, Role, SharedString, StatefulInteractiveElement as _, Styled as _,
+    Subscription, Task, Window, div, list, prelude::FluentBuilder as _, px,
 };
 use gpui_base::{StyledExt as _, h_flex, v_flex};
 
@@ -46,11 +46,11 @@ use crate::window_state::WindowState;
 use self::components::assistant::MdState;
 use self::model::{
     ListSync, Segment, TurnListItem, TurnRenderArgs, activity_run_duration_ms, auto_expanded,
-    displayed_error_text, divergent_served_model, format_compact_span, format_span, index_turns,
-    latest_message_ids, list_sync, live_activity_segment, live_edit_rows, manual_override_key,
-    plain_text_as_markdown, segment_entries, start_hub_projects, timeline_overdraw, user_content,
-    user_visible_text, work_log_auto_expands, work_log_capsule_label, work_log_counts,
-    work_log_outcome, work_log_row_entries,
+    displayed_error_text, divergent_served_model, format_span, index_turns, latest_message_ids,
+    list_sync, live_activity_segment, live_edit_rows, manual_override_key, plain_text_as_markdown,
+    segment_entries, start_hub_projects, timeline_overdraw, user_content, user_visible_text,
+    work_log_auto_expands, work_log_capsule_label, work_log_counts, work_log_outcome,
+    work_log_row_entries,
 };
 use self::residency::{
     MarkdownEntry, ResidencyInput, decide, tail_turn_window, viewport_turn_window,
@@ -165,7 +165,6 @@ impl ChatView {
                         .proposed_plan
                         .as_ref()
                         .map(|plan| (plan.turn, plan.item_id.as_str(), plan.markdown.as_str())),
-                    &timeline.children,
                     &self.expanded,
                 );
                 (timeline.turn_running, turn_items)
@@ -419,9 +418,8 @@ impl ChatView {
         if !self.expanded.remove(key) {
             self.expanded.insert(key.to_string());
         }
-        // Refresh the cached turn fingerprint immediately. Subagent keys feed
-        // `index_turns`, while the direct remeasure below still covers every
-        // other collapsible whose state is intentionally not fingerprinted.
+        // Refresh the cached turn fingerprint immediately; the direct remeasure
+        // below covers collapsibles whose state is intentionally not fingerprinted.
         self.sync_markdown_states(cx);
         self.list_state.remeasure_items(turn..turn + 1);
         cx.notify();
@@ -963,64 +961,25 @@ impl ChatView {
     }
 
     fn compose_subagent_row(&self, entry: &TimelineEntry, cx: &mut Context<Self>) -> AnyElement {
-        let EntryContent::Item(ItemContent::Subagent { status, .. }) = &entry.content else {
-            unreachable!();
-        };
-        let key = format!("subagent-{}", entry.id);
-        let automatic = matches!(status, ItemStatus::InProgress);
-        let expanded = auto_expanded(&self.expanded, &key, automatic);
-        let parent_id = entry.id.clone();
-        let (children, truncated) = self
-            .workspace_store
-            .read(cx)
-            .with_active_timeline(|timeline| {
-                (
-                    timeline.children(&parent_id).to_vec(),
-                    timeline.children_truncated(&parent_id),
-                )
-            })
-            .unwrap_or_default();
-        let duration = (!automatic).then(|| {
-            let end = children
-                .iter()
-                .rev()
-                .find_map(|child| child.ts)
-                .or(entry.ts)
-                .unwrap_or(0);
-            format_compact_span(end.saturating_sub(entry.ts.unwrap_or(end)) / 1000)
+        let active_id = self.workspace_store.read(cx).active_session_id();
+        let mirror_id = active_id.as_deref().and_then(|active_id| {
+            self.workspace_store
+                .read(cx)
+                .sidebar_sessions()
+                .into_iter()
+                .find(|meta| {
+                    meta.parent_session_id.as_deref() == Some(active_id)
+                        && meta.native_subagent.as_deref() == Some(entry.id.as_str())
+                })
+                .map(|meta| meta.id)
         });
-        let rendered_children = children
-            .iter()
-            .map(|child| self.compose_subagent_child(child, cx))
-            .collect();
-        let turn = entry.turn;
-        let click_key = key;
-        components::subagent::subagent_row(
-            entry,
-            components::subagent::SubagentState {
-                expanded,
-                truncated,
-                duration,
-            },
-            rendered_children,
-            cx.listener(move |this, _, _, cx| {
-                this.toggle_auto_expanded(turn, &click_key, automatic, cx);
-            }),
-            cx,
-        )
-    }
-
-    fn compose_subagent_child(&self, entry: &TimelineEntry, cx: &mut Context<Self>) -> AnyElement {
-        let fallback = match &entry.content {
-            EntryContent::Item(ItemContent::UserMessage { .. })
-            | EntryContent::Steer { .. }
-            | EntryContent::Item(ItemContent::AssistantMessage { .. })
-            | EntryContent::Error { .. }
-            | EntryContent::ProviderStartError { .. }
-            | EntryContent::Item(ItemContent::FileChange { .. }) => None,
-            _ => Some(self.compose_activity_row(entry, true, false, cx)),
-        };
-        components::subagent::subagent_child(entry, fallback, cx)
+        let on_open = mirror_id.map(|mirror_id| {
+            let store = self.workspace_store.clone();
+            Box::new(move |_: &ClickEvent, _: &mut Window, cx: &mut App| {
+                store.update(cx, |store, _| store.select_session(mirror_id.clone()));
+            }) as components::subagent::ClickHandler
+        });
+        components::subagent::subagent_row(entry, on_open, cx)
     }
 
     fn compose_proposed_plan_card(
@@ -1737,6 +1696,15 @@ impl Render for ChatView {
                 .child(self.render_empty_state(window, cx));
         };
 
+        let active_session_id = self.workspace_store.read(cx).active_session_id();
+        let native_subagent_readonly = active_session_id.as_deref().is_some_and(|active_id| {
+            self.workspace_store
+                .read(cx)
+                .sidebar_sessions()
+                .iter()
+                .any(|meta| meta.id == active_id && meta.native_subagent.is_some())
+        });
+
         let title = if is_draft { None } else { Some(title) };
         let header = self.render_header(title, is_draft, Some(cwd.clone()), window, cx);
         let panel = self.workspace_store.read(cx).chat_panel_state();
@@ -1816,6 +1784,18 @@ impl Render for ChatView {
         .min_h_0()
         .py_6();
 
+        let composer: AnyElement = if native_subagent_readonly {
+            div()
+                .w_full()
+                .py_3()
+                .text_center()
+                .text_size(px(12.))
+                .text_color(cx.theme().muted_foreground)
+                .child(crate::tr!("chat.subagent_readonly"))
+                .into_any_element()
+        } else {
+            self.composer.clone().into_any_element()
+        };
         let main = v_flex()
             .size_full()
             .min_h_0()
@@ -1833,7 +1813,7 @@ impl Render for ChatView {
                         |this| this.child(self.render_scroll_pill(cx)),
                     ),
             )
-            .child(self.composer.clone());
+            .child(composer);
 
         let body: AnyElement = if terminal_open {
             let drawer = self.terminal_drawer.clone();

--- a/crates/ui/src/chat/model.rs
+++ b/crates/ui/src/chat/model.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::hash::{DefaultHasher, Hash as _, Hasher as _};
 use std::ops::Range;
 use std::path::Path;
@@ -770,7 +770,6 @@ pub(crate) fn index_turns(
     turns: &[TurnMeta],
     entries: &[Arc<TimelineEntry>],
     proposed_plan: Option<(usize, &str, &str)>,
-    children: &HashMap<String, Vec<Arc<TimelineEntry>>>,
     expanded: &HashSet<String>,
 ) -> Vec<TurnListItem> {
     debug_assert!(entries.windows(2).all(|pair| pair[0].turn <= pair[1].turn));
@@ -798,21 +797,6 @@ pub(crate) fn index_turns(
                 std::mem::discriminant(&entry.content).hash(&mut content);
                 entry.ts.hash(&mut content);
                 hash_entry_shape(&entry.content, &mut content);
-                if let EntryContent::Item(ItemContent::Subagent { status, .. }) = &entry.content {
-                    let key = format!("subagent-{}", entry.id);
-                    let subagent_expanded =
-                        auto_expanded(expanded, &key, matches!(status, ItemStatus::InProgress));
-                    subagent_expanded.hash(&mut content);
-                    if subagent_expanded {
-                        let child_entries = children.get(&entry.id).map_or(&[][..], Vec::as_slice);
-                        child_entries.len().hash(&mut content);
-                        for child in child_entries {
-                            child.id.hash(&mut content);
-                            child.ts.hash(&mut content);
-                            hash_entry_shape(&child.content, &mut content);
-                        }
-                    }
-                }
                 // A disclosure row (orchestrate context / callback) grows a tall
                 // scroll card when expanded, so its toggle state must change the
                 // turn fingerprint or the list keeps the collapsed measurement.
@@ -1015,7 +999,7 @@ pub(crate) fn list_sync(
 mod tests {
     use super::*;
     use agent::{FileChange, FileChangeKind, ItemContent, ItemStatus, ProviderKind};
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashSet;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use tcode_core::project::{Project, SessionMeta};
@@ -1188,20 +1172,19 @@ mod tests {
     #[test]
     fn turn_list_index_and_sync_cover_stream_append_truncate_and_session_switch() {
         let turns = vec![TurnMeta::default()];
-        let children = HashMap::new();
         let expanded = HashSet::new();
         let mut entries = vec![
             entry("user-0", user_item("go")),
             entry("assistant-0", assistant("working")),
         ];
-        let initial = index_turns(&turns, &entries, None, &children, &expanded);
+        let initial = index_turns(&turns, &entries, None, &expanded);
         assert_eq!(initial.len(), 1);
         assert_eq!(initial[0].entry_range, 0..2);
 
         // Another entry joins the current turn: identity stays at item index 0,
         // but its variable height must be measured again.
         entries.push(command("command-0"));
-        let current_turn_append = index_turns(&turns, &entries, None, &children, &expanded);
+        let current_turn_append = index_turns(&turns, &entries, None, &expanded);
         assert_eq!(current_turn_append[0].entry_range, 0..3);
         assert_eq!(
             list_sync(&initial, &current_turn_append, false),
@@ -1215,7 +1198,7 @@ mod tests {
         // remeasured because it gains the visual inter-turn gap.
         let turns = vec![TurnMeta::default(), TurnMeta::default()];
         entries.push(at_turn(entry("user-1", user_item("next")), 1));
-        let new_turn = index_turns(&turns, &entries, None, &children, &expanded);
+        let new_turn = index_turns(&turns, &entries, None, &expanded);
         assert_eq!(new_turn[0].entry_range, 0..3);
         assert_eq!(new_turn[1].entry_range, 3..4);
         assert_eq!(
@@ -1239,7 +1222,7 @@ mod tests {
     }
 
     #[test]
-    fn subagent_expansion_and_live_children_remeasure_the_turn() {
+    fn subagent_status_change_remeasures_the_turn() {
         let turns = vec![TurnMeta::default()];
         let entries = vec![entry(
             "spawn",
@@ -1250,26 +1233,18 @@ mod tests {
                 summary: None,
             }),
         )];
-        let mut children = HashMap::new();
-        let automatic = index_turns(&turns, &entries, None, &children, &HashSet::new());
-
-        let collapsed_keys = HashSet::from(["manual-subagent-spawn".to_string()]);
-        let collapsed = index_turns(&turns, &entries, None, &children, &collapsed_keys);
+        let running = index_turns(&turns, &entries, None, &HashSet::new());
+        let mut completed_entries = entries;
+        if let EntryContent::Item(ItemContent::Subagent {
+            status, summary, ..
+        }) = &mut Arc::make_mut(&mut completed_entries[0]).content
+        {
+            *status = ItemStatus::Completed;
+            *summary = Some("Found the event envelope".into());
+        }
+        let completed = index_turns(&turns, &completed_entries, None, &HashSet::new());
         assert_eq!(
-            list_sync(&automatic, &collapsed, false),
-            ListSync::Incremental {
-                append: None,
-                remeasure: vec![0],
-            }
-        );
-
-        children.insert(
-            "spawn".to_string(),
-            vec![entry("spawn:child", assistant("Found the event envelope"))],
-        );
-        let with_child = index_turns(&turns, &entries, None, &children, &HashSet::new());
-        assert_eq!(
-            list_sync(&automatic, &with_child, false),
+            list_sync(&running, &completed, false),
             ListSync::Incremental {
                 append: None,
                 remeasure: vec![0],
@@ -1381,7 +1356,6 @@ mod tests {
             running: true,
             ..Default::default()
         }];
-        let children = HashMap::new();
         let expanded = HashSet::new();
         let pending = entry(
             "steer",
@@ -1397,7 +1371,6 @@ mod tests {
             &turns,
             &[pending.clone(), assistant.clone()],
             None,
-            &children,
             &expanded,
         );
 
@@ -1409,7 +1382,6 @@ mod tests {
             &turns,
             &[accepted.clone(), assistant.clone()],
             None,
-            &children,
             &expanded,
         );
         assert_eq!(
@@ -1420,7 +1392,7 @@ mod tests {
             }
         );
 
-        let reordered = index_turns(&turns, &[assistant, accepted], None, &children, &expanded);
+        let reordered = index_turns(&turns, &[assistant, accepted], None, &expanded);
         assert_eq!(
             list_sync(&status_changed, &reordered, false),
             ListSync::Reset { count: 1 }

--- a/crates/ui/src/gallery_support.rs
+++ b/crates/ui/src/gallery_support.rs
@@ -82,24 +82,7 @@ pub fn work_log(
 }
 
 pub fn subagent(entry: &TimelineEntry, cx: &App) -> AnyElement {
-    subagent::subagent_row(
-        entry,
-        subagent::SubagentState {
-            expanded: false,
-            truncated: false,
-            duration: (!matches!(
-                entry.content,
-                tcode_core::session::EntryContent::Item(agent::ItemContent::Subagent {
-                    status: agent::ItemStatus::InProgress,
-                    ..
-                })
-            ))
-            .then(|| "12.4s".to_string()),
-        },
-        Vec::new(),
-        |_, _, _| {},
-        cx,
-    )
+    subagent::subagent_row(entry, None, cx)
 }
 
 pub fn changed_files(index: usize, cwd: &Path, changes: &[FileChange], cx: &App) -> AnyElement {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -23,7 +23,7 @@ chat:
   hide_previous_logs: "Hide %{count} previous log entries"
   subagent_count: "%{count} subagents"
   subagent_row: "%{agent}: %{description}"
-  earlier_steps_truncated: "+earlier steps truncated"
+  subagent_readonly: "Read-only subagent thread"
   working: "Working"
   turn_ai: "AI thinking & response %{duration}"
   turn_tools: "Tool calls %{duration}"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -23,7 +23,7 @@ chat:
   hide_previous_logs: "收起前面的 %{count} 条日志"
   subagent_count: "%{count} 个子代理"
   subagent_row: "%{agent}：%{description}"
-  earlier_steps_truncated: "+更早的步骤已截断"
+  subagent_readonly: "只读子代理线程"
   working: "工作中"
   turn_ai: "AI 思考与回答 %{duration}"
   turn_tools: "工具调用 %{duration}"


### PR DESCRIPTION
## What

Provider-native subagents (Claude Task subagents, Codex collab subagents) now surface as **collapsed child threads in the sidebar** — the same parent/child presentation orchestrate children use — instead of an expandable inline transcript in the chat timeline. Clicking the timeline status row or the sidebar entry opens the mirror thread **read-only** (no composer, no provider process). The inline sub-conversation display is fully deleted.

## How

- **Runtime choke-point reroute** (`on_event` → new `app/subagents.rs`): agent adapters are untouched. The top-level `ItemContent::Subagent` item still lands in the parent log (simple status row); every child item carrying `parent_item_id` is rerouted — stripped — into a mirror session's own event log and resident timeline.
- **Mirror sessions** are real persisted `SessionMeta`s: `parent_session_id` = parent, new `native_subagent: Option<String>` field carries the spawn item id (read-only marker + restart reattach key). They ride the existing sidebar collapse, working spinner (`turn_in_flight`), and live-view plumbing for free; no provider is ever started for them.
- **Read-only enforcement**: composer replaced with a localized notice; runtime send path refuses; orchestrate `require_child` / status enumeration exclude mirrors; parent `SessionClosed` clears orphaned spinners.
- **Deleted**: `Timeline::children` / `truncated_children` and accessors, the `parent_item_id` branch of `upsert_item` (legacy logs drop those items instead of rendering them inline), `subagent_child`, `SubagentState` expansion/truncation/duration bookkeeping, `chat.earlier_steps_truncated`.

## Tests

- New runtime e2e test: mirror meta creation + persisted routing with stripped `parent_item_id` + parent-log purity + working-flag lifecycle + orchestrate-status exclusion.
- Core: parented items are dropped while Subagent status/summary still merges; partial-turn changes no longer count child file changes.
- Services: SessionMeta serde legacy-safety roundtrip extended for `native_subagent`.
- `cargo check --workspace`, `cargo test -p tcode-core -p tcode-runtime -p tcode-services -p tcode-ui -p agent` (766 tests), fmt, clippy — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)