### PR TITLE
fix(chat): make command panels readable

### DIFF
--- a/crates/ui/src/chat/components/activity.rs
+++ b/crates/ui/src/chat/components/activity.rs
@@ -239,8 +239,9 @@ fn activity_detail(
     let detail = match &entry.content {
         EntryContent::Item(ItemContent::CommandExecution {
             command, output, ..
-        }) => command_detail
-            .unwrap_or_else(|| CommandPanelCache::new().render(&entry.id, command, output, cx)),
+        }) => command_detail.unwrap_or_else(|| {
+            CommandPanelCache::new().render(&entry.id, command, output, None, cx)
+        }),
         EntryContent::Item(ItemContent::ToolCall { input, output, .. }) => {
             let mut input_brief = tool_brief(input);
             if input_brief.is_empty() {

--- a/crates/ui/src/chat/components/command_panel.rs
+++ b/crates/ui/src/chat/components/command_panel.rs
@@ -1,20 +1,27 @@
 use std::collections::HashMap;
 
 use gpui::{
-    AnyElement, App, ContentMask, IntoElement as _, ParentElement as _, Styled as _, canvas, div,
-    px,
+    AnyElement, App, ContentMask, IntoElement as _, ParentElement as _, Styled as _, StyledText,
+    Window, canvas, div, prelude::FluentBuilder as _, px,
 };
+use gpui_base::{ElementExt as _, h_flex};
 use term::{GridEmulator, TermSnapshot};
 
+use crate::highlight;
 use crate::terminal_drawer::{
     TERMINAL_CELL_HEIGHT, TERMINAL_CELL_WIDTH, TerminalPalette, layout_grid, paint_terminal_grid,
 };
 use crate::theme::ActiveTheme as _;
 
-const COLS: usize = 80;
+const DEFAULT_COLS: usize = 80;
+const MIN_COLS: usize = 20;
+const MAX_COLS: usize = 400;
 const MAX_ROWS: usize = 16;
 const MAX_COMMAND_ROWS: usize = 4;
+const PROMPT_COLS: usize = 2;
 const OUTPUT_TAIL_BYTES: usize = 32 * 1024;
+
+pub(crate) type ColsChangeHandler = Box<dyn Fn(&usize, &mut Window, &mut App) + 'static>;
 
 pub(crate) struct CommandPanelCache {
     entries: HashMap<String, CachedPanel>,
@@ -31,39 +38,60 @@ impl CommandPanelCache {
         self.entries.clear();
     }
 
-    pub(crate) fn render(&mut self, id: &str, command: &str, output: &str, cx: &App) -> AnyElement {
+    pub(crate) fn resize(&mut self, id: &str, cols: usize) -> bool {
+        self.entries
+            .get_mut(id)
+            .is_some_and(|panel| panel.resize(cols))
+    }
+
+    pub(crate) fn render(
+        &mut self,
+        id: &str,
+        command: &str,
+        output: &str,
+        on_cols_change: Option<ColsChangeHandler>,
+        cx: &App,
+    ) -> AnyElement {
         let panel = self
             .entries
             .entry(id.to_string())
             .or_insert_with(|| CachedPanel::new(command, output));
         panel.update(command, output);
-        panel.render(cx)
+        panel.render(on_cols_change, cx)
     }
 }
 
 struct CachedPanel {
     command: String,
-    command_snapshot: TermSnapshot,
+    displayed_command: String,
     command_rows: usize,
+    cols: usize,
     output_emulator: GridEmulator,
     output: Vec<u8>,
     fed_start: usize,
+    last_fed_was_cr: bool,
     output_snapshot: TermSnapshot,
     output_rows: usize,
 }
 
 impl CachedPanel {
     fn new(command: &str, output: &str) -> Self {
-        let (command_snapshot, command_rows) = command_snapshot(command);
-        let output_emulator = GridEmulator::with_size(COLS, MAX_ROWS - command_rows);
+        Self::with_cols(command, output, DEFAULT_COLS)
+    }
+
+    fn with_cols(command: &str, output: &str, cols: usize) -> Self {
+        let (displayed_command, command_rows) = clamp_command(command, cols);
+        let output_emulator = GridEmulator::with_size(cols, MAX_ROWS - command_rows);
         let output_snapshot = output_emulator.snapshot();
         let mut panel = Self {
             command: command.to_string(),
-            command_snapshot,
+            displayed_command,
             command_rows,
+            cols,
             output_emulator,
             output: Vec::new(),
             fed_start: 0,
+            last_fed_was_cr: false,
             output_snapshot,
             output_rows: 0,
         };
@@ -74,7 +102,7 @@ impl CachedPanel {
     fn update(&mut self, command: &str, output: &str) {
         if self.command != command {
             self.command = command.to_string();
-            (self.command_snapshot, self.command_rows) = command_snapshot(command);
+            (self.displayed_command, self.command_rows) = clamp_command(command, self.cols);
             self.rebuild_output(output.as_bytes());
             return;
         }
@@ -85,7 +113,7 @@ impl CachedPanel {
         }
         let append_only = bytes.starts_with(&self.output);
         if append_only && bytes.len().saturating_sub(self.fed_start) <= OUTPUT_TAIL_BYTES {
-            self.output_emulator.feed(&bytes[self.output.len()..]);
+            self.feed_output(&bytes[self.output.len()..]);
             self.output = bytes.to_vec();
             self.refresh_output_snapshot();
         } else {
@@ -93,41 +121,103 @@ impl CachedPanel {
         }
     }
 
+    fn resize(&mut self, cols: usize) -> bool {
+        let cols = cols.clamp(MIN_COLS, MAX_COLS);
+        if self.cols == cols {
+            return false;
+        }
+        self.cols = cols;
+        (self.displayed_command, self.command_rows) = clamp_command(&self.command, cols);
+        let output = self.output.clone();
+        self.rebuild_output(&output);
+        true
+    }
+
     fn rebuild_output(&mut self, bytes: &[u8]) {
-        self.output_emulator = GridEmulator::with_size(COLS, MAX_ROWS - self.command_rows);
+        self.output_emulator =
+            GridEmulator::with_size(self.cols, MAX_ROWS.saturating_sub(self.command_rows).max(1));
         self.fed_start = bytes.len().saturating_sub(OUTPUT_TAIL_BYTES);
-        self.output_emulator.feed(&bytes[self.fed_start..]);
+        self.last_fed_was_cr = self.fed_start > 0 && bytes[self.fed_start - 1] == b'\r';
+        self.feed_output(&bytes[self.fed_start..]);
         self.output = bytes.to_vec();
         self.refresh_output_snapshot();
     }
 
-    fn refresh_output_snapshot(&mut self) {
-        self.output_snapshot = self.output_emulator.snapshot();
-        self.output_rows =
-            trim_snapshot(&mut self.output_snapshot, MAX_ROWS - self.command_rows, 0);
+    fn feed_output(&mut self, bytes: &[u8]) {
+        let mut normalized = Vec::with_capacity(bytes.len());
+        for &byte in bytes {
+            if byte == b'\n' && !self.last_fed_was_cr {
+                normalized.push(b'\r');
+            }
+            normalized.push(byte);
+            self.last_fed_was_cr = byte == b'\r';
+        }
+        self.output_emulator.feed(&normalized);
     }
 
-    fn render(&self, cx: &App) -> AnyElement {
+    fn refresh_output_snapshot(&mut self) {
+        self.output_snapshot = self.output_emulator.snapshot();
+        self.output_rows = trim_snapshot(
+            &mut self.output_snapshot,
+            MAX_ROWS.saturating_sub(self.command_rows).max(1),
+            0,
+        );
+    }
+
+    fn render(&self, on_cols_change: Option<ColsChangeHandler>, cx: &App) -> AnyElement {
         let palette = TerminalPalette {
             foreground: cx.theme().foreground,
             background: cx.theme().background,
             selection: cx.theme().primary.opacity(0.28),
         };
-        let command = grid_element(&self.command_snapshot, self.command_rows, palette);
+        let highlights = highlight::highlight_source(
+            &self.displayed_command,
+            "bash",
+            &cx.theme().highlight_theme,
+        );
+        let command = h_flex()
+            .w_full()
+            .min_w_0()
+            .items_start()
+            .px_1()
+            .py_1()
+            .bg(cx.theme().tokens.colors.muted)
+            .font_family(cx.theme().mono_font_family.clone())
+            .text_size(px(13.))
+            .child(div().flex_none().text_color(cx.theme().primary).child("❯ "))
+            .child(div().flex_1().min_w_0().whitespace_normal().child(
+                StyledText::new(self.displayed_command.clone()).with_highlights(highlights),
+            ));
         let output = (self.output_rows > 0)
-            .then(|| grid_element(&self.output_snapshot, self.output_rows, palette));
+            .then(|| grid_element(&self.output_snapshot, self.output_rows, self.cols, palette));
+        let rendered_cols = self.cols;
         div()
-            .w(px(COLS as f32 * TERMINAL_CELL_WIDTH))
-            .max_w_full()
+            .w_full()
             .overflow_hidden()
             .bg(palette.background)
             .child(command)
-            .children(output)
+            .children(output.map(|output| div().mt_1().child(output)))
+            .when_some(on_cols_change, |panel, on_cols_change| {
+                panel.on_prepaint(move |bounds, window, cx| {
+                    let cols = (f32::from(bounds.size.width) / TERMINAL_CELL_WIDTH)
+                        .floor()
+                        .max(0.) as usize;
+                    let cols = cols.clamp(MIN_COLS, MAX_COLS);
+                    if cols != rendered_cols {
+                        on_cols_change(&cols, window, cx);
+                    }
+                })
+            })
             .into_any_element()
     }
 }
 
-fn grid_element(snapshot: &TermSnapshot, rows: usize, palette: TerminalPalette) -> AnyElement {
+fn grid_element(
+    snapshot: &TermSnapshot,
+    rows: usize,
+    cols: usize,
+    palette: TerminalPalette,
+) -> AnyElement {
     let paint_data = layout_grid(snapshot, palette, false, None, false, false);
     canvas(
         |_bounds, _window, _cx| (),
@@ -147,54 +237,46 @@ fn grid_element(snapshot: &TermSnapshot, rows: usize, palette: TerminalPalette) 
             });
         },
     )
-    .w(px(COLS as f32 * TERMINAL_CELL_WIDTH))
+    .w(px(cols as f32 * TERMINAL_CELL_WIDTH))
     .h(px(rows as f32 * TERMINAL_CELL_HEIGHT))
     .into_any_element()
 }
 
-fn command_snapshot(command: &str) -> (TermSnapshot, usize) {
-    let emulator = GridEmulator::with_size(COLS, MAX_COMMAND_ROWS);
-    emulator.feed(clamp_command(command).as_bytes());
-    let mut snapshot = emulator.snapshot();
-    let rows = trim_snapshot(&mut snapshot, MAX_COMMAND_ROWS, 1);
-    (snapshot, rows)
-}
-
-fn clamp_command(command: &str) -> String {
-    let mut result = String::new();
-    let mut row = 0;
-    let mut col = 0;
-    let mut chars = command.chars().peekable();
+fn clamp_command(command: &str, cols: usize) -> (String, usize) {
+    let line_cols = cols.saturating_sub(PROMPT_COLS).max(1);
+    let mut lines = vec![String::new()];
+    let mut truncated = false;
+    let mut chars = command.chars().filter(|ch| *ch != '\r').peekable();
     while let Some(ch) = chars.next() {
         if ch == '\n' {
-            if row + 1 == MAX_COMMAND_ROWS && chars.peek().is_some() {
-                result.push('…');
+            if lines.len() == MAX_COMMAND_ROWS {
+                truncated = chars.peek().is_some();
                 break;
             }
-            result.push_str("\r\n");
-            row += 1;
-            col = 0;
+            lines.push(String::new());
             continue;
         }
-        if ch == '\r' {
-            continue;
+        if lines
+            .last()
+            .is_some_and(|line| line.chars().count() == line_cols)
+        {
+            if lines.len() == MAX_COMMAND_ROWS {
+                truncated = true;
+                break;
+            }
+            lines.push(String::new());
         }
-        if col == COLS {
-            row += 1;
-            col = 0;
-        }
-        if row == MAX_COMMAND_ROWS {
-            result.push('…');
-            break;
-        }
-        if row + 1 == MAX_COMMAND_ROWS && col + 1 == COLS && chars.peek().is_some() {
-            result.push('…');
-            break;
-        }
-        result.push(ch);
-        col += 1;
+        lines.last_mut().expect("command has one line").push(ch);
     }
-    result
+    if truncated {
+        let last = lines.last_mut().expect("command has one line");
+        if last.chars().count() == line_cols {
+            last.pop();
+        }
+        last.push('…');
+    }
+    let rows = lines.len();
+    (lines.join("\n"), rows)
 }
 
 fn trim_snapshot(snapshot: &mut TermSnapshot, max_rows: usize, minimum: usize) -> usize {
@@ -248,19 +330,46 @@ mod tests {
 
     #[test]
     fn command_is_clamped_to_four_rows() {
-        let panel = CachedPanel::new(&"x".repeat(COLS * MAX_COMMAND_ROWS + 1), "");
-        assert_eq!(panel.command_rows, MAX_COMMAND_ROWS);
-        assert!(
-            panel
-                .command_snapshot
-                .cell_text(MAX_COMMAND_ROWS - 1, COLS - 1)
-                .is_some_and(|text| text == "…")
+        let panel = CachedPanel::new(
+            &"x".repeat((DEFAULT_COLS - PROMPT_COLS) * MAX_COMMAND_ROWS + 1),
+            "",
         );
+        assert_eq!(panel.command_rows, MAX_COMMAND_ROWS);
+        assert!(panel.displayed_command.ends_with('…'));
+        assert_eq!(panel.displayed_command.lines().count(), MAX_COMMAND_ROWS);
     }
 
     #[test]
     fn trailing_blank_output_rows_are_trimmed() {
         let panel = CachedPanel::new("printf one", "one\n\n");
         assert_eq!(panel.output_rows, 1);
+    }
+
+    #[test]
+    fn bare_lf_returns_output_to_first_column() {
+        let panel = CachedPanel::new("cmd", "a\nb");
+        assert_eq!(panel.output_snapshot.cell_text(1, 0), Some("b".to_string()));
+    }
+
+    #[test]
+    fn split_crlf_is_not_double_converted() {
+        let mut panel = CachedPanel::new("cmd", "a\r");
+        panel.update("cmd", "a\r\nb");
+        assert_eq!(panel.output_snapshot.cell_text(1, 0), Some("b".to_string()));
+        assert_eq!(panel.output_rows, 2);
+    }
+
+    #[test]
+    fn output_wraps_at_the_configured_column_count() {
+        let output = "abcdefghijklmnopqrstuvwxy";
+        let narrow = CachedPanel::with_cols("cmd", output, 20);
+        let wide = CachedPanel::with_cols("cmd", output, 40);
+        assert_eq!(
+            narrow.output_snapshot.cell_text(1, 0),
+            Some("u".to_string())
+        );
+        assert_eq!(narrow.output_rows, 2);
+        assert_eq!(wide.output_snapshot.cell_text(0, 20), Some("u".to_string()));
+        assert_eq!(wide.output_rows, 1);
     }
 }

--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -1063,21 +1063,32 @@ impl ChatView {
                 })
             );
         let expanded = automatic || self.expanded.contains(&key);
+        let turn = entry.turn;
         let command_detail = if expanded {
             match &entry.content {
                 EntryContent::Item(ItemContent::CommandExecution {
                     command, output, ..
-                }) => Some(
-                    self.command_panels
-                        .borrow_mut()
-                        .render(&entry.id, command, output, cx),
-                ),
+                }) => {
+                    let panel_id = entry.id.clone();
+                    let on_cols_change = cx.listener(move |this, cols: &usize, _window, cx| {
+                        if this.command_panels.borrow_mut().resize(&panel_id, *cols) {
+                            this.list_state.remeasure_items(turn..turn + 1);
+                            cx.notify();
+                        }
+                    });
+                    Some(self.command_panels.borrow_mut().render(
+                        &entry.id,
+                        command,
+                        output,
+                        Some(Box::new(on_cols_change)),
+                        cx,
+                    ))
+                }
                 _ => None,
             }
         } else {
             None
         };
-        let turn = entry.turn;
         let click_key = key;
         components::activity::activity_row_with_command_detail(
             entry,


### PR DESCRIPTION
Fixes three independent readability problems in the chat command-execution panel, plus one width improvement.

## What was wrong

1. **Staircase layout**: tool output is plain `\n`-separated text, but the grid emulator follows strict VT semantics — bare LF moves the cursor down without returning to column 0, so every output line started where the previous one ended.
2. **No visual distinction between command and output**: both were rendered as terminal grids with the same palette and background, stacked with no separator.
3. **No coloring**: commands run without a TTY, so programs never emit ANSI colors — the emulator's ANSI support (which works) had nothing to render.
4. Panel width was hardcoded to 80 columns (~626px): clipped in narrow windows, wasted space in wide ones.

## Changes

- Normalize bare LF to CRLF before feeding output into the emulator. CR state is carried across incremental append chunks and the 32KB tail-rebuild boundary so existing CRLF is never double-converted.
- Replace the command grid with a styled prompt line: `❯` prefix in theme primary, syntect bash highlighting via the existing `highlight_source` infra, mono font on a muted background — structurally and visually distinct from the output grid below.
- Derive the output column count from the measured panel width (`on_prepaint`, same pattern as the terminal drawer), clamped to 20–400 cols; emulators rebuild and the virtual-list row remeasures only when the count actually changes.

## Tests

- `bare_lf_returns_output_to_first_column`
- `split_crlf_is_not_double_converted` (CR/LF split across two incremental updates)
- `output_wraps_at_the_configured_column_count`
- Existing clamp/ANSI tests adapted to the new structure.

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked` (894 passed) are green locally.