### PR TITLE
fix(chat): opaque backing for scroll-to-end pill

### DIFF
--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -1817,16 +1817,24 @@ impl ChatView {
             .flex()
             .justify_center()
             .child(
-                Button::new("scroll-to-end")
-                    .outline()
-                    .small()
-                    .icon(IconName::ChevronDown)
-                    .label(crate::tr!("chat.scroll_end"))
-                    .on_click(cx.listener(|this, _, _, cx| {
-                        this.list_state.set_follow_mode(FollowMode::Tail);
-                        this.list_state.scroll_to_end();
-                        cx.notify();
-                    })),
+                // The outline button's bg is ~transparent; an opaque popover
+                // backing keeps the pill readable over the chat text below.
+                div()
+                    .rounded(cx.theme().radius)
+                    .bg(cx.theme().popover)
+                    .shadow_md()
+                    .child(
+                        Button::new("scroll-to-end")
+                            .outline()
+                            .small()
+                            .icon(IconName::ChevronDown)
+                            .label(crate::tr!("chat.scroll_end"))
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.list_state.set_follow_mode(FollowMode::Tail);
+                                this.list_state.scroll_to_end();
+                                cx.notify();
+                            })),
+                    ),
             )
             .into_any_element()
     }


### PR DESCRIPTION
The scroll-to-end button uses the `.outline()` variant whose background is `opacity(0.1)` — chat text bleeds through and the label is nearly unreadable. Call-site `.bg()` is overwritten by `Button::render`, so wrap the button in an opaque `theme().popover` backing with matching radius and `shadow_md`, consistent with other floating surfaces.