### PR TITLE
fix(ui): import ItemStatus in chat module

### DIFF
--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     icon::{Icon, IconName},
     sizing::Sizable as _,
 };
-use agent::{ItemContent, RewindMode};
+use agent::{ItemContent, ItemStatus, RewindMode};
 use gpui::{
     Anchor, AnyElement, App, AppContext as _, ClickEvent, ClipboardItem, Context, Entity,
     FollowMode, InteractiveElement as _, IntoElement, ListAlignment, ListOffset, ListState,


### PR DESCRIPTION
`compose_activity_row` in `crates/ui/src/chat/mod.rs` matches on `ItemStatus::InProgress`, but `ItemStatus` was never imported — `cargo build` fails with E0433.

Added it to the existing `use agent::{...}` line. `cargo check -p tcode-ui` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jkpr6o61d9vNYZChz3vUvG