### PR TITLE
fix: inject release version into update check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
       CARGO_PROFILE_RELEASE_LTO: thin
       CARGO_PROFILE_RELEASE_STRIP: symbols
       VERSION: ${{ needs.setup.outputs.version }}
+      TCODE_BUILD_VERSION: ${{ needs.setup.outputs.version }}
       RELEASE_TAG: ${{ needs.setup.outputs.tag }}
       PRERELEASE: ${{ needs.setup.outputs.prerelease }}
 

--- a/crates/runtime/src/app/mod.rs
+++ b/crates/runtime/src/app/mod.rs
@@ -304,7 +304,9 @@ pub struct TcodeUpdateState {
 impl Default for TcodeUpdateState {
     fn default() -> Self {
         Self {
-            current: env!("CARGO_PKG_VERSION").to_string(),
+            current: option_env!("TCODE_BUILD_VERSION")
+                .unwrap_or(env!("CARGO_PKG_VERSION"))
+                .to_string(),
             latest: None,
             release_url: None,
             update_available: false,


### PR DESCRIPTION
## Problem

The update check compared `CARGO_PKG_VERSION` against the latest GitHub release, but the crate version is never bumped (always 0.1.0), so every release build permanently reported an update available.

## Fix

- `release.yml` exports `TCODE_BUILD_VERSION` from the release tag during build.
- `TcodeUpdateState::default` prefers `option_env!("TCODE_BUILD_VERSION")` at compile time, falling back to the crate version for dev builds.