### PR TITLE
fix(markdown,menu): make link clicks and context menus reliable

### DIFF
--- a/crates/ui/src/markdown/inline.rs
+++ b/crates/ui/src/markdown/inline.rs
@@ -360,23 +360,33 @@ impl Element for Inline {
             let text = self.text.clone();
             let view = self.view.clone();
             move |event: &MouseDownEvent, phase, window, cx| {
-                if !phase.bubble()
-                    || event.button != MouseButton::Right
-                    || !hitbox.is_hovered(window)
-                {
+                if !phase.bubble() || !hitbox.is_hovered(window) {
                     return;
                 }
-                let pending = Self::link_and_range_for_position(&layout, &links, event.position)
-                    .map(|(range, link)| {
-                        let target = view.read(cx).resolve_link(&link.url);
-                        let text = text.get(range).map(SharedString::from).unwrap_or_default();
-                        PendingLinkMenu {
-                            target,
-                            text,
-                            raw_url: link.url,
-                        }
-                    });
-                view.update(cx, |state, cx| state.set_pending_context_link(pending, cx));
+                match event.button {
+                    MouseButton::Left => {
+                        let origin = Self::link_for_position(&layout, &links, event.position)
+                            .is_some()
+                            .then_some(event.position);
+                        view.update(cx, |state, _| state.link_press_origin = origin);
+                    }
+                    MouseButton::Right => {
+                        let pending =
+                            Self::link_and_range_for_position(&layout, &links, event.position)
+                                .map(|(range, link)| {
+                                    let target = view.read(cx).resolve_link(&link.url);
+                                    let text =
+                                        text.get(range).map(SharedString::from).unwrap_or_default();
+                                    PendingLinkMenu {
+                                        target,
+                                        text,
+                                        raw_url: link.url,
+                                    }
+                                });
+                        view.update(cx, |state, cx| state.set_pending_context_link(pending, cx));
+                    }
+                    _ => {}
+                }
             }
         });
 
