### PR TITLE
perf(chat): keep the virtual list at full framerate in long sessions

### DIFF
--- a/crates/ui/benches/markdown_perf.rs
+++ b/crates/ui/benches/markdown_perf.rs
@@ -247,12 +247,14 @@ fn measure_streaming(document: &str) -> (Duration, Vec<Duration>) {
     let state = cx.new(|cx| MarkdownState::new("", cx));
     let mut deltas = Vec::with_capacity(STREAM_BYTES / STREAM_DELTA_BYTES);
     let total_start = Instant::now();
+    let mut offset = 0;
     for end in (STREAM_DELTA_BYTES..=STREAM_BYTES).step_by(STREAM_DELTA_BYTES) {
         let start = Instant::now();
         state.update(&mut cx, |state, cx| {
-            state.set_text(black_box(&document[..end]), cx)
+            state.push_str(black_box(&document[offset..end]), cx)
         });
         deltas.push(start.elapsed());
+        offset = end;
     }
     (total_start.elapsed(), deltas)
 }
@@ -336,10 +338,12 @@ fn markdown_benchmarks(c: &mut Criterion) {
         let state = cx.new(|cx| MarkdownState::new("", cx));
         b.iter(|| {
             state.update(&mut cx, |state, cx| state.set_text("", cx));
+            let mut start = 0;
             for end in (STREAM_DELTA_BYTES..=STREAM_BYTES).step_by(STREAM_DELTA_BYTES) {
                 state.update(&mut cx, |state, cx| {
-                    state.set_text(black_box(&stream_document[..end]), cx)
+                    state.push_str(black_box(&stream_document[start..end]), cx)
                 });
+                start = end;
             }
         });
     });

--- a/crates/ui/src/chat/components/assistant.rs
+++ b/crates/ui/src/chat/components/assistant.rs
@@ -15,6 +15,7 @@ use gpui::{
 };
 use gpui_base::{h_flex, v_flex};
 
+use crate::markdown::parse::ParsedDocument;
 use crate::markdown::{MarkdownState, MarkdownView};
 
 use super::super::model::{MdSync, md_sync};
