### PR TITLE
fix(runtime): restore last-used reasoning effort on model switch

### DIFF
--- a/crates/runtime/src/app/options.rs
+++ b/crates/runtime/src/app/options.rs
@@ -18,6 +18,7 @@ impl AppState {
         cx: &mut HostCx,
     ) {
         let profile_id = profile_id.filter(|id| !Settings::is_builtin_profile_id(id));
+        let remembered_effort = self.remembered_effort(provider, model.as_deref());
         let store = self.store.clone();
         let Some(active) = self.residents.active.as_mut() else {
             return;
@@ -37,8 +38,9 @@ impl AppState {
             active.meta.profile_id = profile_id;
             active.meta.model = model;
             // A different model has different option descriptors: drop stale
-            // selections so each resolves to the new model's defaults.
+            // selections, then restore the effort last used with this model.
             active.meta.option_selections.clear();
+            active.meta.option_selections.extend(remembered_effort);
             active.provider_commands = store.load_commands(active.meta.provider, None);
             active.pending_ultrathink = false;
             return;
@@ -68,6 +70,7 @@ impl AppState {
             active.meta.profile_id = profile_id;
             active.meta.model = model;
             active.meta.option_selections.clear();
+            active.meta.option_selections.extend(remembered_effort);
             active.provider_commands = store.load_commands(provider, None);
             active.provider_options.clear();
             active.pending_ultrathink = false;
@@ -82,6 +85,7 @@ impl AppState {
         }
         active.meta.model = model;
         active.meta.option_selections.clear();
+        active.meta.option_selections.extend(remembered_effort);
         active.pending_ultrathink = false;
         if active.pending_relay.is_some() {
             return;

--- a/crates/runtime/src/app/sessions.rs
+++ b/crates/runtime/src/app/sessions.rs
@@ -966,6 +966,28 @@ impl AppState {
         }
     }
 
+    /// The reasoning effort last used with exactly this (provider, model),
+    /// from the most recently updated session that ran it (archived included:
+    /// memory outlives the thread). Model switches restore this instead of
+    /// resetting to the model's default. Keyed per model, so the remembered
+    /// value is always one the model accepts.
+    pub(super) fn remembered_effort(
+        &self,
+        provider: ProviderKind,
+        model: Option<&str>,
+    ) -> Option<OptionSelection> {
+        self.sessions
+            .iter()
+            .filter(|meta| meta.provider == provider && meta.model.as_deref() == model)
+            .max_by_key(|meta| meta.updated_at)
+            .and_then(|meta| {
+                meta.option_selections
+                    .iter()
+                    .find(|selection| selection.id == "reasoningEffort")
+                    .cloned()
+            })
+    }
+
     /// Switch the main area into a draft for `project_id` (rooted at `cwd`): an
     /// empty timeline with a focused, functional composer. The session is
     /// created lazily on the first send (see `send_turn`/`commit_draft`).

--- a/crates/runtime/src/app/tests.rs
+++ b/crates/runtime/src/app/tests.rs
@@ -1266,6 +1266,50 @@ fn draft_model_selection_switches_to_the_rows_explicit_provider() {
 }
 
 #[test]
+fn model_switch_restores_last_effort_used_with_that_model() {
+    let cx = &mut TestAppContext::default();
+    let test_store = TestStore::new("tcode-model-switch-effort-memory-test");
+    let store = (*test_store).clone();
+    let state = cx.new_entity(|_| AppState::new(store));
+
+    state.host_update(cx, |state, cx| {
+        let mut sol = SessionMeta::new(
+            ProviderKind::Codex,
+            PathBuf::from("/tmp/sol"),
+            Some("gpt-5.6-sol".into()),
+        );
+        sol.project_id = Some("project-target".into());
+        sol.updated_at = 10;
+        sol.option_selections.push(OptionSelection {
+            id: "reasoningEffort".into(),
+            value: serde_json::json!("max"),
+        });
+        let mut fable = SessionMeta::new(
+            ProviderKind::ClaudeCode,
+            PathBuf::from("/tmp/fable"),
+            Some("claude-fable-5".into()),
+        );
+        fable.project_id = Some("project-target".into());
+        fable.updated_at = 20;
+        state.sessions = vec![sol, fable];
+        state.start_draft("project-target".into(), PathBuf::from("/tmp/target"), cx);
+
+        // Switching the draft to a model brings back the effort it last ran at,
+        // not the model's default.
+        state.set_active_model(ProviderKind::Codex, Some("gpt-5.6-sol".into()), None, cx);
+
+        let draft = state.residents.active.as_ref().unwrap();
+        assert_eq!(draft.meta.model.as_deref(), Some("gpt-5.6-sol"));
+        assert_eq!(draft.meta.option_selections.len(), 1);
+        assert_eq!(draft.meta.option_selections[0].id, "reasoningEffort");
+        assert_eq!(
+            draft.meta.option_selections[0].value,
+            serde_json::json!("max")
+        );
+    });
+}
+
+#[test]
 fn draft_inherits_acp_agent_id_from_project_history() {
     let test_store = TestStore::new("tcode-draft-acp-defaults-test");
     let store = (*test_store).clone();


### PR DESCRIPTION
## Problem

Switching the active model (draft or established session) unconditionally cleared `option_selections`, so reasoning effort always reset to the model's default — e.g. every new conversation switched to `gpt-5.6-sol` came up at `low`.

## Fix

Each session's meta already persists the effort it ran at, so no new storage is needed. `set_active_model` now restores the `reasoningEffort` last used with exactly that `(provider, model)` from session history (most recently updated match, archived included) after clearing stale selections. Keyed per model, the remembered value is always one the target model accepts.

- `sessions.rs`: new `remembered_effort()` helper next to `draft_defaults`
- `options.rs`: all three clear sites in `set_active_model` re-extend with the remembered effort

## Test

`model_switch_restores_last_effort_used_with_that_model`: last `gpt-5.6-sol` session ran at `max`, newest session is `claude-fable-5`; switching a fresh draft back to sol restores `max`. Full `cargo test -p tcode-runtime`: 124 passed.