### PR TITLE
fix(ui): tighten oversized padding and add visible borders to dropdown triggers

### DIFF
--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -1810,7 +1810,7 @@ impl Render for ChatView {
         .with_sizing_behavior(gpui::ListSizingBehavior::Auto)
         .flex_1()
         .min_h_0()
-        .py_6();
+        .py_4();
 
         let composer: AnyElement = if native_subagent_readonly {
             div()

--- a/crates/ui/src/composer/components/checkout.rs
+++ b/crates/ui/src/composer/components/checkout.rs
@@ -23,6 +23,7 @@ impl Composer {
         let right: AnyElement = if turn_running {
             Button::new("branch-picker")
                 .ghost()
+                .outline()
                 .compact()
                 .tooltip(crate::tr!("composer.wait_turn"))
                 .child(
@@ -39,16 +40,20 @@ impl Composer {
             let store_open = self.workspace_store.clone();
             let store_content = self.workspace_store.clone();
             let current = picker_current.clone();
-            let trigger = Button::new("branch-picker").ghost().compact().child(
-                h_flex()
-                    .gap_1p5()
-                    .items_center()
-                    .text_size(px(13.))
-                    .text_color(muted)
-                    .child(Icon::empty().path("icons/git-branch.svg").xsmall())
-                    .child(picker_current.clone())
-                    .child(Icon::new(IconName::ChevronDown).xsmall().text_color(muted)),
-            );
+            let trigger = Button::new("branch-picker")
+                .ghost()
+                .outline()
+                .compact()
+                .child(
+                    h_flex()
+                        .gap_1p5()
+                        .items_center()
+                        .text_size(px(13.))
+                        .text_color(muted)
+                        .child(Icon::empty().path("icons/git-branch.svg").xsmall())
+                        .child(picker_current.clone())
+                        .child(Icon::new(IconName::ChevronDown).xsmall().text_color(muted)),
+                );
             crate::material::overlay_popover("branch-popover")
                 .anchor(Anchor::BottomRight)
                 .trigger(trigger)
@@ -158,7 +163,6 @@ impl Composer {
             h_flex()
                 .w_full()
                 .px_2()
-                .pt_2()
                 .items_center()
                 .justify_between()
                 .text_size(px(13.))
@@ -199,16 +203,20 @@ impl Composer {
 
         let store_content = self.workspace_store.clone();
         let base_default = base_default.to_string();
-        let trigger = Button::new("workspace-picker").ghost().compact().child(
-            h_flex()
-                .gap_1p5()
-                .items_center()
-                .text_size(px(13.))
-                .text_color(muted)
-                .child(Icon::empty().path("icons/folder-closed.svg").xsmall())
-                .child(label)
-                .child(Icon::new(IconName::ChevronDown).xsmall().text_color(muted)),
-        );
+        let trigger = Button::new("workspace-picker")
+            .ghost()
+            .outline()
+            .compact()
+            .child(
+                h_flex()
+                    .gap_1p5()
+                    .items_center()
+                    .text_size(px(13.))
+                    .text_color(muted)
+                    .child(Icon::empty().path("icons/folder-closed.svg").xsmall())
+                    .child(label)
+                    .child(Icon::new(IconName::ChevronDown).xsmall().text_color(muted)),
+            );
         crate::material::overlay_popover("workspace-popover")
             .anchor(Anchor::BottomLeft)
             .trigger(trigger)

--- a/crates/ui/src/composer/components/pickers.rs
+++ b/crates/ui/src/composer/components/pickers.rs
@@ -200,6 +200,7 @@ impl Composer {
 
         let trigger = Button::new("model-picker")
             .ghost()
+            .outline()
             .compact()
             .h(px(28.))
             .rounded(crate::material::radius_input())
@@ -286,6 +287,7 @@ impl Composer {
 
         let trigger = Button::new("traits-chip")
             .ghost()
+            .outline()
             .compact()
             .h(px(28.))
             .rounded(crate::material::radius_chip())
@@ -406,6 +408,7 @@ impl Composer {
 
         let trigger = Button::new("permission-chip")
             .ghost()
+            .outline()
             .compact()
             .h(px(28.))
             .rounded(crate::material::radius_input())

--- a/crates/ui/src/composer/mod.rs
+++ b/crates/ui/src/composer/mod.rs
@@ -1024,8 +1024,8 @@ impl Render for Composer {
             .w_full()
             .items_center()
             .px(px(crate::chat::CONTENT_MIN_PADDING))
-            .pt_2()
-            .pb_3()
+            .pt_1()
+            .pb_2()
             // Shift+Tab toggles Build ↔ Plan (S1 §4).
             .on_key_down(cx.listener(|this, ev: &gpui::KeyDownEvent, _, cx| {
                 if ev.keystroke.key == "tab" && ev.keystroke.modifiers.shift {

--- a/crates/ui/src/diff/view.rs
+++ b/crates/ui/src/diff/view.rs
@@ -828,15 +828,19 @@ impl DiffPanel {
         let panel = cx.entity();
         let session_selector = session.clone();
 
-        let trigger = Button::new("diff-turn-select").ghost().compact().child(
-            h_flex()
-                .gap_1p5()
-                .items_center()
-                .text_size(px(13.))
-                .font_medium()
-                .child(label)
-                .child(Icon::new(IconName::ChevronDown).xsmall().text_color(muted)),
-        );
+        let trigger = Button::new("diff-turn-select")
+            .ghost()
+            .outline()
+            .compact()
+            .child(
+                h_flex()
+                    .gap_1p5()
+                    .items_center()
+                    .text_size(px(13.))
+                    .font_medium()
+                    .child(label)
+                    .child(Icon::new(IconName::ChevronDown).xsmall().text_color(muted)),
+            );
 
         let selector = Popover::new("diff-turn-popover")
             .trigger(trigger)
@@ -1087,6 +1091,7 @@ impl DiffPanel {
             let session_base = session.clone();
             let trigger = Button::new("diff-base-select")
                 .ghost()
+                .outline()
                 .compact()
                 .label(current.clone())
                 .icon(IconName::ChevronDown);

--- a/crates/ui/src/orchestrate_settings.rs
+++ b/crates/ui/src/orchestrate_settings.rs
@@ -545,10 +545,11 @@ impl OrchestrateSettingsPanel {
             }
             ChildApprovalMode::Manual => crate::tr!("orchestrate.child_approval.manual"),
         };
-        // Ghost, not outline: a quiet resting trigger that only tints on hover,
-        // consistent with the General page dropdowns and the composer picker.
+        // A quiet resting trigger that only tints on hover, consistent with the
+        // General page dropdowns and the composer picker.
         let trigger = Button::new("orchestrate-child-approval-dropdown")
             .ghost()
+            .outline()
             .compact()
             .child(
                 h_flex()

--- a/crates/ui/src/provider_card.rs
+++ b/crates/ui/src/provider_card.rs
@@ -322,6 +322,8 @@ impl ProviderCard {
         let store = self.store.clone();
 
         crate::material::overlay_popover("update-popover")
+            // Prose card, not a menu: keep the roomier panel padding.
+            .p_3()
             .trigger(
                 Button::new("update-available")
                     .ghost()

--- a/crates/ui/src/provider_model_picker.rs
+++ b/crates/ui/src/provider_model_picker.rs
@@ -192,24 +192,27 @@ impl ProviderModelPicker {
                     });
                 let display = self.display_name(provider, model, profile_id, cx);
                 let glyph = tinted_glyph(&self.store, provider, profile_id, cx);
-                // Ghost, not outline: a quiet resting trigger (glyph + value +
-                // muted chevron) that only tints on hover, matching the
-                // composer's model picker. The "Add" variant stays an outlined
-                // action button.
-                Button::new(self.trigger_id).ghost().compact().child(
-                    h_flex()
-                        .w(px(230.))
-                        .items_center()
-                        .gap_2()
-                        .text_size(px(13.))
-                        .child(glyph.small())
-                        .child(div().flex_1().min_w_0().child(display))
-                        .child(
-                            Icon::new(IconName::ChevronDown)
-                                .xsmall()
-                                .text_color(cx.theme().muted_foreground),
-                        ),
-                )
+                // A quiet resting trigger (glyph + value + muted chevron) that
+                // only tints on hover, matching the composer's model picker; the
+                // hairline marks it as a dropdown.
+                Button::new(self.trigger_id)
+                    .ghost()
+                    .outline()
+                    .compact()
+                    .child(
+                        h_flex()
+                            .w(px(230.))
+                            .items_center()
+                            .gap_2()
+                            .text_size(px(13.))
+                            .child(glyph.small())
+                            .child(div().flex_1().min_w_0().child(display))
+                            .child(
+                                Icon::new(IconName::ChevronDown)
+                                    .xsmall()
+                                    .text_color(cx.theme().muted_foreground),
+                            ),
+                    )
             }
         }
     }

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -825,6 +825,8 @@ impl SettingsPage {
         let release_url = status.release_url.unwrap_or_default();
 
         crate::material::overlay_popover("tcode-update-popover")
+            // Prose card, not a menu: keep the roomier panel padding.
+            .p_3()
             .trigger(
                 Button::new("tcode-update-available")
                     .ghost()
@@ -1555,11 +1557,10 @@ impl SettingsPage {
         label: impl Into<SharedString>,
         cx: &Context<Self>,
     ) -> Button {
-        // Ghost, not outline: transparent at rest (value + muted chevron) with a
-        // light tint only on hover — the same quiet trigger the composer's model
-        // picker uses. An outlined trigger reads as a card nested inside the
-        // already-bordered group.
-        Button::new(id).ghost().compact().child(
+        // Ghost fill (transparent at rest, light tint on hover) over a hairline
+        // outline — the same quiet trigger the composer's model picker uses, but
+        // bordered so it reads as a dropdown rather than plain text.
+        Button::new(id).ghost().outline().compact().child(
             gpui_base::h_flex()
                 .w(px(160.))
                 .items_center()

--- a/crates/ui/src/widgets/button.rs
+++ b/crates/ui/src/widgets/button.rs
@@ -221,7 +221,10 @@ impl RenderOnce for Button {
                 theme.success.opacity(0.3),
                 theme.success,
             ),
-            ButtonVariant::Ghost => (transparent, theme.foreground, theme.muted, transparent),
+            // Transparent at rest; the hairline only shows with `.outline()`
+            // (border width is 0 otherwise), which is how select/dropdown
+            // triggers read as interactive controls.
+            ButtonVariant::Ghost => (transparent, theme.foreground, theme.muted, theme.border),
             ButtonVariant::Text => (
                 transparent,
                 theme.foreground.opacity(0.9),

--- a/crates/ui/src/widgets/menu.rs
+++ b/crates/ui/src/widgets/menu.rs
@@ -207,7 +207,6 @@ impl Render for PopupMenu {
             .min_w(px(160.))
             .max_w(px(420.))
             .p_1()
-            .gap_1()
             .rounded(crate::material::radius_overlay())
             .bg(cx.theme().popover)
             .border_1()
@@ -217,7 +216,7 @@ impl Render for PopupMenu {
         for (index, item) in self.items.iter().enumerate() {
             match item {
                 MenuItem::Separator => {
-                    root = root.child(div().h(px(1.)).mx_1().bg(cx.theme().border))
+                    root = root.child(div().h(px(1.)).mx_1().my_1().bg(cx.theme().border))
                 }
                 MenuItem::Item {
                     label,

--- a/crates/ui/src/widgets/popover.rs
+++ b/crates/ui/src/widgets/popover.rs
@@ -139,7 +139,7 @@ impl RenderOnce for Popover {
                     .id("tcode-popover-content")
                     .occlude()
                     .when(appearance, |el| {
-                        el.p_3()
+                        el.p_1()
                             .rounded(crate::material::radius_overlay())
                             .bg(cx.theme().popover)
                             .border_1()


### PR DESCRIPTION
## Feedback addressed

Many components had unnecessarily large padding, hurting visual density:

1. **ChatView**: gap between the message stream and the composer — timeline `py_6` → `py_4`, composer wrapper `pt_2` → `pt_1` (32px → 20px combined)
2. **Composer → worktree/branch row**: removed a `pt_2` stacking on the parent's `gap_2`; wrapper `pb_3` → `pb_2` (16px → 8px)
3. **Top-right Commit / Open menus**: shared popover panel padding `p_3` → `p_1` (16px → 8px inset)
4. **Model / reasoning-effort / permission popovers**: covered by the same shared popover change
5. **Settings select menus**: same shared change; the two prose-card popovers (update notices) explicitly keep `p_3`
6. **Dropdown triggers lacked a visible border**: Ghost buttons now use `theme.border` as their border color — still zero-width by default, visible only with `.outline()`, which was applied to every value+chevron select trigger (settings selects, composer model/effort/permission pickers, branch/workspace pickers, diff turn/base selects, provider model picker, orchestrate child-approval dropdown)
7. **Shared context menu** (markdown link right-click, sidebar, terminal): dropped the `gap_1` between items; separators keep `my_1` breathing room

Deliberately not bordered: split-button chevrons (already inside a bordered group) and bare icon-only ghost buttons.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — 878 passed, 0 failed