@@ -30,6 +31,13 @@ impl MdState {
     pub(crate) fn new(text: &str, cx: &mut App) -> Self {
         Self {
             state: cx.new(|cx| MarkdownState::new(text, cx)),
+            synced: Arc::from(text),
+        }
+    }
+
+    pub(crate) fn from_parsed(text: &str, parsed: ParsedDocument, cx: &mut App) -> Self {
+        Self {
+            state: cx.new(|cx| MarkdownState::from_parsed(text, parsed, cx)),
             synced: Arc::from(text),
         }
     }

--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -29,7 +29,7 @@ use gpui_base::{StyledExt as _, h_flex, v_flex};
 
 use tcode_core::git::GitAction;
 use tcode_core::session::{
-    EntryContent, OrchestrateCallback, TimelineEntry, parse_orchestrate_callback,
+    EntryContent, OrchestrateCallback, Timeline, TimelineEntry, parse_orchestrate_callback,
 };
 use tcode_core::ui::RightTab;
 
@@ -47,15 +47,15 @@ use crate::window_state::WindowState;
 use self::components::assistant::MdState;
 use self::components::command_panel::CommandPanelCache;
 use self::model::{
-    ListSync, Segment, TurnListItem, TurnRenderArgs, activity_run_duration_ms, auto_expanded,
-    displayed_error_text, divergent_served_model, format_span, index_turns, latest_message_ids,
-    list_sync, live_activity_segment, live_edit_rows, manual_override_key, plain_text_as_markdown,
+    ListSync, Segment, TurnIndexCache, TurnListItem, TurnRenderArgs, activity_run_duration_ms,
+    auto_expanded, displayed_error_text, divergent_served_model, format_span, latest_message_ids,
+    live_activity_segment, live_edit_rows, manual_override_key, plain_text_as_markdown,
     segment_entries, start_hub_projects, timeline_overdraw, user_content, user_visible_text,
     work_log_auto_expands, work_log_capsule_label, work_log_counts, work_log_outcome,
     work_log_row_entries,
 };
 use self::residency::{
-    MarkdownEntry, ResidencyInput, decide, tail_turn_window, viewport_turn_window,
+    MarkdownEntry, ResidencyInput, ResidencyScope, decide, tail_turn_window, viewport_turn_window,
 };
 pub(crate) use crate::material::{
     CHAT_CONTENT_MAX_WIDTH as CONTENT_MAX_WIDTH, CHAT_CONTENT_MIN_PADDING as CONTENT_MIN_PADDING,
@@ -74,6 +74,7 @@ pub struct ChatView {
     terminal_drawer: Entity<TerminalDrawer>,
     list_state: ListState,
     turn_items: Vec<TurnListItem>,
+    turn_index_cache: TurnIndexCache,
     md_states: HashMap<String, MdState>,
     markdown_visible_turns: Range<usize>,
     markdown_scroll_top: Option<usize>,
@@ -138,6 +139,7 @@ impl ChatView {
             terminal_drawer,
             list_state,
             turn_items: Vec::new(),
+            turn_index_cache: TurnIndexCache::default(),
             md_states: HashMap::new(),
             markdown_visible_turns: 0..0,
             markdown_scroll_top: None,
@@ -158,11 +160,16 @@ impl ChatView {
     /// Mirror timeline markdown text into synchronous [`MarkdownState`] entities.
     fn sync_markdown_states(&mut self, cx: &mut Context<Self>) {
         let session_key = self.workspace_store.read(cx).active_session_id();
-        let (running, turn_items) = self
+        let session_changed = session_key != self.session_key;
+        if session_changed {
+            self.expanded.clear();
+        }
+        let (running, list_sync) = self
             .workspace_store
             .read(cx)
             .with_active_timeline(|timeline| {
-                let turn_items = index_turns(
+                let list_sync = self.turn_index_cache.sync(
+                    &mut self.turn_items,
                     &timeline.turns,
                     &timeline.entries,
                     timeline
@@ -170,26 +177,33 @@ impl ChatView {
                         .as_ref()
                         .map(|plan| (plan.turn, plan.item_id.as_str(), plan.markdown.as_str())),
                     &self.expanded,
+                    session_changed,
                 );
-                (timeline.turn_running, turn_items)
+                (timeline.turn_running, list_sync)
             })
-            .unwrap_or_default();
+            .unwrap_or_else(|| {
+                let list_sync = self.turn_index_cache.sync(
+                    &mut self.turn_items,
+                    &[],
+                    &[],
+                    None,
+                    &self.expanded,
+                    session_changed,
+                );
+                (false, list_sync)
+            });
 
-        let session_changed = session_key != self.session_key;
         let requested_turn = session_key
             .as_deref()
             .and_then(|session_id| self.workspace_store.read(cx).pending_chat_turn(session_id));
-        let list_sync = list_sync(&self.turn_items, &turn_items, session_changed);
         if session_changed {
             self.md_states.clear();
-            self.expanded.clear();
             self.command_panels.borrow_mut().clear();
             self.highlighted_turn = None;
             self.session_key = session_key;
-            self.markdown_visible_turns = tail_turn_window(turn_items.len());
-            self.markdown_scroll_top = Some(turn_items.len());
+            self.markdown_visible_turns = tail_turn_window(self.turn_items.len());
+            self.markdown_scroll_top = Some(self.turn_items.len());
         }
-        self.turn_items = turn_items;
 
         match list_sync {
             ListSync::None => {}
@@ -278,34 +292,13 @@ impl ChatView {
             .workspace_store
             .read(cx)
             .with_active_timeline(|timeline| {
-                let mut entries = Vec::new();
-                for entry in &timeline.entries {
-                    let markdown_bearing = matches!(
-                        entry.content,
-                        EntryContent::Item(ItemContent::AssistantMessage { .. })
-                            | EntryContent::Item(ItemContent::Reasoning { .. })
-                    ) || user_content(&entry.content).is_some();
-                    if markdown_bearing {
-                        entries.push(MarkdownEntry {
-                            id: entry.id.clone(),
-                            turn: entry.turn,
-                            turn_running: timeline
-                                .turns
-                                .get(entry.turn)
-                                .is_some_and(|turn| turn.running),
-                        });
-                    }
-                }
-                if let Some(plan) = &timeline.proposed_plan {
-                    entries.push(MarkdownEntry {
-                        id: format!("plan:{}", plan.item_id),
-                        turn: plan.turn,
-                        turn_running: timeline
-                            .turns
-                            .get(plan.turn)
-                            .is_some_and(|turn| turn.running),
-                    });
-                }
+                let scope = ResidencyScope::new(
+                    turn_count,
+                    self.markdown_visible_turns.clone(),
+                    one_shot_turn_target,
+                    timeline.turn_running,
+                );
+                let entries = markdown_entries_for_residency(timeline, &scope).entries;
                 let decisions = decide(ResidencyInput {
                     turn_count,
                     visible_turns: self.markdown_visible_turns.clone(),
@@ -1711,6 +1704,58 @@ impl ChatView {
     }
 }
 
+struct ResidencyMarkdownEntries {
+    entries: Vec<MarkdownEntry>,
+    #[cfg(test)]
+    constructions: usize,
+}
+
+fn markdown_entries_for_residency(
+    timeline: &Timeline,
+    scope: &ResidencyScope,
+) -> ResidencyMarkdownEntries {
+    let mut entries = Vec::new();
+    for entry in &timeline.entries {
+        let turn_running = timeline
+            .turns
+            .get(entry.turn)
+            .is_some_and(|turn| turn.running);
+        if !scope.includes(entry.turn, turn_running) {
+            continue;
+        }
+        let markdown_bearing = matches!(
+            entry.content,
+            EntryContent::Item(ItemContent::AssistantMessage { .. })
+                | EntryContent::Item(ItemContent::Reasoning { .. })
+        ) || user_content(&entry.content).is_some();
+        if markdown_bearing {
+            entries.push(MarkdownEntry {
+                id: entry.id.clone(),
+                turn: entry.turn,
+                turn_running,
+            });
+        }
+    }
+    if let Some(plan) = &timeline.proposed_plan {
+        let turn_running = timeline
+            .turns
+            .get(plan.turn)
+            .is_some_and(|turn| turn.running);
+        if scope.includes(plan.turn, turn_running) {
+            entries.push(MarkdownEntry {
+                id: format!("plan:{}", plan.item_id),
+                turn: plan.turn,
+                turn_running,
+            });
+        }
+    }
+    ResidencyMarkdownEntries {
+        #[cfg(test)]
+        constructions: entries.len(),
+        entries,
+    }
+}
+
 impl Render for ChatView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         self.sync_markdown_scroll_position(cx);
@@ -1936,7 +1981,7 @@ fn open_in_zed(cwd: &Path, window: &mut Window, cx: &mut App) {
 
 #[cfg(test)]
 mod tests {
-    use super::ChatView;
+    use super::{ChatView, ResidencyScope, markdown_entries_for_residency};
     use crate::store::WorkspaceStore;
     use crate::window_state::WindowState;
     use agent::ItemContent;
@@ -1948,6 +1993,21 @@ mod tests {
     use tcode_core::session::{EntryContent, Timeline, TimelineEntry, TurnMeta};
 
     static NEXT_RESIDENCY_TEST_ID: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn residency_markdown_entry_allocations_are_bounded_by_candidate_windows() {
+        let mut timeline = synthetic_markdown_timeline(200);
+        timeline.turns[5].running = true;
+        timeline.turn_running = true;
+        let scope = ResidencyScope::new(200, 40..48, None, true);
+
+        let candidates = markdown_entries_for_residency(&timeline, &scope);
+
+        assert_eq!(candidates.constructions, 177);
+        assert!(candidates.constructions < timeline.entries.len());
+        assert!(candidates.entries.iter().any(|entry| entry.turn == 5));
+        assert!(candidates.entries.iter().any(|entry| entry.turn == 199));
+    }
 
     #[gpui::test]
     fn chat_view_applies_markdown_residency_decisions(cx: &mut TestAppContext) {

--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -67,6 +67,16 @@ const TRAFFIC_LIGHT_INSET: f32 = 80.;
 /// Vertical rhythm between turns. Turns are separated by space and typographic
 /// hierarchy alone — there is deliberately no rule/divider under the user bubble.
 const TURN_GAP: f32 = 32.;
+/// Large documents are parsed away from the UI executor before becoming resident.
+const ASYNC_MARKDOWN_THRESHOLD_BYTES: usize = 4 * 1024;
+
+struct PendingMarkdownBuild {
+    generation: u64,
+    session_key: Option<String>,
+    desired_text: String,
+    turn: usize,
+}
+
 pub struct ChatView {
     workspace_store: Entity<WorkspaceStore>,
     window_state: Entity<WindowState>,
@@ -76,6 +86,8 @@ pub struct ChatView {
     turn_items: Vec<TurnListItem>,
     turn_index_cache: TurnIndexCache,
     md_states: HashMap<String, MdState>,
+    pending_md_builds: HashMap<String, PendingMarkdownBuild>,
+    next_md_build_generation: u64,
     markdown_visible_turns: Range<usize>,
     markdown_scroll_top: Option<usize>,
     /// Open/closed keys for collapsibles (work logs, activity rows, cards, files).
@@ -93,6 +105,8 @@ pub struct ChatView {
     /// The live commit dialog entity while it is open (kept alive across frames).
     commit_dialog: Option<Entity<CommitDialog>>,
     _subscriptions: Vec<Subscription>,
+    #[cfg(test)]
+    markdown_remeasured_turns: Vec<usize>,
 }
 
 impl ChatView {
@@ -141,6 +155,8 @@ impl ChatView {
             turn_items: Vec::new(),
             turn_index_cache: TurnIndexCache::default(),
             md_states: HashMap::new(),
+            pending_md_builds: HashMap::new(),
+            next_md_build_generation: 0,
             markdown_visible_turns: 0..0,
             markdown_scroll_top: None,
             expanded: HashSet::new(),
@@ -152,6 +168,8 @@ impl ChatView {
             _copied_task: None,
             commit_dialog: None,
             _subscriptions: subscriptions,
+            #[cfg(test)]
+            markdown_remeasured_turns: Vec::new(),
         };
         this.sync_markdown_states(cx);
         this
@@ -198,6 +216,7 @@ impl ChatView {
             .and_then(|session_id| self.workspace_store.read(cx).pending_chat_turn(session_id));
         if session_changed {
             self.md_states.clear();
+            self.pending_md_builds.clear();
             self.command_panels.borrow_mut().clear();
             self.highlighted_turn = None;
             self.session_key = session_key;
@@ -341,11 +360,24 @@ impl ChatView {
             })
             .unwrap_or_default();
         self.md_states.retain(|id, _| !decisions.evict.contains(id));
+        self.pending_md_builds
+            .retain(|id, _| decisions.build.contains(id) && !decisions.evict.contains(id));
 
         let mut rebuilt_turns = HashSet::new();
         for (turn, id, text) in texts {
             match self.md_states.get_mut(&id) {
                 Some(md) => md.sync(text, cx),
+                None if self.pending_md_builds.contains_key(&id) => {
+                    let pending = self
+                        .pending_md_builds
+                        .get_mut(&id)
+                        .expect("pending Markdown build disappeared");
+                    pending.desired_text = text;
+                    pending.turn = turn;
+                }
+                None if text.len() > ASYNC_MARKDOWN_THRESHOLD_BYTES => {
+                    self.spawn_markdown_build(turn, id, text, cx);
+                }
                 None => {
                     self.md_states.insert(id, MdState::new(&text, cx));
                     rebuilt_turns.insert(turn);
@@ -368,10 +400,84 @@ impl ChatView {
                 // Eviction leaves this cache untouched. A lazy rebuild only
                 // invalidates rebuilt rows; ListState preserves the absolute
                 // scroll-top offset while it measures the parsed Markdown.
-                self.list_state.remeasure_items(range);
+                self.remeasure_markdown_turns(range);
                 range = turn..turn + 1;
             }
         }
+        self.remeasure_markdown_turns(range);
+    }
+
+    fn spawn_markdown_build(
+        &mut self,
+        turn: usize,
+        id: String,
+        text: String,
+        cx: &mut Context<Self>,
+    ) {
+        self.next_md_build_generation = self.next_md_build_generation.wrapping_add(1);
+        let generation = self.next_md_build_generation;
+        self.pending_md_builds.insert(
+            id.clone(),
+            PendingMarkdownBuild {
+                generation,
+                session_key: self.session_key.clone(),
+                desired_text: text.clone(),
+                turn,
+            },
+        );
+        let parse_text = text;
+        cx.spawn(async move |this, cx| {
+            let parsed_text = parse_text.clone();
+            let parsed = cx
+                .background_executor()
+                .spawn(async move { crate::markdown::parse::parse_document(&parse_text) })
+                .await;
+            let _ = this.update(cx, |chat, cx| {
+                chat.finish_markdown_build(id, generation, parsed_text, parsed, cx);
+            });
+        })
+        .detach();
+    }
+
+    fn finish_markdown_build(
+        &mut self,
+        id: String,
+        generation: u64,
+        parsed_text: String,
+        parsed: crate::markdown::parse::ParsedDocument,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(pending) = self.pending_md_builds.get(&id) else {
+            return;
+        };
+        if pending.generation != generation || pending.session_key != self.session_key {
+            return;
+        }
+        let desired_text = pending.desired_text.clone();
+        let turn = pending.turn;
+        self.pending_md_builds.remove(&id);
+
+        if desired_text != parsed_text && !desired_text.starts_with(&parsed_text) {
+            // An edit invalidated the parse. Re-evaluate residency and kick a
+            // replacement job for the latest text if it is still wanted.
+            self.sync_markdown_residency(None, cx);
+            return;
+        }
+
+        let mut state = MdState::from_parsed(&parsed_text, parsed, cx);
+        if desired_text != parsed_text {
+            state.sync(desired_text, cx);
+        }
+        self.md_states.insert(id, state);
+        if turn < self.turn_items.len() {
+            self.remeasure_markdown_turns(turn..turn + 1);
+        }
+        cx.notify();
+    }
+
+    fn remeasure_markdown_turns(&mut self, range: Range<usize>) {
+        #[cfg(test)]
+        self.markdown_remeasured_turns.extend(range.clone());
         self.list_state.remeasure_items(range);
     }
 
@@ -410,6 +516,11 @@ impl ChatView {
     #[cfg(test)]
     fn has_resident_markdown_state(&self, id: &str) -> bool {
         self.md_states.contains_key(id)
+    }
+
+    #[cfg(test)]
+    fn resident_markdown_source(&self, id: &str) -> Option<&str> {
+        self.md_states.get(id).map(|md| md.synced.as_ref())
     }
 
     fn toggle_expanded(&mut self, turn: usize, key: &str, cx: &mut Context<Self>) {
@@ -1981,7 +2092,9 @@ fn open_in_zed(cwd: &Path, window: &mut Window, cx: &mut App) {
 
 #[cfg(test)]
 mod tests {
-    use super::{ChatView, ResidencyScope, markdown_entries_for_residency};
+    use super::{
+        ASYNC_MARKDOWN_THRESHOLD_BYTES, ChatView, ResidencyScope, markdown_entries_for_residency,
+    };
     use crate::store::WorkspaceStore;
     use crate::window_state::WindowState;
     use agent::ItemContent;
@@ -2076,6 +2189,116 @@ mod tests {
             px(7.),
             "rebuilding the scroll-top turn changed the list anchor"
         );
+    }
+
+    #[gpui::test]
+    fn large_markdown_becomes_resident_asynchronously_and_remeasures_turn(cx: &mut TestAppContext) {
+        let text = large_markdown("async content");
+        let timeline = single_assistant_timeline("large", &text);
+        let (workspace_store, window_state, _) = seed_chat(cx, timeline);
+        let view =
+            cx.add_window(|window, cx| ChatView::new(workspace_store, window_state, window, cx));
+        let view = view.root(cx).expect("chat window should have a root");
+
+        view.read_with(cx, |chat, _| {
+            assert!(!chat.has_resident_markdown_state("large"));
+            assert!(!chat.markdown_remeasured_turns.contains(&0));
+        });
+        cx.run_until_parked();
+        view.read_with(cx, |chat, cx| {
+            assert!(chat.has_resident_markdown_state("large"));
+            assert_eq!(chat.resident_markdown_source("large"), Some(text.as_str()));
+            let rendered = chat
+                .md_states
+                .get("large")
+                .expect("large Markdown state should be resident")
+                .state
+                .read(cx)
+                .rendered_text();
+            assert!(rendered.contains("async content"));
+            assert!(chat.markdown_remeasured_turns.contains(&0));
+        });
+    }
+
+    #[gpui::test]
+    fn in_flight_markdown_update_finishes_with_latest_text(cx: &mut TestAppContext) {
+        let original = large_markdown("original");
+        let latest = large_markdown("edited");
+        let timeline = single_assistant_timeline("large", &original);
+        let (workspace_store, window_state, session_id) = seed_chat(cx, timeline);
+        let view = cx.add_window(|window, cx| {
+            ChatView::new(workspace_store.clone(), window_state, window, cx)
+        });
+        let view = view.root(cx).expect("chat window should have a root");
+        let generation = view.read_with(cx, |chat, _| {
+            chat.pending_md_builds
+                .get("large")
+                .expect("large build should be pending")
+                .generation
+        });
+
+        workspace_store.update(cx, |store, _| {
+            store.set_session_replica_for_test(
+                session_id,
+                single_assistant_timeline("large", &latest),
+            );
+        });
+        view.update(cx, |chat, cx| chat.sync_markdown_states(cx));
+        view.read_with(cx, |chat, _| {
+            assert_eq!(chat.pending_md_builds.len(), 1);
+            assert_eq!(
+                chat.pending_md_builds["large"].generation, generation,
+                "a text update spawned a duplicate in-flight job"
+            );
+        });
+
+        cx.run_until_parked();
+        view.read_with(cx, |chat, _| {
+            assert_eq!(
+                chat.resident_markdown_source("large"),
+                Some(latest.as_str())
+            );
+            assert!(chat.pending_md_builds.is_empty());
+        });
+    }
+
+    #[gpui::test]
+    fn session_switch_does_not_resurrect_in_flight_markdown(cx: &mut TestAppContext) {
+        let text = large_markdown("stale session");
+        let timeline = single_assistant_timeline("large", &text);
+        let (workspace_store, window_state, _) = seed_chat(cx, timeline);
+        let view = cx.add_window(|window, cx| {
+            ChatView::new(workspace_store.clone(), window_state, window, cx)
+        });
+        let view = view.root(cx).expect("chat window should have a root");
+        assert!(view.read_with(cx, |chat, _| chat.pending_md_builds.contains_key("large")));
+
+        workspace_store.update(cx, |store, _| {
+            store.set_session_replica_for_test("replacement-session".into(), Timeline::default());
+        });
+        view.update(cx, |chat, cx| chat.sync_markdown_states(cx));
+        cx.run_until_parked();
+
+        view.read_with(cx, |chat, _| {
+            assert!(!chat.has_resident_markdown_state("large"));
+            assert!(!chat.pending_md_builds.contains_key("large"));
+        });
+    }
+
+    #[gpui::test]
+    fn small_markdown_is_resident_synchronously(cx: &mut TestAppContext) {
+        let text = "small **streaming** reply";
+        assert!(text.len() < ASYNC_MARKDOWN_THRESHOLD_BYTES);
+        let timeline = single_assistant_timeline("small", text);
+        let (workspace_store, window_state, _) = seed_chat(cx, timeline);
+        let view =
+            cx.add_window(|window, cx| ChatView::new(workspace_store, window_state, window, cx));
+        let view = view.root(cx).expect("chat window should have a root");
+
+        view.read_with(cx, |chat, _| {
+            assert_eq!(chat.resident_markdown_source("small"), Some(text));
+            assert!(!chat.pending_md_builds.contains_key("small"));
+        });
     }
 
     #[gpui::test]
@@ -2302,6 +2525,21 @@ This begins after the hard break."#;
             ]);
         }
         timeline
+    }
+
+    fn single_assistant_timeline(id: &str, text: &str) -> Timeline {
+        let mut timeline = Timeline::default();
+        timeline.turns = vec![TurnMeta::default()];
+        timeline.entries.push(entry(id, assistant(text)));
+        timeline
+    }
+
+    fn large_markdown(marker: &str) -> String {
+        let mut text = format!("# {marker}\n\n");
+        while text.len() <= ASYNC_MARKDOWN_THRESHOLD_BYTES {
+            text.push_str("- a sufficiently substantial Markdown list item\n");
+        }
+        text
     }
 
     fn seed_chat(

--- a/crates/ui/src/chat/model.rs
+++ b/crates/ui/src/chat/model.rs
@@ -743,6 +743,165 @@ pub(crate) struct TurnListItem {
     pub(crate) content: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TurnIndexMeta {
+    start_ts: Option<u64>,
+    end_ts: Option<u64>,
+    running: bool,
+    timing: Option<tcode_core::session::TurnTiming>,
+    served_model: Option<String>,
+    cost_usd: Option<u64>,
+    status: Option<TurnStatus>,
+}
+
+impl From<&TurnMeta> for TurnIndexMeta {
+    fn from(turn: &TurnMeta) -> Self {
+        Self {
+            start_ts: turn.start_ts,
+            end_ts: turn.end_ts,
+            running: turn.running,
+            timing: turn.timing,
+            served_model: turn.served_model.clone(),
+            cost_usd: turn.cost_usd.map(f64::to_bits),
+            status: turn.status,
+        }
+    }
+}
+
+impl TurnIndexMeta {
+    fn matches(&self, turn: &TurnMeta) -> bool {
+        self.start_ts == turn.start_ts
+            && self.end_ts == turn.end_ts
+            && self.running == turn.running
+            && self.timing == turn.timing
+            && self.served_model.as_deref() == turn.served_model.as_deref()
+            && self.cost_usd == turn.cost_usd.map(f64::to_bits)
+            && self.status == turn.status
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProposedPlanIndex {
+    turn: usize,
+    item_id: String,
+    markdown: String,
+}
+
+/// Stateful input snapshot for reusing indexed turns across store notifications.
+#[derive(Debug, Default)]
+pub(crate) struct TurnIndexCache {
+    entries: Vec<Arc<TimelineEntry>>,
+    turns: Vec<TurnIndexMeta>,
+    proposed_plan: Option<ProposedPlanIndex>,
+    expanded: HashSet<String>,
+    #[cfg(test)]
+    reindexed_turns: usize,
+}
+
+impl TurnIndexCache {
+    pub(crate) fn sync(
+        &mut self,
+        items: &mut Vec<TurnListItem>,
+        turns: &[TurnMeta],
+        entries: &[Arc<TimelineEntry>],
+        proposed_plan: Option<(usize, &str, &str)>,
+        expanded: &HashSet<String>,
+        reset: bool,
+    ) -> ListSync {
+        let item_count = turns
+            .len()
+            .max(entries.last().map_or(0, |entry| entry.turn + 1));
+        let entry_divergence = self
+            .entries
+            .iter()
+            .zip(entries)
+            .position(|(old, new)| !Arc::ptr_eq(old, new))
+            .unwrap_or(self.entries.len().min(entries.len()));
+        let tail_replace = entries.len() == self.entries.len()
+            && entry_divergence.checked_add(1) == Some(entries.len());
+        let append = entry_divergence == self.entries.len() && entries.len() >= self.entries.len();
+        let proposed_plan_changed = match (&self.proposed_plan, proposed_plan) {
+            (None, None) => false,
+            (Some(old), Some((turn, item_id, markdown))) => {
+                old.turn != turn || old.item_id != item_id || old.markdown != markdown
+            }
+            _ => true,
+        };
+        let settings_changed = proposed_plan_changed || self.expanded != *expanded;
+        let must_reset = reset
+            || settings_changed
+            || entries.len() < self.entries.len()
+            || (!append && !tail_replace)
+            || turns.len() < self.turns.len();
+
+        let turn_divergence = self
+            .turns
+            .iter()
+            .zip(turns)
+            .position(|(old, new)| !old.matches(new))
+            .unwrap_or(self.turns.len().min(turns.len()));
+        let mut reindex_from = if must_reset { 0 } else { item_count };
+        if !must_reset {
+            if entry_divergence < entries.len() {
+                reindex_from = reindex_from.min(entries[entry_divergence].turn);
+            }
+            if entry_divergence < self.entries.len() {
+                reindex_from = reindex_from.min(self.entries[entry_divergence].turn);
+            }
+            if turn_divergence < turns.len() {
+                reindex_from = reindex_from.min(turn_divergence);
+            }
+        }
+
+        let suffix = if reindex_from == 0 {
+            index_turns(turns, entries, proposed_plan, expanded)
+        } else {
+            if reindex_from < item_count {
+                index_turns_from(turns, entries, proposed_plan, expanded, reindex_from)
+            } else {
+                Vec::new()
+            }
+        };
+        let sync = list_sync_with(items, item_count, reset, |index| {
+            if index < reindex_from {
+                &items[index]
+            } else {
+                &suffix[index - reindex_from]
+            }
+        });
+        items.truncate(reindex_from);
+        items.extend(suffix);
+        items.truncate(item_count);
+
+        #[cfg(test)]
+        {
+            self.reindexed_turns = item_count.saturating_sub(reindex_from);
+        }
+        self.entries.truncate(entry_divergence);
+        self.entries
+            .extend(entries[entry_divergence..].iter().cloned());
+        self.turns.truncate(turn_divergence);
+        self.turns
+            .extend(turns[turn_divergence..].iter().map(TurnIndexMeta::from));
+        if proposed_plan_changed {
+            self.proposed_plan = proposed_plan.map(|(turn, item_id, markdown)| ProposedPlanIndex {
+                turn,
+                item_id: item_id.to_owned(),
+                markdown: markdown.to_owned(),
+            });
+        }
+        if self.expanded != *expanded {
+            self.expanded.clone_from(expanded);
+        }
+        sync
+    }
+
+    #[cfg(test)]
+    fn reindexed_turns(&self) -> usize {
+        self.reindexed_turns
+    }
+}
+
 /// Mutation to apply to the persistent [`ListState`] after a timeline sync.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ListSync {
@@ -767,14 +926,25 @@ pub(crate) fn index_turns(
     proposed_plan: Option<(usize, &str, &str)>,
     expanded: &HashSet<String>,
 ) -> Vec<TurnListItem> {
+    index_turns_from(turns, entries, proposed_plan, expanded, 0)
+}
+
+fn index_turns_from(
+    turns: &[TurnMeta],
+    entries: &[Arc<TimelineEntry>],
+    proposed_plan: Option<(usize, &str, &str)>,
+    expanded: &HashSet<String>,
+    first_turn: usize,
+) -> Vec<TurnListItem> {
     debug_assert!(entries.windows(2).all(|pair| pair[0].turn <= pair[1].turn));
 
     let item_count = turns
         .len()
         .max(entries.last().map_or(0, |entry| entry.turn + 1));
-    let mut ranges = vec![entries.len()..entries.len(); item_count];
-    for (index, entry) in entries.iter().enumerate() {
-        let range = &mut ranges[entry.turn];
+    let first_entry = entries.partition_point(|entry| entry.turn < first_turn);
+    let mut ranges = vec![entries.len()..entries.len(); item_count.saturating_sub(first_turn)];
+    for (index, entry) in entries.iter().enumerate().skip(first_entry) {
+        let range = &mut ranges[entry.turn - first_turn];
         if range.start == entries.len() {
             range.start = index;
         }
@@ -784,7 +954,8 @@ pub(crate) fn index_turns(
     ranges
         .into_iter()
         .enumerate()
-        .map(|(index, entry_range)| {
+        .map(|(offset, entry_range)| {
+            let index = first_turn + offset;
             let mut identity = DefaultHasher::new();
             let mut content = DefaultHasher::new();
             for entry in &entries[entry_range.clone()] {
@@ -955,27 +1126,37 @@ fn hash_entry_shape(content: &EntryContent, hash: &mut DefaultHasher) {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn list_sync(
     old: &[TurnListItem],
     new: &[TurnListItem],
     session_changed: bool,
 ) -> ListSync {
-    let common = old.len().min(new.len());
+    list_sync_with(old, new.len(), session_changed, |index| &new[index])
+}
+
+fn list_sync_with<'a>(
+    old: &[TurnListItem],
+    new_len: usize,
+    session_changed: bool,
+    new_at: impl Fn(usize) -> &'a TurnListItem,
+) -> ListSync {
+    let common = old.len().min(new_len);
     let replaced = (0..common).any(|index| {
         let old = &old[index];
-        let new = &new[index];
+        let new = new_at(index);
         new.entry_count < old.entry_count
             || (new.entry_count == old.entry_count && new.identity != old.identity)
     });
-    if session_changed || new.len() < old.len() || replaced {
-        return ListSync::Reset { count: new.len() };
+    if session_changed || new_len < old.len() || replaced {
+        return ListSync::Reset { count: new_len };
     }
 
-    let append = (new.len() > old.len()).then_some(old.len()..new.len());
+    let append = (new_len > old.len()).then_some(old.len()..new_len);
     let mut remeasure = (0..common)
         .filter(|&index| {
-            old[index].entry_count != new[index].entry_count
-                || old[index].content != new[index].content
+            old[index].entry_count != new_at(index).entry_count
+                || old[index].content != new_at(index).content
         })
         .collect::<Vec<_>>();
     // The former last item gains an inter-turn gap when a new turn appears.
@@ -1213,6 +1394,105 @@ mod tests {
         assert_eq!(
             list_sync(&initial, &initial, true),
             ListSync::Reset { count: 1 }
+        );
+    }
+
+    #[test]
+    fn incremental_turn_index_matches_full_index_across_tail_and_reset_scenarios() {
+        let mut cache = TurnIndexCache::default();
+        let mut turns = vec![TurnMeta::default()];
+        let mut entries = vec![entry("user-0", user_item("go"))];
+        let mut expanded = HashSet::new();
+        let mut indexed = Vec::new();
+
+        cache.sync(&mut indexed, &turns, &entries, None, &expanded, false);
+        assert_eq!(indexed, index_turns(&turns, &entries, None, &expanded));
+
+        // (a) Append an entry to the last turn.
+        entries.push(entry("assistant-0", assistant("working")));
+        cache.sync(&mut indexed, &turns, &entries, None, &expanded, false);
+        assert_eq!(indexed, index_turns(&turns, &entries, None, &expanded));
+
+        // (b) Append a new turn.
+        turns.push(TurnMeta::default());
+        entries.push(at_turn(entry("user-1", user_item("next")), 1));
+        cache.sync(&mut indexed, &turns, &entries, None, &expanded, false);
+        assert_eq!(indexed, index_turns(&turns, &entries, None, &expanded));
+
+        // (c) Replace the streaming tail Arc with updated content.
+        entries[2] = at_turn(entry("user-1", user_item("next, updated")), 1);
+        cache.sync(&mut indexed, &turns, &entries, None, &expanded, false);
+        assert_eq!(indexed, index_turns(&turns, &entries, None, &expanded));
+
+        // (d) Toggle a disclosure expansion key.
+        entries[2] = at_turn(
+            entry(
+                "user-1",
+                EntryContent::Item(ItemContent::UserMessage {
+                    text: "context\nquestion".into(),
+                    context_len: Some(8),
+                    attachments: Vec::new(),
+                }),
+            ),
+            1,
+        );
+        cache.sync(&mut indexed, &turns, &entries, None, &expanded, false);
+        expanded.insert("orchestrate-context-user-1".into());
+        cache.sync(&mut indexed, &turns, &entries, None, &expanded, false);
+        assert_eq!(indexed, index_turns(&turns, &entries, None, &expanded));
+
+        // (e) A session switch resets unrelated cached inputs.
+        let switched_turns = vec![TurnMeta::default()];
+        let switched_entries = vec![entry("new-session", assistant("fresh"))];
+        let no_expanded = HashSet::new();
+        cache.sync(
+            &mut indexed,
+            &switched_turns,
+            &switched_entries,
+            None,
+            &no_expanded,
+            true,
+        );
+        assert_eq!(
+            indexed,
+            index_turns(&switched_turns, &switched_entries, None, &no_expanded)
+        );
+
+        // (f) Rewind/removal takes the full path and remains equivalent.
+        let empty_entries = Vec::new();
+        cache.sync(
+            &mut indexed,
+            &switched_turns,
+            &empty_entries,
+            None,
+            &no_expanded,
+            false,
+        );
+        assert_eq!(
+            indexed,
+            index_turns(&switched_turns, &empty_entries, None, &no_expanded)
+        );
+    }
+
+    #[test]
+    fn replacing_the_tail_of_a_200_turn_timeline_reindexes_one_turn() {
+        let turns = vec![TurnMeta::default(); 200];
+        let mut entries = (0..200)
+            .map(|turn| at_turn(entry(&format!("assistant-{turn}"), assistant("x")), turn))
+            .collect::<Vec<_>>();
+        let expanded = HashSet::new();
+        let mut cache = TurnIndexCache::default();
+        let mut incremental = Vec::new();
+        cache.sync(&mut incremental, &turns, &entries, None, &expanded, false);
+
+        entries[199] = at_turn(entry("assistant-199", assistant("streamed")), 199);
+        cache.sync(&mut incremental, &turns, &entries, None, &expanded, false);
+
+        assert_eq!(incremental, index_turns(&turns, &entries, None, &expanded));
+        assert!(
+            cache.reindexed_turns() <= 1,
+            "tail replacement reindexed {} turns",
+            cache.reindexed_turns()
         );
     }
 

--- a/crates/ui/src/chat/residency.rs
+++ b/crates/ui/src/chat/residency.rs
@@ -31,6 +31,46 @@ pub(super) struct ResidencyInput<'a> {
     pub selection_drag_active: bool,
 }
 
+/// Turn-only superset of entries that can affect [`decide`].
+pub(super) struct ResidencyScope {
+    build_turns: Range<usize>,
+    keep_turns: Range<usize>,
+    tail_start: usize,
+    last_turn: Option<usize>,
+    stream_running: bool,
+}
+
+impl ResidencyScope {
+    pub(super) fn new(
+        turn_count: usize,
+        visible_turns: Range<usize>,
+        one_shot_turn_target: Option<usize>,
+        stream_running: bool,
+    ) -> Self {
+        let visible_turns = one_shot_turn_target
+            .filter(|turn| *turn < turn_count)
+            .map(|turn| turn..(turn + VIEWPORT_TURN_HINT).min(turn_count))
+            .unwrap_or(visible_turns);
+        Self {
+            build_turns: expand_turn_window(visible_turns.clone(), BUILD_MARGIN_TURNS, turn_count),
+            keep_turns: expand_turn_window(visible_turns, EVICT_MARGIN_TURNS, turn_count),
+            tail_start: turn_count.saturating_sub(TAIL_PIN_TURNS),
+            last_turn: turn_count.checked_sub(1),
+            stream_running,
+        }
+    }
+
+    pub(super) fn includes(&self, turn: usize, turn_running: bool) -> bool {
+        self.keep_turns.contains(&turn) || self.pinned(turn, turn_running)
+    }
+
+    fn pinned(&self, turn: usize, turn_running: bool) -> bool {
+        self.last_turn.is_some() && turn >= self.tail_start
+            || turn_running
+            || self.stream_running && self.last_turn == Some(turn)
+    }
+}
+
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(super) struct ResidencyDecisions {
     pub build: HashSet<String>,
@@ -38,26 +78,19 @@ pub(super) struct ResidencyDecisions {
 }
 
 pub(super) fn decide(input: ResidencyInput<'_>) -> ResidencyDecisions {
-    let visible_turns = input
-        .one_shot_turn_target
-        .filter(|turn| *turn < input.turn_count)
-        .map(|turn| turn..(turn + VIEWPORT_TURN_HINT).min(input.turn_count))
-        .unwrap_or(input.visible_turns);
-    let build_turns =
-        expand_turn_window(visible_turns.clone(), BUILD_MARGIN_TURNS, input.turn_count);
-    let keep_turns = expand_turn_window(visible_turns, EVICT_MARGIN_TURNS, input.turn_count);
-    let tail_start = input.turn_count.saturating_sub(TAIL_PIN_TURNS);
-    let last_turn = input.turn_count.checked_sub(1);
-    let pinned = |entry: &MarkdownEntry| {
-        (input.turn_count > 0 && entry.turn >= tail_start)
-            || entry.turn_running
-            || (input.stream_running && last_turn == Some(entry.turn))
-    };
+    let scope = ResidencyScope::new(
+        input.turn_count,
+        input.visible_turns,
+        input.one_shot_turn_target,
+        input.stream_running,
+    );
 
     let build = input
         .entries
         .iter()
-        .filter(|entry| build_turns.contains(&entry.turn) || pinned(entry))
+        .filter(|entry| {
+            scope.build_turns.contains(&entry.turn) || scope.pinned(entry.turn, entry.turn_running)
+        })
         .map(|entry| entry.id.clone())
         .collect();
     let evict = if input.selection_drag_active {
@@ -66,7 +99,7 @@ pub(super) fn decide(input: ResidencyInput<'_>) -> ResidencyDecisions {
         let keep = input
             .entries
             .iter()
-            .filter(|entry| keep_turns.contains(&entry.turn) || pinned(entry))
+            .filter(|entry| scope.includes(entry.turn, entry.turn_running))
             .map(|entry| entry.id.as_str())
             .collect::<HashSet<_>>();
         input
@@ -99,7 +132,9 @@ fn expand_turn_window(window: Range<usize>, margin: usize, turn_count: usize) ->
 
 #[cfg(test)]
 mod tests {
-    use super::{MarkdownEntry, ResidencyDecisions, ResidencyInput, decide, tail_turn_window};
+    use super::{
+        MarkdownEntry, ResidencyDecisions, ResidencyInput, ResidencyScope, decide, tail_turn_window,
+    };
     use std::collections::HashSet;
 
     #[test]
@@ -163,6 +198,45 @@ mod tests {
         assert!(decisions.build.contains("assistant-239"));
         assert!(!decisions.evict.contains("assistant-7"));
         assert!(decisions.evict.contains("assistant-100"));
+    }
+
+    #[test]
+    fn candidate_filter_preserves_decisions_with_distant_running_and_selection() {
+        let mut all_entries = entries(200);
+        for entry in &mut all_entries {
+            entry.turn_running = entry.turn == 5;
+        }
+        let residents = [
+            "assistant-5".to_string(),
+            "assistant-40".to_string(),
+            "assistant-100".to_string(),
+            "assistant-199".to_string(),
+        ]
+        .into_iter()
+        .collect();
+        let selection_participants = ["assistant-100".to_string()].into_iter().collect();
+        let scope = ResidencyScope::new(200, 40..48, None, true);
+        let filtered_entries = all_entries
+            .iter()
+            .filter(|entry| scope.includes(entry.turn, entry.turn_running))
+            .cloned()
+            .collect::<Vec<_>>();
+        let run = |entries: &[MarkdownEntry]| {
+            decide(ResidencyInput {
+                turn_count: 200,
+                visible_turns: 40..48,
+                one_shot_turn_target: None,
+                entries,
+                stream_running: true,
+                resident_ids: &residents,
+                selection_participants: &selection_participants,
+                selection_drag_active: false,
+            })
+        };
+
+        assert_eq!(run(&filtered_entries), run(&all_entries));
+        assert!(run(&filtered_entries).build.contains("assistant-5"));
+        assert!(!run(&filtered_entries).evict.contains("assistant-100"));
     }
 
     fn entries(turn_count: usize) -> Vec<MarkdownEntry> {

--- a/crates/ui/src/markdown/mod.rs
+++ b/crates/ui/src/markdown/mod.rs
@@ -18,6 +18,7 @@ mod view;
 use gpui::{App, KeyBinding};
 use gpui_base::input::{Copy, SelectAll};
 
+#[cfg(test)]
 pub(crate) use parse::parse;
 pub use state::MarkdownState;
 pub use view::MarkdownView;

--- a/crates/ui/src/markdown/parse.rs
+++ b/crates/ui/src/markdown/parse.rs
@@ -9,14 +9,41 @@ use super::nodes::{
     TableCell, TableRow, TextMark,
 };
 
+pub(crate) struct ParsedDocument {
+    pub(crate) root: BlockNode,
+    pub(crate) root_starts: Option<Vec<usize>>,
+}
+
+#[cfg(test)]
 pub(crate) fn parse(source: &str) -> BlockNode {
+    parse_document(source).root
+}
+
+pub(crate) fn parse_document(source: &str) -> ParsedDocument {
     let parser = rushdown::parser::Parser::with_extensions(
         rushdown::parser::Options::default(),
         rushdown::parser::gfm(rushdown::parser::GfmOptions::default()),
     );
     let mut reader = rushdown::text::BasicReader::new(source);
     let (arena, doc_ref) = parser.parse(&mut reader);
-    block_node(&arena, doc_ref, source, None).unwrap_or(BlockNode::Unknown)
+    let mut root_starts = Vec::new();
+    let mut positions_available = true;
+    let children = arena[doc_ref]
+        .children(&arena)
+        .filter_map(|child| {
+            let block = block_node(&arena, child, source, None)?;
+            if let Some(pos) = arena[child].pos() {
+                root_starts.push(pos);
+            } else {
+                positions_available = false;
+            }
+            Some(block)
+        })
+        .collect();
+    ParsedDocument {
+        root: BlockNode::Root { children },
+        root_starts: positions_available.then_some(root_starts),
+    }
 }
 
 fn block_node(

--- a/crates/ui/src/markdown/state.rs
+++ b/crates/ui/src/markdown/state.rs
@@ -55,6 +55,15 @@ impl MarkdownState {
     /// Parse `text` immediately and create a Markdown state entity value.
     pub fn new(text: &str, cx: &mut Context<Self>) -> Self {
         let parsed_document = super::parse::parse_document(text);
+        Self::from_parsed(text, parsed_document, cx)
+    }
+
+    /// Create a Markdown state from a document parsed on another executor.
+    pub(crate) fn from_parsed(
+        text: &str,
+        parsed_document: super::parse::ParsedDocument,
+        cx: &mut Context<Self>,
+    ) -> Self {
         let parsed = parsed_document.root;
         let block_count = root_block_count(&parsed);
         let selection_adapter = MarkdownSelectionAdapter::new(cx.entity().downgrade(), cx);
@@ -568,6 +577,40 @@ mod tests {
         state.read_with(cx, |state, _| {
             assert_eq!(state.last_reparse_bytes(), state.text.len());
             assert_eq!(state.parsed, super::super::parse(&state.text));
+        });
+    }
+
+    #[gpui::test]
+    fn pre_parsed_constructor_matches_synchronous_constructor(cx: &mut TestAppContext) {
+        cx.update(crate::theme::init);
+        cx.update(super::super::init);
+        let document =
+            "An earlier [reference].\n\n[reference]: https://example.com\n\nFinal paragraph.";
+        let parsed_document = super::super::parse::parse_document(document);
+        let synchronous = cx.update(|cx| cx.new(|cx| MarkdownState::new(document, cx)));
+        let pre_parsed =
+            cx.update(|cx| cx.new(|cx| MarkdownState::from_parsed(document, parsed_document, cx)));
+
+        let expected = synchronous.read_with(cx, |state, _| {
+            (
+                state.text.clone(),
+                state.parsed.clone(),
+                state.root_block_starts.clone(),
+                state.has_potential_link_reference_definition,
+                state.last_reparse_bytes,
+            )
+        });
+        pre_parsed.read_with(cx, |state, _| {
+            assert_eq!(
+                (
+                    state.text.clone(),
+                    state.parsed.clone(),
+                    state.root_block_starts.clone(),
+                    state.has_potential_link_reference_definition,
+                    state.last_reparse_bytes,
+                ),
+                expected
+            );
         });
     }
 

--- a/crates/ui/src/markdown/state.rs
+++ b/crates/ui/src/markdown/state.rs
@@ -41,16 +41,21 @@ pub struct MarkdownState {
     pub(super) is_selecting: bool,
     text: String,
     parsed: BlockNode,
+    root_block_starts: Option<Vec<usize>>,
+    has_potential_link_reference_definition: bool,
     pub(super) list_state: ListState,
     measured_content_height: Option<Pixels>,
     selection_revision: usize,
     pub(super) selection_adapter: MarkdownSelectionAdapter,
+    #[cfg(test)]
+    last_reparse_bytes: usize,
 }
 
 impl MarkdownState {
     /// Parse `text` immediately and create a Markdown state entity value.
     pub fn new(text: &str, cx: &mut Context<Self>) -> Self {
-        let parsed = super::parse(text);
+        let parsed_document = super::parse::parse_document(text);
+        let parsed = parsed_document.root;
         let block_count = root_block_count(&parsed);
         let selection_adapter = MarkdownSelectionAdapter::new(cx.entity().downgrade(), cx);
         Self {
@@ -65,12 +70,18 @@ impl MarkdownState {
             is_selecting: false,
             text: text.to_string(),
             parsed,
+            root_block_starts: parsed_document.root_starts,
+            has_potential_link_reference_definition: contains_potential_link_reference_definition(
+                text,
+            ),
             // Measure every block once so the list has a stable total height,
             // then construct/layout/paint only the visible blocks on warm frames.
             list_state: ListState::new(block_count, ListAlignment::Top, px(1000.)).measure_all(),
             measured_content_height: None,
             selection_revision: 0,
             selection_adapter,
+            #[cfg(test)]
+            last_reparse_bytes: text.len(),
         }
     }
 
@@ -79,6 +90,9 @@ impl MarkdownState {
         if text.is_empty() {
             return;
         }
+        self.has_potential_link_reference_definition |=
+            contains_potential_link_reference_definition(text)
+                || self.text.ends_with(']') && text.starts_with(':');
         self.text.push_str(text);
         self.reparse_append(cx);
     }
@@ -90,6 +104,8 @@ impl MarkdownState {
         }
         self.text.clear();
         self.text.push_str(text);
+        self.has_potential_link_reference_definition =
+            contains_potential_link_reference_definition(text);
         self.reparse_reset(cx);
     }
 
@@ -172,16 +188,54 @@ impl MarkdownState {
 
     fn reparse_append(&mut self, cx: &mut Context<Self>) {
         self.prepare_reparse(cx);
-        let parsed = super::parse(&self.text);
-        let old_blocks = root_blocks(&self.parsed);
-        let new_blocks = root_blocks(&parsed);
-        let unchanged = old_blocks
-            .iter()
-            .zip(new_blocks)
-            .take_while(|(old, new)| old == new)
-            .count();
-        let old_count = old_blocks.len();
-        let new_count = new_blocks.len();
+        let reparse_start = self.incremental_reparse_start();
+        let parsed_document = super::parse::parse_document(&self.text[reparse_start..]);
+        #[cfg(test)]
+        {
+            self.last_reparse_bytes = self.text.len() - reparse_start;
+        }
+
+        let old_count = root_block_count(&self.parsed);
+        let (parsed, unchanged, new_count) = if reparse_start == 0 {
+            let old_blocks = root_blocks(&self.parsed);
+            let new_blocks = root_blocks(&parsed_document.root);
+            let unchanged = old_blocks
+                .iter()
+                .zip(new_blocks)
+                .take_while(|(old, new)| old == new)
+                .count();
+            let new_count = new_blocks.len();
+            self.root_block_starts = parsed_document.root_starts;
+            (parsed_document.root, unchanged, new_count)
+        } else {
+            let old_prefix_count = old_count - 1;
+            let BlockNode::Root { mut children } =
+                std::mem::replace(&mut self.parsed, BlockNode::Unknown)
+            else {
+                unreachable!("parsed markdown document must have a root")
+            };
+            children.truncate(old_prefix_count);
+            let BlockNode::Root {
+                children: tail_children,
+            } = parsed_document.root
+            else {
+                unreachable!("parsed markdown tail must have a root")
+            };
+            let new_count = old_prefix_count + tail_children.len();
+            children.extend(tail_children);
+
+            self.root_block_starts =
+                match (self.root_block_starts.take(), parsed_document.root_starts) {
+                    (Some(mut prefix), Some(mut tail)) => {
+                        prefix.truncate(old_prefix_count);
+                        tail.iter_mut().for_each(|start| *start += reparse_start);
+                        prefix.extend(tail);
+                        Some(prefix)
+                    }
+                    _ => None,
+                };
+            (BlockNode::Root { children }, old_prefix_count, new_count)
+        };
         self.parsed = parsed;
         self.selection_revision = self.selection_revision.wrapping_add(1);
 
@@ -197,9 +251,27 @@ impl MarkdownState {
         cx.notify();
     }
 
+    fn incremental_reparse_start(&self) -> usize {
+        if self.has_potential_link_reference_definition {
+            return 0;
+        }
+        let block_count = root_block_count(&self.parsed);
+        self.root_block_starts
+            .as_ref()
+            .filter(|starts| starts.len() == block_count)
+            .and_then(|starts| starts.last().copied())
+            .unwrap_or(0)
+    }
+
     fn reparse_reset(&mut self, cx: &mut Context<Self>) {
         self.prepare_reparse(cx);
-        self.parsed = super::parse(&self.text);
+        let parsed_document = super::parse::parse_document(&self.text);
+        self.parsed = parsed_document.root;
+        self.root_block_starts = parsed_document.root_starts;
+        #[cfg(test)]
+        {
+            self.last_reparse_bytes = self.text.len();
+        }
         self.selection_revision = self.selection_revision.wrapping_add(1);
         let block_count = root_block_count(&self.parsed);
         // Even an edit that preserves the number of root blocks can change
@@ -302,6 +374,11 @@ impl MarkdownState {
     pub(super) fn has_measured_block(&self, index: usize) -> bool {
         self.list_state.bounds_for_item(index).is_some()
     }
+
+    #[cfg(test)]
+    fn last_reparse_bytes(&self) -> usize {
+        self.last_reparse_bytes
+    }
 }
 
 fn with_trailing_newline(mut text: String) -> String {
@@ -323,6 +400,10 @@ fn root_blocks(node: &BlockNode) -> &[BlockNode] {
         BlockNode::Root { children, .. } => children,
         _ => std::slice::from_ref(node),
     }
+}
+
+fn contains_potential_link_reference_definition(source: &str) -> bool {
+    source.contains("]:")
 }
 
 impl Render for MarkdownState {
@@ -423,6 +504,70 @@ mod tests {
         state.read_with(cx, |state, _| {
             assert_eq!(state.source(), "new **value**");
             assert_eq!(state.rendered_text(), "new value\n");
+        });
+    }
+
+    #[gpui::test]
+    fn streamed_appends_match_full_parse(cx: &mut TestAppContext) {
+        cx.update(crate::theme::init);
+        cx.update(super::super::init);
+        let documents = [
+            "plain paragraph\ncontinued line\n\n# atx heading\n\nSetext heading\n===\n",
+            "- outer\n  - nested one\n  - nested two\n\n1. ordered\n   1. nested ordered\n\n> quoted\n>\n> - with a list\n",
+            "````text\na literal ``` inside the longer fence\n````\n\n```rust\nfn main() {}\n```\n",
+            "before\n\n```rust\nlet unfinished = true;\n",
+            "| left | center | right |\n| :--- | :---: | ---: |\n| a | b | c |\n",
+            "An earlier [reference] is resolved later.\n\n[reference]: https://example.com \"title\"\n",
+        ];
+
+        for document in documents {
+            let expected = cx.update(|cx| cx.new(|cx| MarkdownState::new(document, cx)));
+            let expected_tree = expected.read_with(cx, |state, _| state.parsed.clone());
+            for chunk_size in [1, 7, 64] {
+                let streamed = cx.update(|cx| cx.new(|cx| MarkdownState::new("", cx)));
+                for chunk in document.as_bytes().chunks(chunk_size) {
+                    let chunk = std::str::from_utf8(chunk).expect("test corpus is ASCII");
+                    streamed.update(cx, |state, cx| state.push_str(chunk, cx));
+                }
+                streamed.read_with(cx, |state, _| {
+                    assert_eq!(state.parsed, expected_tree, "chunk size {chunk_size}");
+                });
+            }
+        }
+    }
+
+    #[gpui::test]
+    fn append_reparses_only_the_last_root_block(cx: &mut TestAppContext) {
+        cx.update(crate::theme::init);
+        cx.update(super::super::init);
+        let document = (0..120)
+            .map(|ix| format!("## Closed block {ix}\n\nParagraph {ix}.\n\n"))
+            .collect::<String>();
+        assert!(document.len() > 2_000);
+        let state = cx.update(|cx| cx.new(|cx| MarkdownState::new(&document, cx)));
+
+        state.update(cx, |state, cx| state.push_str("new tail", cx));
+        state.read_with(cx, |state, _| {
+            assert!(
+                state.last_reparse_bytes() < 64,
+                "parsed {} of {} bytes",
+                state.last_reparse_bytes(),
+                state.text.len()
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn link_reference_definitions_force_a_full_reparse(cx: &mut TestAppContext) {
+        cx.update(crate::theme::init);
+        cx.update(super::super::init);
+        let document = "An earlier [reference].\n\n[reference]: https://example.com\n\nTail";
+        let state = cx.update(|cx| cx.new(|cx| MarkdownState::new(document, cx)));
+
+        state.update(cx, |state, cx| state.push_str(" grows", cx));
+        state.read_with(cx, |state, _| {
+            assert_eq!(state.last_reparse_bytes(), state.text.len());
+            assert_eq!(state.parsed, super::super::parse(&state.text));
         });
     }
 


### PR DESCRIPTION
## Problem

Perceptible jank and low framerate in ChatView, worst in long sessions and during long streaming replies. Three synchronous cost centers were responsible:

1. `MarkdownState::push_str` reparsed the **whole document** on every streamed delta — O(len) per append, quadratic over a long reply, all on the UI thread.
2. Every store notification re-hashed **every timeline entry** (`index_turns`) and cloned a String id per markdown entry (`sync_markdown_residency`) — O(session) per notification, growing with chat length.
3. Scrolling into an evicted region or opening a long session parsed large markdown documents **synchronously inside the frame**.

## Changes

- **Incremental streaming parse** — the parser records root-block source offsets; an append reparses only from the last root block's start and splices the tail onto the reused prefix. Appended link reference definitions (which can restyle earlier blocks) conservatively fall back to a full reparse. Streaming bench (50KB in 100B deltas): **~151ms → ~7ms**.
- **Incremental turn indexing** — `TurnIndexCache` finds the divergence point via `Arc::ptr_eq` prefix scan and re-hashes only affected tail turns (1 turn per streaming tick on a 200-turn timeline, asserted in tests). The residency walk pre-filters by the same keep/pinned window `decide()` uses before allocating ids.
- **Async large-markdown builds** — texts over 4KiB parse on the background executor while the existing plain-text fallback renders; completion inserts the state, remeasures the turn, and notifies. Generation + pending-map guards handle in-flight updates, evictions, and session switches. Streaming replies start under the threshold and stay on the synchronous incremental path.

## Verification

- Equivalence tests: streamed parse ≡ full parse (chunk sizes 1/7/64 over a corpus incl. setext, nested lists, unclosed fences, tables, link refs); incremental indexing ≡ full `index_turns` across append/replace/toggle/reset/rewind; filtered residency decisions ≡ unfiltered.
- Race tests: in-flight text update lands with latest text; session switch does not resurrect stale builds; no duplicate jobs; small texts stay synchronous.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked` all pass locally (280 UI tests).