### PR TITLE
fix(subagents): synthesize turn boundaries in native subagent mirror timelines

### DIFF
--- a/crates/runtime/src/app/subagents.rs
+++ b/crates/runtime/src/app/subagents.rs
@@ -27,6 +27,7 @@ impl AppState {
                 );
                 return true;
             };
+            self.sync_mirror_turn(&mirror_id, true, parent_item_id, TurnStatus::Completed, cx);
             self.record_event(&mirror_id, &strip_parent_item_id(event), cx);
             return true;
         }
@@ -62,8 +63,49 @@ impl AppState {
             if let Some(meta) = meta.flatten() {
                 self.persist_meta(&meta, cx);
             }
+            let turn_status = match status {
+                ItemStatus::Failed | ItemStatus::Declined => TurnStatus::Failed,
+                _ => TurnStatus::Completed,
+            };
+            self.sync_mirror_turn(&mirror_id, in_progress, &item.id, turn_status, cx);
         }
         false
+    }
+
+    /// Mirrors never receive provider Turn events, but the chat view derives
+    /// its working indicator, live timer, and live work-log expansion from
+    /// timeline turn state — so synthesize the boundaries from the parent
+    /// Subagent item's lifecycle.
+    fn sync_mirror_turn(
+        &mut self,
+        mirror_id: &str,
+        running: bool,
+        subagent_item_id: &str,
+        status: TurnStatus,
+        cx: &mut HostCx,
+    ) {
+        let open = self
+            .resident(mirror_id)
+            .is_some_and(|mirror| mirror.timeline.turn_running);
+        if running && !open {
+            self.record_event(
+                mirror_id,
+                &AgentEvent::TurnStarted {
+                    turn_id: subagent_item_id.to_string(),
+                },
+                cx,
+            );
+        } else if !running && open {
+            self.record_event(
+                mirror_id,
+                &AgentEvent::TurnCompleted {
+                    turn_id: subagent_item_id.to_string(),
+                    status,
+                    usage: None,
+                },
+                cx,
+            );
+        }
     }
 
     fn ensure_native_subagent_mirror(
@@ -142,9 +184,10 @@ impl AppState {
                 meta.parent_session_id.as_deref() == Some(parent_session_id)
                     && meta.native_subagent.is_some()
             })
-            .map(|meta| meta.id.clone())
+            .map(|meta| (meta.id.clone(), meta.native_subagent.clone().unwrap()))
             .collect();
-        for mirror_id in mirror_ids {
+        for (mirror_id, subagent_item_id) in mirror_ids {
+            self.sync_mirror_turn(&mirror_id, false, &subagent_item_id, TurnStatus::Completed, cx);
             let meta = self.resident_mut(&mirror_id).and_then(|mirror| {
                 if !mirror.turn_in_flight {
                     return None;

--- a/crates/runtime/src/app/subagents.rs
+++ b/crates/runtime/src/app/subagents.rs
@@ -187,7 +187,13 @@ impl AppState {
             .map(|meta| (meta.id.clone(), meta.native_subagent.clone().unwrap()))
             .collect();
         for (mirror_id, subagent_item_id) in mirror_ids {
-            self.sync_mirror_turn(&mirror_id, false, &subagent_item_id, TurnStatus::Completed, cx);
+            self.sync_mirror_turn(
+                &mirror_id,
+                false,
+                &subagent_item_id,
+                TurnStatus::Completed,
+                cx,
+            );
             let meta = self.resident_mut(&mirror_id).and_then(|mirror| {
                 if !mirror.turn_in_flight {
                     return None;

--- a/crates/runtime/src/app/tests.rs
+++ b/crates/runtime/src/app/tests.rs
@@ -47,6 +47,7 @@ fn provider_native_subagent_events_create_and_feed_read_only_mirror_session() {
         assert_eq!(mirror.parent_session_id.as_deref(), Some("parent"));
         assert_eq!(mirror.title, "explorer: Inspect event routing");
         assert!(state.resident(&mirror.id).unwrap().has_work());
+        assert!(state.resident(&mirror.id).unwrap().timeline.turn_running);
 
         state.on_event(
             "parent",
@@ -84,6 +85,7 @@ fn provider_native_subagent_events_create_and_feed_read_only_mirror_session() {
             cx,
         );
         assert!(!state.resident(&mirror.id).unwrap().has_work());
+        assert!(!state.resident(&mirror.id).unwrap().timeline.turn_running);
         assert!(matches!(
             &state.resident("parent").unwrap().timeline.entries[0].content,
             EntryContent::Item(ItemContent::Subagent {


### PR DESCRIPTION
## Problem

Native subagent mirror sessions (#275) never showed the bottom working indicator or the live elapsed timer, and their in-progress activity block rendered collapsed instead of expanded.

Root cause: mirrors only receive rerouted `Item*` events — never `TurnStarted`/`TurnCompleted` — so the mirror timeline's `turn_running` stayed false. The chat view derives all three behaviors from timeline turn state (`chat/mod.rs:672` working indicator, `chat/mod.rs:240` 100ms timer ticker, `chat/model.rs:177` live work-log expansion). `mirror.turn_in_flight` only drives the sidebar spinner.

## Fix

New `sync_mirror_turn` records synthetic `TurnStarted`/`TurnCompleted` into the mirror timeline from the parent Subagent item's lifecycle:

- opened before child transcript items are folded in
- closed when the Subagent item completes (`Failed`/`Declined` → `TurnStatus::Failed`)
- force-closed by `clear_native_subagent_work` on parent session close

Events go through `record_event`, so persisted logs replay with correct turn boundaries and durations; mid-turn crashes are still cleaned up by the existing `clear_stale_running`.

## Testing

Extended the existing mirror test to assert `timeline.turn_running` flips true while the subagent is in progress and false after completion. All 122 `tcode-runtime` tests pass.