### PR TITLE
fix: inject release version into update check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
       CARGO_PROFILE_RELEASE_LTO: thin
       CARGO_PROFILE_RELEASE_STRIP: symbols
       VERSION: ${{ needs.setup.outputs.version }}
+      TCODE_BUILD_VERSION: ${{ needs.setup.outputs.version }}
       RELEASE_TAG: ${{ needs.setup.outputs.tag }}
       PRERELEASE: ${{ needs.setup.outputs.prerelease }}
 

--- a/crates/runtime/src/app/mod.rs
+++ b/crates/runtime/src/app/mod.rs
@@ -304,7 +304,9 @@ pub struct TcodeUpdateState {
 impl Default for TcodeUpdateState {
     fn default() -> Self {
         Self {
-            current: env!("CARGO_PKG_VERSION").to_string(),
+            current: option_env!("TCODE_BUILD_VERSION")
+                .unwrap_or(env!("CARGO_PKG_VERSION"))
+                .to_string(),
             latest: None,
             release_url: None,
             update_available: false,


### PR DESCRIPTION
The update check compared `CARGO_PKG_VERSION` (always `0.1.0`, never bumped) against the latest GitHub release, so every released build permanently reported "update available" — including the latest one.

Release CI now exports `TCODE_BUILD_VERSION` from the release tag during the build, and `TcodeUpdateState` prefers it over the crate version. Local dev builds fall back to `CARGO_PKG_VERSION` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)