### PR TITLE
feat(sidebar): show distinct badge when only background tasks remain

### DIFF
--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -119,6 +119,8 @@ struct ThreadFlags {
     waiting_for_approval: bool,
     waiting_for_input: bool,
     working: bool,
+    /// Working only because background tasks remain; the turn has finished.
+    background: bool,
 }
 
 struct ThreadRowState {
@@ -126,6 +128,7 @@ struct ThreadRowState {
     row_key: String,
     waiting_for_approval: bool,
     waiting_for_input: bool,
+    background: bool,
     is_worktree: bool,
     is_child: bool,
     show_unread: bool,
@@ -1461,6 +1464,7 @@ impl SessionsSidebar {
             row_key,
             waiting_for_approval: own_flags.waiting_for_approval,
             waiting_for_input: own_flags.waiting_for_input,
+            background: own_flags.background,
             is_worktree: meta.worktree.is_some(),
             is_child: render_state.is_child,
             show_unread: render_state.show_unread,
@@ -1564,6 +1568,11 @@ impl SessionsSidebar {
             (cx.theme().warning, crate::tr!("sidebar.waiting_approval"))
         } else if state.waiting_for_input {
             (cx.theme().warning, crate::tr!("sidebar.waiting_input"))
+        } else if working && state.background {
+            (
+                cx.theme().muted_foreground,
+                crate::tr!("sidebar.background_tasks"),
+            )
         } else if working {
             (cx.theme().primary, crate::tr!("sidebar.working"))
         } else {
@@ -2125,6 +2134,7 @@ impl Render for SessionsSidebar {
                             waiting_for_approval: store.pending_approval_for(&meta.id),
                             waiting_for_input: store.pending_user_input_for(&meta.id),
                             working: store.turn_running_for(&meta.id),
+                            background: store.background_only_for(&meta.id),
                         },
                     )
                 })

--- a/crates/ui/src/store/mod.rs
+++ b/crates/ui/src/store/mod.rs
@@ -95,7 +95,9 @@ pub struct WorkspaceStore {
     session_status_replica: Option<SessionStatus>,
     providers_replica: ProvidersStatus,
     git_status_replica: GitStatusStatus,
-    background_session_flags: HashMap<String, (bool, bool, bool)>,
+    /// (working, pending_approval, pending_user_input, background_only) for
+    /// parked sessions.
+    background_session_flags: HashMap<String, (bool, bool, bool, bool)>,
     active_destination: Option<ConversationDestination>,
     /// One-shot turn navigation requested by a cross-session content search.
     pending_chat_turn: Option<(String, usize)>,
@@ -325,6 +327,7 @@ impl WorkspaceStore {
                             previous_status.working,
                             previous_status.pending_approval,
                             previous_status.pending_user_input,
+                            Self::status_background_only(previous_status),
                         ),
                     );
                 }
@@ -433,6 +436,7 @@ impl WorkspaceStore {
                             status.working,
                             status.pending_approval,
                             status.pending_user_input,
+                            Self::status_background_only(status),
                         ),
                     );
                 }
@@ -614,7 +618,7 @@ impl WorkspaceStore {
             + self
                 .background_session_flags
                 .values()
-                .filter(|(working, _, _)| *working)
+                .filter(|(working, ..)| *working)
                 .count()
     }
 
@@ -935,6 +939,28 @@ impl WorkspaceStore {
                 self.background_session_flags
                     .get(session_id)
                     .map(|flags| flags.0)
+            })
+            .unwrap_or(false)
+    }
+
+    /// Working only because provider background tasks are still running: the
+    /// turn itself has finished and nothing is queued or in delivery.
+    fn status_background_only(status: &SessionStatus) -> bool {
+        status.working
+            && !status.turn_running
+            && status.delivery_in_flight.is_none()
+            && status.queued_messages.is_empty()
+    }
+
+    pub fn background_only_for(&self, session_id: &str) -> bool {
+        self.session_status_replica
+            .as_ref()
+            .filter(|status| status.session_id == session_id)
+            .map(Self::status_background_only)
+            .or_else(|| {
+                self.background_session_flags
+                    .get(session_id)
+                    .map(|flags| flags.3)
             })
             .unwrap_or(false)
     }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -122,6 +122,7 @@ sidebar:
     got_it: "Got it"
     open_settings: "Open Settings"
   working: "Working"
+  background_tasks: "Background"
   child_threads: "%{count} child threads"
   waiting_approval: "Approval"
   waiting_approval_tooltip: "Waiting for approval"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -122,6 +122,7 @@ sidebar:
     got_it: "知道了"
     open_settings: "打开设置"
   working: "工作中"
+  background_tasks: "后台中"
   child_threads: "%{count} 个子对话"
   waiting_approval: "待审批"
   waiting_approval_tooltip: "正在等待审批"


### PR DESCRIPTION
## Summary
- The sidebar showed Working whenever `SessionStatus.working` was true, which merges turn-in-flight, delivery, queued messages, and provider background tasks into one boolean. After a turn ends with a long-running background command, the row kept saying Working.
- Derive a background-only state client-side from fields `SessionStatus` already carries (`working && !turn_running && no delivery && no queue`) — no protocol change.
- Render it as a muted Background badge; a real running turn keeps the blue Working badge, and approval/input states keep priority.

## Testing
- `cargo check -p tcode-ui`
- `cargo test -p tcode-ui` sidebar/store/i18n suites pass