### PR TITLE
fix(composer): drop borders from model/traits/permission picker chips

### DIFF
--- a/crates/ui/src/composer/components/pickers.rs
+++ b/crates/ui/src/composer/components/pickers.rs
@@ -200,7 +200,6 @@ impl Composer {
 
         let trigger = Button::new("model-picker")
             .ghost()
-            .outline()
             .compact()
             .h(px(28.))
             .rounded(crate::material::radius_input())
@@ -287,7 +286,6 @@ impl Composer {
 
         let trigger = Button::new("traits-chip")
             .ghost()
-            .outline()
             .compact()
             .h(px(28.))
             .rounded(crate::material::radius_chip())
@@ -408,7 +406,6 @@ impl Composer {
 
         let trigger = Button::new("permission-chip")
             .ghost()
-            .outline()
             .compact()
             .h(px(28.))
             .rounded(crate::material::radius_input())


### PR DESCRIPTION
Follow-up to #284: the composer input's model / reasoning-effort / permission picker chips should not carry the dropdown outline — reverts `.outline()` on those three triggers only. Select controls elsewhere (settings, branch/workspace pickers, diff selects) keep their borders.

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test` — passes (one unrelated flaky markdown tooltip test failed once in a `--workspace` run, passed on rerun and in isolation)