@@ -389,8 +399,19 @@ impl Element for Inline {
                 if !phase.bubble()
                     || event.button != MouseButton::Left
                     || !hitbox.is_hovered(window)
-                    || gpui_base::TextSelection::has_selection(window, cx)
                 {
+                    return;
+                }
+                let Some(origin) = view.update(cx, |state, _| state.link_press_origin.take())
+                else {
+                    return;
+                };
+                // A press-and-release on the link is a click even with the
+                // pixel of jitter a real mouse adds; farther apart is a
+                // drag-selection. click_count 1 keeps a double-click (which
+                // selects the word) from opening the link a second time.
+                let moved = event.position - origin;
+                if event.click_count != 1 || moved.x.abs() > px(3.) || moved.y.abs() > px(3.) {
                     return;
                 }
                 if let Some(link) = Self::link_for_position(&layout, &links, event.position) {

--- a/crates/ui/src/markdown/inline.rs
+++ b/crates/ui/src/markdown/inline.rs
@@ -372,8 +372,8 @@ impl Element for Inline {
                     }
                     MouseButton::Right => {
                         let pending =
-                            Self::link_and_range_for_position(&layout, &links, event.position)
-                                .map(|(range, link)| {
+                            Self::link_and_range_for_position(&layout, &links, event.position).map(
+                                |(range, link)| {
                                     let target = view.read(cx).resolve_link(&link.url);
                                     let text =
                                         text.get(range).map(SharedString::from).unwrap_or_default();
@@ -382,7 +382,8 @@ impl Element for Inline {
                                         text,
                                         raw_url: link.url,
                                     }
-                                });
+                                },
+                            );
                         view.update(cx, |state, cx| state.set_pending_context_link(pending, cx));
                     }
                     _ => {}

--- a/crates/ui/src/markdown/state.rs
+++ b/crates/ui/src/markdown/state.rs
@@ -8,7 +8,7 @@ use std::{
 
 use gpui::{
     Bounds, Context, FocusHandle, IntoElement, ListAlignment, ListState, ParentElement as _,
-    Pixels, Render, SharedString, Styled as _, Window, px,
+    Pixels, Point, Render, SharedString, Styled as _, Window, px,
 };
 use gpui_base::{ElementExt as _, v_flex};
 
@@ -35,6 +35,9 @@ pub struct MarkdownState {
     pub(super) base_dir: Option<PathBuf>,
     link_targets: LinkTargetCache,
     pub(super) pending_context_link: Option<PendingLinkMenu>,
+    /// Window position of the last left mouse-down that landed on a link;
+    /// a mouse-up nearby is a click, anything farther is a drag-selection.
+    pub(super) link_press_origin: Option<Point<Pixels>>,
     pub(super) is_selecting: bool,
     text: String,
     parsed: BlockNode,
@@ -58,6 +61,7 @@ impl MarkdownState {
             base_dir: None,
             link_targets: LinkTargetCache::default(),
             pending_context_link: None,
+            link_press_origin: None,
             is_selecting: false,
             text: text.to_string(),
             parsed,

--- a/crates/ui/src/markdown/view.rs
+++ b/crates/ui/src/markdown/view.rs
@@ -907,6 +907,67 @@ mod tests {
     }
 
     #[gpui::test]
+    fn link_click_survives_pixel_jitter_but_not_a_drag(cx: &mut TestAppContext) {
+        cx.update(crate::theme::init);
+        cx.update(crate::markdown::init);
+        let (view, cx) = cx.add_window_view(|_, cx| RightClickRoot::new(cx));
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        let link_pos = view.read_with(cx, |root, cx| {
+            let link = root.markdown.read(cx).list_state.bounds_for_item(1).unwrap();
+            point(px(5.), link.center().y)
+        });
+
+        // A drag that starts on the link is a selection, not a click.
+        let far = point(link_pos.x + px(60.), link_pos.y);
+        cx.simulate_mouse_down(link_pos, MouseButton::Left, Modifiers::default());
+        cx.simulate_mouse_move(far, Some(MouseButton::Left), Modifiers::default());
+        cx.simulate_mouse_up(far, MouseButton::Left, Modifiers::default());
+        assert_eq!(cx.opened_url(), None, "a drag must not open the link");
+
+        // A press-and-release with a pixel of jitter is still a click.
+        let jittered = point(link_pos.x + px(1.), link_pos.y + px(1.));
+        cx.simulate_mouse_down(link_pos, MouseButton::Left, Modifiers::default());
+        cx.simulate_mouse_move(jittered, Some(MouseButton::Left), Modifiers::default());
+        cx.simulate_mouse_up(jittered, MouseButton::Left, Modifiers::default());
+        assert_eq!(cx.opened_url().as_deref(), Some("https://example.com"));
+    }
+
+    #[gpui::test]
+    fn link_context_menu_action_opens_the_url(cx: &mut TestAppContext) {
+        cx.update(crate::theme::init);
+        cx.update(crate::markdown::init);
+        cx.update(crate::widgets::menu::init);
+        let (view, cx) = cx.add_window_view(|_, cx| RightClickRoot::new(cx));
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        let link_pos = view.read_with(cx, |root, cx| {
+            let link = root.markdown.read(cx).list_state.bounds_for_item(1).unwrap();
+            point(px(5.), link.center().y)
+        });
+        cx.simulate_mouse_down(link_pos, MouseButton::Right, Modifiers::default());
+        cx.simulate_mouse_up(link_pos, MouseButton::Right, Modifiers::default());
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        // Select "Open Link" and confirm; the action must dispatch through
+        // the trigger's ancestor chain to the OpenLink handler.
+        cx.simulate_keystrokes("down enter");
+        cx.run_until_parked();
+        assert_eq!(cx.opened_url().as_deref(), Some("https://example.com"));
+    }
+
+    #[gpui::test]
     fn right_click_off_link_is_swallowed_so_no_menu_opens(cx: &mut TestAppContext) {
         cx.update(crate::theme::init);
         cx.update(crate::markdown::init);

--- a/crates/ui/src/markdown/view.rs
+++ b/crates/ui/src/markdown/view.rs
@@ -918,7 +918,12 @@ mod tests {
         });
 
         let link_pos = view.read_with(cx, |root, cx| {
-            let link = root.markdown.read(cx).list_state.bounds_for_item(1).unwrap();
+            let link = root
+                .markdown
+                .read(cx)
+                .list_state
+                .bounds_for_item(1)
+                .unwrap();
             point(px(5.), link.center().y)
         });
 
@@ -950,7 +955,12 @@ mod tests {
         });
 
         let link_pos = view.read_with(cx, |root, cx| {
-            let link = root.markdown.read(cx).list_state.bounds_for_item(1).unwrap();
+            let link = root
+                .markdown
+                .read(cx)
+                .list_state
+                .bounds_for_item(1)
+                .unwrap();
             point(px(5.), link.center().y)
         });
         cx.simulate_mouse_down(link_pos, MouseButton::Right, Modifiers::default());

--- a/crates/ui/src/widgets/menu.rs
+++ b/crates/ui/src/widgets/menu.rs
@@ -3,8 +3,9 @@ use std::rc::Rc;
 use gpui::{
     Action, AnyElement, App, AppContext as _, Context, DismissEvent, ElementId, Entity,
     EventEmitter, FocusHandle, Focusable, InteractiveElement, IntoElement, KeyBinding, MouseButton,
-    ParentElement, Render, RenderOnce, Role, SharedString, StatefulInteractiveElement as _, Styled,
-    Window, div, prelude::FluentBuilder, px,
+    MouseDownEvent, ParentElement, Pixels, Point, Render, RenderOnce, Role, SharedString,
+    StatefulInteractiveElement as _, Styled, Subscription, Window, anchored, deferred, div,
+    prelude::FluentBuilder, px,
 };
 use gpui_base::actions::{Cancel, Confirm, SelectDown, SelectUp};
 
@@ -339,21 +340,97 @@ pub trait ContextMenuExt:
 impl<T: InteractiveElement + ParentElement + Styled + IntoElement + 'static> ContextMenuExt for T {}
 
 #[derive(IntoElement)]
-pub struct ContextMenu<T: IntoElement + 'static> {
+pub struct ContextMenu<T: InteractiveElement + ParentElement + Styled + IntoElement + 'static> {
     id: ElementId,
     trigger: T,
     builder: MenuBuilder,
 }
-impl<T: IntoElement + 'static> RenderOnce for ContextMenu<T> {
+
+#[derive(Default)]
+struct ContextMenuState {
+    menu: Option<Entity<PopupMenu>>,
+    position: Point<Pixels>,
+    _subscription: Option<Subscription>,
+}
+
+impl<T: InteractiveElement + ParentElement + Styled + IntoElement + 'static> RenderOnce
+    for ContextMenu<T>
+{
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
-        menu_popover(
-            self.id,
-            self.trigger,
-            MouseButton::Right,
-            self.builder,
-            window,
-            cx,
-        )
+        let state = window.use_keyed_state((self.id, "context-menu"), cx, |_, _| {
+            ContextMenuState::default()
+        });
+        let builder = self.builder;
+        let mut trigger = self.trigger.on_mouse_down(MouseButton::Right, {
+            let state = state.clone();
+            move |event: &MouseDownEvent, window, cx| {
+                cx.stop_propagation();
+                let position = event.position;
+                let builder = builder.clone();
+                let state = state.clone();
+                // Deeper bubble handlers have already run, but entity updates
+                // they queued may not be applied yet; build after this event
+                // settles so the builder reads their state.
+                window.defer(cx, move |window, cx| {
+                    let menu =
+                        PopupMenu::build(window, cx, |menu, window, cx| builder(menu, window, cx));
+                    // A builder can decide there is nothing to offer (e.g. a
+                    // right-click on non-link Markdown text): open nothing.
+                    if menu.read(cx).is_empty() {
+                        return;
+                    }
+                    let previous_focus = window.focused(cx);
+                    let menu_focus = menu.focus_handle(cx);
+                    gpui_base::GlobalState::register_deferred_popover(&menu_focus, cx);
+                    let subscription = window.subscribe(&menu, cx, {
+                        let state = state.clone();
+                        move |_, _: &DismissEvent, window, cx| {
+                            state.update(cx, |state, _| {
+                                state.menu = None;
+                                state._subscription = None;
+                            });
+                            gpui_base::GlobalState::unregister_deferred_popover(&menu_focus, cx);
+                            if menu_focus.contains_focused(window, cx)
+                                && let Some(previous) = &previous_focus
+                            {
+                                previous.focus(window, cx);
+                            }
+                            window.refresh();
+                        }
+                    });
+                    menu.focus_handle(cx).focus(window, cx);
+                    state.update(cx, |state, _| {
+                        state.menu = Some(menu);
+                        state.position = position;
+                        state._subscription = Some(subscription);
+                    });
+                    window.refresh();
+                });
+            }
+        });
+        let (menu, position) = {
+            let state = state.read(cx);
+            (state.menu.clone(), state.position)
+        };
+        if let Some(menu) = menu {
+            // The menu stays a child of the trigger so its actions dispatch
+            // through the trigger's ancestor chain, where on_action handlers
+            // (on the trigger itself or above it) live.
+            trigger = trigger.child(
+                deferred(
+                    anchored()
+                        .position(position)
+                        .snap_to_window_with_margin(px(8.))
+                        .child(div().child(menu.clone()).on_mouse_down_out(
+                            move |_, _window, cx| {
+                                menu.update(cx, |_, cx| cx.emit(DismissEvent));
+                            },
+                        )),
+                )
+                .with_priority(gpui_base::POPUP_PRIORITY),
+            );
+        }
+        trigger
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes three defects in ChatView Markdown link interaction:

1. **Context menu opened at the wrong place** — the Popover-based `ContextMenu` could only anchor to the trigger element's bounds, and for Markdown the trigger is the whole block, so the menu appeared at the block's edge instead of the cursor. `ContextMenu` is rewritten (modeled on the upstream gpui-component implementation at the same pinned revision) to anchor at the right-click mouse position via `deferred` + `anchored().position(...)`, snapped to the window with an 8px margin. Sidebar and terminal context menus pick up mouse-position anchoring too.

2. **Menu items did nothing** — the menu rendered as a *sibling* of the trigger, while the `OpenLink`/`CopyLinkAddress`/`OpenPath`/… handlers are registered `on_action` on the trigger div itself. Actions dispatch along the focused (menu) node's ancestor chain, which never included the trigger, so every action was silently dropped. The menu is now a *child* of the trigger, putting those handlers on the dispatch path. The new `link_context_menu_action_opens_the_url` test fails on the old structure.

3. **Left clicks unreliable** — mouse-up was guarded by the window-wide `TextSelection::has_selection`, and the selection snapshot compares anchor/cursor as *pixels*, so the ~1px jitter of a real press-and-release registered as a selection and swallowed the click. Replaced with press-origin tracking: a release within 3px of a press that started on the link is a click; farther is a drag-selection. `click_count == 1` keeps a double-click (which selects the word) from opening the link twice.

## Changes

- `crates/ui/src/widgets/menu.rs` — `ContextMenu` rewritten off `gpui_base::Popover`: mouse-position anchoring, menu as trigger child, focus restore on dismiss, deferred-popover registration preserved (keeps the collapsed-sidebar hover overlay alive while a menu is open).
- `crates/ui/src/markdown/inline.rs` — link press-origin tracking replaces the `has_selection` guard.
- `crates/ui/src/markdown/state.rs` — new `link_press_origin` field.
- `crates/ui/src/markdown/view.rs` — two regression tests.

## Testing

- `cargo test -p tcode-ui`: 268 passed, 0 failed (includes new `link_click_survives_pixel_jitter_but_not_a_drag` and `link_context_menu_action_opens_the_url`).
- `cargo clippy -p tcode-ui`: clean.