### PR TITLE
fix: stop on detected model fallback via stream detection, not a model whitelist

### DIFF
--- a/crates/agent/examples/probe.rs
+++ b/crates/agent/examples/probe.rs
@@ -245,7 +245,6 @@ async fn run_probe(
     let opts = SessionOptions {
         cwd,
         model,
-        abort_on_model_fallback: true,
         resume: None,
         fork: false,
         binary_path: None,

--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -109,11 +109,7 @@ pub async fn start(opts: SessionOptions) -> Result<SessionHandle, AgentError> {
     // Resolve model-scoped launch options from the persisted selections
     // (effort/context/fast/thinking are launch-time only; mid-session changes
     // ride the resume-restart machinery).
-    let launch = ClaudeLaunchOptions::resolve(
-        opts.model.as_deref(),
-        &opts.option_selections,
-        opts.abort_on_model_fallback,
-    );
+    let launch = ClaudeLaunchOptions::resolve(opts.model.as_deref(), &opts.option_selections);
     let base_permission_mode = permission_mode_flag(opts.approval_mode);
     let launch_permission_mode = initial_permission_mode(opts.approval_mode, opts.interaction_mode);
     // Launch arguments are deliberately appended last, so the tracker must
@@ -317,25 +313,7 @@ struct ClaudeLaunchOptions {
     ultrathink: bool,
 }
 
-fn fallback_guard_models(model: &str) -> Vec<String> {
-    let base = model.split('[').next().unwrap_or(model);
-    let primary = if base.contains("fable") {
-        "fable"
-    } else {
-        base
-    };
-    let mut allow = vec![primary.to_string()];
-    for extra in ["sonnet", "haiku"] {
-        if !allow.iter().any(|m| m == extra) {
-            allow.push(extra.to_string());
-        }
-    }
-    allow
-}
-
 fn launch_settings_json(
-    model: Option<&str>,
-    abort_on_model_fallback: bool,
     thinking: Option<bool>,
     fast_mode: bool,
     ultracode: bool,
@@ -350,23 +328,12 @@ fn launch_settings_json(
     if ultracode {
         settings.insert("ultracode".into(), json!(true));
     }
-    if abort_on_model_fallback && let Some(model) = model {
-        settings.insert(
-            "availableModels".into(),
-            json!(fallback_guard_models(model)),
-        );
-        settings.insert("switchModelsOnFlag".into(), json!(false));
-    }
     (!settings.is_empty())
         .then(|| serde_json::to_string(&Value::Object(settings)).unwrap_or_default())
 }
 
 impl ClaudeLaunchOptions {
-    fn resolve(
-        model: Option<&str>,
-        selections: &[OptionSelection],
-        abort_on_model_fallback: bool,
-    ) -> Self {
+    fn resolve(model: Option<&str>, selections: &[OptionSelection]) -> Self {
         let spec = model.and_then(model_spec);
         let raw_effort = selection_str(selections, "reasoningEffort");
         let resolved_effort = resolve_claude_effort(spec.as_ref(), raw_effort.as_deref());
@@ -399,13 +366,7 @@ impl ClaudeLaunchOptions {
             None
         };
 
-        let settings_json = launch_settings_json(
-            model,
-            abort_on_model_fallback,
-            thinking,
-            fast_mode,
-            ultracode,
-        );
+        let settings_json = launch_settings_json(thinking, fast_mode, ultracode);
 
         ClaudeLaunchOptions {
             model_id,
@@ -1025,6 +986,13 @@ struct PendingRewind {
     conversation: bool,
 }
 
+fn served_model_is_fallback(expected: &str, served: &str) -> bool {
+    (expected.contains("fable") && served.contains("opus"))
+        || (served.contains("opus-4-8")
+            && expected.contains("opus")
+            && !expected.contains("opus-4-8"))
+}
+
 pub(crate) struct Mapper {
     session_started: bool,
     current_message_id: Option<String>,
@@ -1095,6 +1063,8 @@ pub(crate) struct Mapper {
     last_served_model: Option<String>,
     /// Model selected for this session, used when Claude reports a synthetic refusal message.
     expected_model: Option<String>,
+    /// Whether a served-model mismatch was already reported for the active turn.
+    fallback_detected: bool,
     /// Latest structured stop reason for the active turn.
     stop_reason: Option<String>,
     /// Classifier category captured from the active turn's structured refusal details.
@@ -1158,6 +1128,7 @@ impl Mapper {
             native_rewind,
             last_served_model: None,
             expected_model,
+            fallback_detected: false,
             stop_reason: None,
             pending_refusal_category: None,
             warned_stop_reason: None,
@@ -1180,6 +1151,7 @@ impl Mapper {
         self.current_turn_id = Some(id.clone());
         self.awaiting_turn_checkpoint = self.native_rewind;
         self.exit_plan_captured = false;
+        self.fallback_detected = false;
         self.stop_reason = None;
         self.pending_refusal_category = None;
         self.warned_stop_reason = None;
@@ -1464,7 +1436,7 @@ impl Mapper {
         events
     }
 
-    fn on_model_refusal_fallback(&self, msg: &Value) -> Vec<AgentEvent> {
+    fn on_model_refusal_fallback(&mut self, msg: &Value) -> Vec<AgentEvent> {
         let (Some(expected), Some(actual)) = (
             msg.get("original_model").and_then(Value::as_str),
             msg.get("fallback_model").and_then(Value::as_str),
@@ -1472,6 +1444,7 @@ impl Mapper {
             log::debug!("claude: ignoring malformed model_refusal_fallback");
             return Vec::new();
         };
+        self.fallback_detected = true;
         vec![AgentEvent::ModelFallbackDetected {
             expected: expected.to_owned(),
             actual: actual.to_owned(),
@@ -1755,14 +1728,41 @@ impl Mapper {
                 .and_then(Value::as_str)
                 .map(ClassifierCategory::parse);
         }
-        if let Some(model) = message.get("model").and_then(Value::as_str)
-            && self.last_served_model.as_deref() != Some(model)
-        {
-            self.last_served_model = Some(model.to_owned());
-            out.push(AgentEvent::ServedModel {
-                model: model.to_owned(),
-                reason: None,
-            });
+        if let Some(model) = message.get("model").and_then(Value::as_str) {
+            if !self.fallback_detected
+                && let Some(expected) = self.expected_model.as_deref()
+            {
+                let normalized_expected = expected
+                    .split('[')
+                    .next()
+                    .unwrap_or(expected)
+                    .to_ascii_lowercase();
+                let normalized_served = model
+                    .split('[')
+                    .next()
+                    .unwrap_or(model)
+                    .to_ascii_lowercase();
+                if served_model_is_fallback(&normalized_expected, &normalized_served) {
+                    self.fallback_detected = true;
+                    out.push(AgentEvent::ModelFallbackDetected {
+                        expected: expected.to_owned(),
+                        actual: model.to_owned(),
+                        category: None,
+                        checkpoint_id: None,
+                        parent_tool_use_id: msg
+                            .get("parent_tool_use_id")
+                            .and_then(Value::as_str)
+                            .map(str::to_owned),
+                    });
+                }
+            }
+            if self.last_served_model.as_deref() != Some(model) {
+                self.last_served_model = Some(model.to_owned());
+                out.push(AgentEvent::ServedModel {
+                    model: model.to_owned(),
+                    reason: None,
+                });
+            }
         }
         out.extend(self.observe_stop_reason(message.get("stop_reason").and_then(Value::as_str)));
         let msg_id = message
@@ -3150,6 +3150,81 @@ mod tests {
     }
 
     #[test]
+    fn served_model_fallback_family_rule() {
+        let cases = [
+            ("claude-fable-5", "claude-opus-4-8", true),
+            ("claude-fable-5", "claude-opus-5", true),
+            ("claude-opus-5", "claude-opus-4-8", true),
+            ("claude-opus-4-8", "claude-opus-4-8", false),
+            ("claude-fable-5", "claude-fable-5", false),
+            ("claude-fable-5", "claude-sonnet-4-5", false),
+            ("claude-fable-5", "claude-haiku-4-5", false),
+            ("anything", "<synthetic>", false),
+        ];
+        for (expected, served, is_fallback) in cases {
+            assert_eq!(
+                served_model_is_fallback(expected, served),
+                is_fallback,
+                "expected={expected}, served={served}"
+            );
+        }
+
+        let expected = "claude-opus-5[1m]";
+        let normalized_expected = expected.split('[').next().unwrap_or(expected);
+        assert!(served_model_is_fallback(
+            normalized_expected,
+            "claude-opus-4-8"
+        ));
+    }
+
+    #[test]
+    fn assistant_model_mismatch_emits_one_fallback_per_turn() {
+        let mut mapper = Mapper::new_configured(
+            false,
+            InteractionMode::Build,
+            "default",
+            "default".into(),
+            ApprovalMode::Supervised,
+            false,
+            Some("claude-fable-5".into()),
+        );
+        mapper.start_turn();
+
+        let first = feed(
+            &mut mapper,
+            r#"{"type":"assistant","message":{"id":"msg-fallback-1","model":"claude-opus-4-8","content":[]},"parent_tool_use_id":null}"#,
+        );
+        assert_eq!(
+            first
+                .iter()
+                .filter(|event| matches!(event, AgentEvent::ModelFallbackDetected { .. }))
+                .count(),
+            1
+        );
+        assert!(first.iter().any(|event| matches!(
+            event,
+            AgentEvent::ModelFallbackDetected {
+                expected,
+                actual,
+                category: None,
+                checkpoint_id: None,
+                parent_tool_use_id: None,
+            } if expected == "claude-fable-5"
+                && actual == "claude-opus-4-8"
+        )));
+
+        let second = feed(
+            &mut mapper,
+            r#"{"type":"assistant","message":{"id":"msg-fallback-2","model":"claude-opus-4-8","content":[]},"parent_tool_use_id":null}"#,
+        );
+        assert!(
+            !second
+                .iter()
+                .any(|event| matches!(event, AgentEvent::ModelFallbackDetected { .. }))
+        );
+    }
+
+    #[test]
     fn classifier_refusal_result_emits_turn_blocked() {
         let mut mapper = Mapper::new_configured(
             false,
@@ -3403,7 +3478,6 @@ mod tests {
                     value: json!(true),
                 },
             ],
-            false,
         );
         assert_eq!(launch.model_id.as_deref(), Some("claude-opus-4-8"));
         assert_eq!(launch.effort.as_deref(), Some("xhigh"));
@@ -3426,7 +3500,6 @@ mod tests {
                     value: json!("1m"),
                 },
             ],
-            false,
         );
         assert_eq!(launch.model_id.as_deref(), Some("claude-fable-5[1m]"));
         assert_eq!(launch.effort, None);
@@ -3440,45 +3513,10 @@ mod tests {
                 id: "thinking".into(),
                 value: json!(true),
             }],
-            false,
         );
         let settings: Value =
             serde_json::from_str(launch.settings_json.as_deref().unwrap()).unwrap();
         assert_eq!(settings["alwaysThinkingEnabled"], true);
-    }
-
-    #[test]
-    fn fallback_guard_settings_merge_with_launch_settings() {
-        let parse = |model, thinking, fast_mode, ultracode| -> Value {
-            serde_json::from_str(
-                launch_settings_json(Some(model), true, thinking, fast_mode, ultracode)
-                    .as_deref()
-                    .unwrap(),
-            )
-            .unwrap()
-        };
-
-        let fable = parse("claude-fable-5", Some(true), true, true);
-        assert_eq!(
-            fable["availableModels"],
-            json!(["fable", "sonnet", "haiku"])
-        );
-        assert_eq!(fable["switchModelsOnFlag"], false);
-        assert_eq!(fable["alwaysThinkingEnabled"], true);
-        assert_eq!(fable["fastMode"], true);
-        assert_eq!(fable["ultracode"], true);
-
-        let opus = parse("claude-opus-5", None, false, false);
-        assert_eq!(
-            opus["availableModels"],
-            json!(["claude-opus-5", "sonnet", "haiku"])
-        );
-
-        let opus_1m = parse("claude-opus-5[1m]", None, false, false);
-        assert_eq!(
-            opus_1m["availableModels"],
-            json!(["claude-opus-5", "sonnet", "haiku"])
-        );
     }
 
     #[test]

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -393,7 +393,6 @@ pub struct SessionOptions {
     pub cwd: PathBuf,
     /// Provider-native model id; `None` = provider default.
     pub model: Option<String>,
-    pub abort_on_model_fallback: bool,
     pub resume: Option<ResumeCursor>,
     /// Fork the resumed provider session instead of continuing it in place.
     /// This is meaningful only when `resume` is present.

--- a/crates/runtime/src/app/events.rs
+++ b/crates/runtime/src/app/events.rs
@@ -344,10 +344,11 @@ impl AppState {
                         .filter(|active| active.meta.id == session_id)
                         .is_some_and(|active| {
                             active.queue.clear();
+                            active.timeline.mark_idle();
+                            active.shutdown_to_idle();
                             true
                         });
                     if is_active {
-                        self.interrupt(cx);
                         self.emit_domain(
                             Topic::SessionStatus {
                                 session_id: session_id.to_owned(),

--- a/crates/runtime/src/app/providers.rs
+++ b/crates/runtime/src/app/providers.rs
@@ -779,7 +779,6 @@ pub(super) fn session_options(
     SessionOptions {
         cwd: meta.cwd.clone(),
         model: meta.model.clone(),
-        abort_on_model_fallback: settings.abort_on_model_fallback,
         resume: meta.resume_cursor.clone(),
         fork: meta.pending_fork,
         binary_path: provider_settings.binary_path.clone(),

--- a/crates/runtime/src/app/tests.rs
+++ b/crates/runtime/src/app/tests.rs
@@ -3678,6 +3678,61 @@ fn turn_blocked_clears_active_session_queue_when_abort_on_model_fallback_is_enab
 }
 
 #[test]
+fn model_fallback_stops_active_session_when_abort_on_model_fallback_is_enabled() {
+    let cx = &mut TestAppContext::default();
+    let test_store = TestStore::new("tcode-model-fallback-stop-test");
+    let state = cx.new_entity(|_| AppState::new((*test_store).clone()));
+    let (commands, receiver) = smol::channel::unbounded();
+
+    state.host_update(cx, |state, cx| {
+        state.settings.abort_on_model_fallback = true;
+        let mut active = live_session(ProviderKind::ClaudeCode, commands);
+        active.meta.model = Some("claude-fable-5".into());
+        active.turn_in_flight = true;
+        active.timeline.apply_at(
+            None,
+            &AgentEvent::TurnStarted {
+                turn_id: "turn-fallback".into(),
+            },
+        );
+        let session_id = active.meta.id.clone();
+        active.push_queued("do not auto-send".into(), Vec::new());
+        state.residents.active = Some(active);
+
+        state.on_event(
+            &session_id,
+            AgentEvent::ModelFallbackDetected {
+                expected: "claude-fable-5".into(),
+                actual: "claude-opus-4-8".into(),
+                category: None,
+                checkpoint_id: None,
+                parent_tool_use_id: None,
+            },
+            cx,
+        );
+
+        let active = state.residents.active.as_ref().unwrap();
+        assert!(active.queue.is_empty());
+        assert!(matches!(active.runtime, Runtime::Idle));
+        assert!(!active.turn_in_flight);
+        assert!(!active.timeline.turn_running);
+    });
+
+    assert!(matches!(receiver.try_recv(), Ok(SessionCommand::Shutdown)));
+    assert!(cx.drain_outgoing().iter().any(|message| matches!(
+        message,
+        HostMessage::Event(EventEnvelope {
+            topic: Topic::SessionStatus { .. },
+            event: ServerEvent::ModelFallbackBlocked {
+                model: Some(model),
+                fallback_model: Some(fallback_model),
+                ..
+            },
+        }) if model == "claude-fable-5" && fallback_model == "claude-opus-4-8"
+    )));
+}
+
+#[test]
 fn shutdown_all_notifies_active_and_parked_live_providers() {
     let cx = &mut TestAppContext::default();
     let test_store = TestStore::new("tcode-app-test");

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -233,7 +233,7 @@ settings:
     description: "Drop to ~2 FPS while the window is unfocused to save energy. Takes effect after restart."
   abort_on_model_fallback:
     title: "Abort on model fallback"
-    description: "When on, Claude Code sessions are pinned so a flagged request is interrupted instead of silently switching models; subagents may only use the main model, Sonnet, or Haiku."
+    description: "When on, tcode watches Claude Code's stream for safety-classifier fallbacks or flags and stops the turn at the conversation level, handing control back to you. Subagents are unaffected."
   fallback_review_advisor:
     title: "Fallback review advisor"
     description: "Use a separate model to review requests interrupted by Claude Code's fallback guard."

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -233,7 +233,7 @@ settings:
     description: "窗口失焦时将刷新率降至约 2 FPS 以节省能耗。重启后生效。"
   abort_on_model_fallback:
     title: "模型回退时中止"
-    description: "开启后，Claude Code 会话将锁定可用模型，使被标记的请求中断，而不是静默切换模型；子代理只能使用主模型、Sonnet 或 Haiku。"
+    description: "开启后，tcode 会监控 Claude Code 的流，在检测到安全分类器回退或标记时从对话层面停止当前轮次，并将控制权交还给你。子代理不受影响。"
   fallback_review_advisor:
     title: "回退审查顾问"
     description: "使用独立模型审查被 Claude Code 回退防护中断的请求。"


### PR DESCRIPTION
## Summary

Revises how `abort_on_model_fallback` (#277) works. The previous implementation injected an `availableModels` whitelist + `switchModelsOnFlag:false` into Claude Code's `--settings`, which had an unacceptable side effect: subagents could no longer freely choose their models.

This removes **all** settings injection and stops the session at the **conversation level** when a fallback is detected in the stream:

- **Detection (two signals, both live-verified shapes):** the authoritative `system/model_refusal_fallback` notice (carries category + refused-message checkpoint), plus a fast served-model family check on every assistant message (Fable → any Opus, Opus 5 → Opus 4.8; Sonnet/Haiku subagents and `<synthetic>` never match, at most one fire per turn). The fast path also covers resuming a session already stuck on the fallback model, where no new notice is emitted.
- **Stop:** on detection (setting on + active session), the runtime clears the queue, marks the turn idle, and shuts the provider process down — the same proven stop used by orchestrate cancel. The next send auto-restarts from the resume cursor with the originally selected `--model`, undoing Claude Code's session-sticky fallback without a manual `/model`.
- **No spawn-side coupling left:** `SessionOptions::abort_on_model_fallback` is removed; the recovery card, blocked-turn handling, and review advisor are unchanged. Setting descriptions (en/zh-CN) updated — subagents are unaffected.

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, full `cargo test --workspace --locked` all pass.
- New tests: the family-rule matrix, one-emission-per-turn mapper test, and a runtime test asserting queue cleared + idle timeline + provider shutdown.
- `grep -rn 'availableModels|switchModelsOnFlag|fallback_guard' crates/` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)