### PR TITLE
feat(settings): per-item restore-default buttons, quieter global reset

### DIFF
--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -776,12 +776,18 @@ pub struct Settings {
     pub unknown: serde_json::Map<String, serde_json::Value>,
 }
 
+/// Factory value for [`Settings::auto_archive_max_idle_days`]. Public so the
+/// settings page can tell an overridden field from an untouched one.
+pub const DEFAULT_AUTO_ARCHIVE_MAX_IDLE_DAYS: u32 = 7;
+/// Factory value for [`Settings::auto_archive_keep_count`].
+pub const DEFAULT_AUTO_ARCHIVE_KEEP_COUNT: usize = 30;
+
 const fn default_auto_archive_max_idle_days() -> u32 {
-    7
+    DEFAULT_AUTO_ARCHIVE_MAX_IDLE_DAYS
 }
 
 const fn default_auto_archive_keep_count() -> usize {
-    30
+    DEFAULT_AUTO_ARCHIVE_KEEP_COUNT
 }
 
 impl Default for Settings {

--- a/crates/runtime/src/app/acp.rs
+++ b/crates/runtime/src/app/acp.rs
@@ -238,13 +238,28 @@ impl AppState {
         self.preview_draft_or_persist_active(cx);
     }
 
-    /// Reset user settings to defaults, preserving the sidebar's per-project
-    /// collapsed state and the model favorites (UI state, not page settings).
-    /// The theme is reset too; the caller re-applies it to the window.
+    /// Reset the *preferences* to defaults. Anything the user had to configure
+    /// or install survives: provider profiles and their credentials, the ACP
+    /// agents on disk, and the legacy binary overrides — wiping those would cost
+    /// re-authentication and re-downloads, which is never what "restore
+    /// defaults" means. Sidebar/UI state (collapsed projects, favorites, sort,
+    /// layout, last-visited) is preserved for the same reason, and `unknown`
+    /// must survive so a newer build's keys are not destroyed by an older one.
+    /// The theme is reset; the caller re-applies it to the window.
     pub fn reset_settings(&mut self, cx: &mut HostCx) {
         let settings = Settings {
+            providers: self.settings.providers.clone(),
+            profiles: self.settings.profiles.clone(),
+            codex_binary: self.settings.codex_binary.clone(),
+            claude_binary: self.settings.claude_binary.clone(),
+            acp_agents: self.settings.acp_agents.clone(),
+            sidebar_collapsed: self.settings.sidebar_collapsed,
             collapsed_projects: self.settings.collapsed_projects.clone(),
             favorite_models: self.settings.favorite_models.clone(),
+            project_sort: self.settings.project_sort,
+            sidebar_layout: self.settings.sidebar_layout,
+            last_visited: self.settings.last_visited.clone(),
+            unknown: self.settings.unknown.clone(),
             ..Settings::default()
         };
         self.update_settings(settings, cx);

--- a/crates/runtime/src/app/tests.rs
+++ b/crates/runtime/src/app/tests.rs
@@ -218,6 +218,106 @@ fn settings_patches_from_stale_snapshot_preserve_nested_sibling_fields() {
 }
 
 #[test]
+fn reset_settings_clears_preferences_but_keeps_credentials_installs_and_unknown_keys() {
+    let cx = &mut TestAppContext::default();
+    let test_store = TestStore::new("tcode-reset-settings-scope-test");
+    let state = cx.new_entity(|_| AppState::new((*test_store).clone()));
+
+    // Preferences the reset must clear.
+    let mut settings = Settings {
+        theme_mode: ThemeMode::Dark,
+        language: Some("zh-CN".into()),
+        word_wrap_diffs: true,
+        auto_archive_max_idle_days: 99,
+        ..Settings::default()
+    };
+    settings.browser.home_url = Some("https://example.com".into());
+    // Everything below cost the user a login, a download, or a newer build.
+    settings
+        .provider_mut(ProviderKind::Codex)
+        .env
+        .push(tcode_core::settings::EnvVar {
+            name: "OPENAI_API_KEY".into(),
+            value: "secret".into(),
+            sensitive: true,
+        });
+    settings.profiles.insert(
+        "work-claude".into(),
+        ProviderProfile {
+            kind: ProviderKind::ClaudeCode,
+            settings: ProviderSettings::default(),
+        },
+    );
+    settings.codex_binary = Some(PathBuf::from("/custom/codex"));
+    settings.claude_binary = Some(PathBuf::from("/custom/claude"));
+    settings.acp_agents.insert(
+        "first".into(),
+        InstalledAgent {
+            id: "first".into(),
+            name: "First".into(),
+            version: "1.2.3".into(),
+            icon: None,
+            launch: agent::AcpLaunch::Npx {
+                package: "first-agent".into(),
+                args: Vec::new(),
+                env: Vec::new(),
+            },
+            enabled: true,
+            env: Vec::new(),
+            launch_args: None,
+        },
+    );
+    settings.collapsed_projects.push("project".into());
+    settings.favorite_models.push("gpt-5.6-sol".into());
+    settings.sidebar_collapsed = true;
+    settings.project_sort = tcode_core::settings::ProjectSort::NameAsc;
+    settings.sidebar_layout = tcode_core::settings::SidebarLayout::Grouped;
+    settings.last_visited.insert("session".into(), 42);
+    settings
+        .unknown
+        .insert("future_key".into(), serde_json::json!({"kept": true}));
+
+    state.update(cx, |state, cx| {
+        state.update_settings(settings, cx);
+        state.reset_settings(cx);
+
+        let reset = &state.settings;
+        assert_eq!(reset.theme_mode, ThemeMode::System);
+        assert_eq!(reset.language, None);
+        assert!(!reset.word_wrap_diffs);
+        assert_eq!(reset.auto_archive_max_idle_days, 7);
+        assert_eq!(reset.browser.home_url, None);
+
+        assert_eq!(
+            reset.provider(ProviderKind::Codex).env[0].value,
+            "secret",
+            "provider credentials must survive a restore"
+        );
+        assert!(reset.profiles.contains_key("work-claude"));
+        assert_eq!(reset.codex_binary, Some(PathBuf::from("/custom/codex")));
+        assert_eq!(reset.claude_binary, Some(PathBuf::from("/custom/claude")));
+        assert!(reset.acp_agents.contains_key("first"));
+        assert_eq!(reset.collapsed_projects, vec!["project".to_string()]);
+        assert_eq!(reset.favorite_models, vec!["gpt-5.6-sol".to_string()]);
+        assert!(reset.sidebar_collapsed);
+        assert_eq!(
+            reset.project_sort,
+            tcode_core::settings::ProjectSort::NameAsc
+        );
+        assert_eq!(
+            reset.sidebar_layout,
+            tcode_core::settings::SidebarLayout::Grouped
+        );
+        assert_eq!(reset.last_visited.get("session"), Some(&42));
+        assert_eq!(
+            reset.unknown.get("future_key"),
+            Some(&serde_json::json!({"kept": true})),
+            "forward-compat keys must not be destroyed by a restore"
+        );
+    });
+}
+
+#[test]
 fn provider_projection_diff_emits_once_then_suppresses_noop_turn() {
     let cx = &mut TestAppContext::default();
     let test_store = TestStore::new("tcode-provider-diff-test");

--- a/crates/ui/src/orchestrate_settings.rs
+++ b/crates/ui/src/orchestrate_settings.rs
@@ -10,9 +10,9 @@ use crate::{
     sizing::Sizable as _,
 };
 use gpui::{
-    AnyElement, App, AppContext as _, Context, Entity, InteractiveElement as _, IntoElement,
-    ParentElement as _, Render, StatefulInteractiveElement as _, Styled as _, Subscription, Window,
-    div, prelude::FluentBuilder as _, px,
+    AnyElement, App, AppContext as _, Context, ElementId, Entity, InteractiveElement as _,
+    IntoElement, ParentElement as _, Render, StatefulInteractiveElement as _, Styled as _,
+    Subscription, Window, div, prelude::FluentBuilder as _, px,
 };
 use gpui_base::{StyledExt as _, h_flex, v_flex};
 
@@ -431,36 +431,73 @@ impl OrchestrateSettingsPanel {
         }
     }
 
+    /// Restore both halves of a child row's routing preset — effort and
+    /// definition — from the bundled fleet entry it maps to. `enabled` is
+    /// list-level state and deliberately untouched.
     fn reset_child_definition(&self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
         let settings = self.store.read(cx).settings();
-        let Some(entry) = settings.orchestrate.child_models.get(index) else {
+        let Some(target) = builtin_child_target(&settings.orchestrate.child_models, index) else {
             return;
         };
-        let provider = entry.provider;
-        let model = entry.model.clone();
-        let value = OrchestrateSettings::builtin_child_definition(
-            provider,
-            &model,
-            entry.effort.as_deref(),
-        )
-        .unwrap_or_default()
-        .to_string();
-        let persisted = value.clone();
+        let provider = target.provider;
+        let model = target.model.clone();
+        let effort = target.effort;
+        let description = target.description;
+        let persisted_description = description.clone();
         self.update_child_models(
             move |models| {
                 if let Some(entry) = models.get_mut(index)
                     && entry.provider == provider
                     && entry.model == model
                 {
-                    entry.description = persisted;
+                    entry.effort = effort;
+                    entry.description = persisted_description;
                 }
             },
             cx,
         );
+        // The effort dropdown reads straight from settings; only the
+        // description textarea holds its own copy.
         if let Some(row) = self.child_rows.get(index) {
             row.description
-                .update(cx, |input, cx| input.set_value(value, window, cx));
+                .update(cx, |input, cx| input.set_value(description, window, cx));
         }
+    }
+
+    /// The per-item "restore default" affordance, mirroring the General page:
+    /// icon-only, ghost, and inline immediately after the row's title.
+    fn reset_button(
+        &self,
+        id: impl Into<ElementId>,
+        cx: &mut Context<Self>,
+        on_reset: impl Fn(&mut Self, &mut Window, &mut Context<Self>) + 'static,
+    ) -> AnyElement {
+        let label = crate::tr!("settings.reset_item").into_owned();
+        Button::new(id)
+            .ghost()
+            .xsmall()
+            .icon(IconName::Undo)
+            .tooltip(label.clone())
+            .aria_label(label)
+            .on_click(cx.listener(move |this, _, window, cx| {
+                cx.stop_propagation();
+                on_reset(this, window, cx);
+            }))
+            .into_any_element()
+    }
+
+    /// A 13px row title carrying its optional inline reset affordance.
+    fn row_title(
+        &self,
+        title: impl Into<gpui::SharedString>,
+        reset: Option<AnyElement>,
+    ) -> AnyElement {
+        h_flex()
+            .items_center()
+            .gap_1()
+            .child(div().text_size(px(13.)).font_medium().child(title.into()))
+            .children(reset)
+            .into_any_element()
     }
 
     fn model_name(
@@ -537,6 +574,13 @@ impl OrchestrateSettingsPanel {
 
     fn render_child_approval(&self, cx: &mut Context<Self>) -> AnyElement {
         let selected = self.store.read(cx).settings().orchestrate.child_approval;
+        let reset = (selected != ChildApprovalMode::Orchestrator).then(|| {
+            self.reset_button("reset-orchestrate-child-approval", cx, |this, _, cx| {
+                this.store.update(cx, |store, _cx| {
+                    store.set_orchestrate_child_approval(ChildApprovalMode::Orchestrator)
+                });
+            })
+        });
         let selected_label = match selected {
             ChildApprovalMode::Orchestrator => {
                 crate::tr!("orchestrate.child_approval.orchestrator")
@@ -646,12 +690,10 @@ impl OrchestrateSettingsPanel {
                             .flex_1()
                             .min_w_0()
                             .gap_0p5()
-                            .child(
-                                div()
-                                    .text_size(px(13.))
-                                    .font_medium()
-                                    .child(crate::tr!("orchestrate.child_approval.title")),
-                            )
+                            .child(self.row_title(
+                                crate::tr!("orchestrate.child_approval.title").into_owned(),
+                                reset,
+                            ))
                             .child(
                                 div()
                                     .text_size(px(11.))
@@ -671,6 +713,13 @@ impl OrchestrateSettingsPanel {
             .settings()
             .orchestrate
             .archive_on_complete;
+        let reset = (!checked).then(|| {
+            self.reset_button("reset-orchestrate-auto-archive", cx, |this, _, cx| {
+                this.store.update(cx, |store, _cx| {
+                    store.set_orchestrate_archive_on_complete(true)
+                });
+            })
+        });
         crate::material::group(cx)
             .child(
                 h_flex()
@@ -685,12 +734,10 @@ impl OrchestrateSettingsPanel {
                             .flex_1()
                             .min_w_0()
                             .gap_0p5()
-                            .child(
-                                div()
-                                    .text_size(px(13.))
-                                    .font_medium()
-                                    .child(crate::tr!("orchestrate.auto_archive.title")),
-                            )
+                            .child(self.row_title(
+                                crate::tr!("orchestrate.auto_archive.title").into_owned(),
+                                reset,
+                            ))
                             .child(
                                 div()
                                     .text_size(px(11.))
@@ -714,6 +761,13 @@ impl OrchestrateSettingsPanel {
 
     fn render_child_worktrees(&self, cx: &mut Context<Self>) -> AnyElement {
         let checked = self.store.read(cx).settings().orchestrate.child_worktrees;
+        let reset = checked.then(|| {
+            self.reset_button("reset-orchestrate-child-worktrees", cx, |this, _, cx| {
+                this.store.update(cx, |store, _cx| {
+                    store.set_orchestrate_child_worktrees(false)
+                });
+            })
+        });
         crate::material::group(cx)
             .child(
                 h_flex()
@@ -728,12 +782,10 @@ impl OrchestrateSettingsPanel {
                             .flex_1()
                             .min_w_0()
                             .gap_0p5()
-                            .child(
-                                div()
-                                    .text_size(px(13.))
-                                    .font_medium()
-                                    .child(crate::tr!("orchestrate.child_worktrees.title")),
-                            )
+                            .child(self.row_title(
+                                crate::tr!("orchestrate.child_worktrees.title").into_owned(),
+                                reset,
+                            ))
                             .child(
                                 div()
                                     .text_size(px(11.))
@@ -784,63 +836,56 @@ impl OrchestrateSettingsPanel {
     }
 
     fn render_identities(&self, cx: &mut Context<Self>) -> AnyElement {
-        let section =
-            v_flex()
-                .w_full()
-                .gap_3()
-                .child(self.section_heading(
-                    crate::tr!("orchestrate.identity.title"),
-                    crate::tr!("orchestrate.identity.description"),
-                    None,
-                    cx,
-                ))
-                // Generic identity: a single-row group holding the header, help and
-                // its text area — no slab fill.
-                .child(
-                    crate::material::group(cx).child(
-                        v_flex()
-                            .w_full()
-                            .gap_1p5()
-                            .px_3()
-                            .py_3()
-                            .child(
-                                h_flex()
-                                    .w_full()
-                                    .items_center()
-                                    .child(
-                                        div().flex_1().text_size(px(13.)).font_medium().child(
-                                            crate::tr!("orchestrate.generic_identity.title"),
-                                        ),
-                                    )
-                                    .child(
-                                        Button::new("reset-generic-orchestrator-identity")
-                                            .ghost()
-                                            .xsmall()
-                                            .icon(IconName::Undo)
-                                            .label(crate::tr!("orchestrate.restore_default"))
-                                            .on_click(cx.listener(|this, _, window, cx| {
-                                                this.reset_generic_identity(window, cx);
-                                            })),
-                                    ),
-                            )
-                            .child(
-                                div()
-                                    .text_size(px(13.))
-                                    .text_color(cx.theme().muted_foreground)
-                                    .child(crate::tr!("orchestrate.generic_identity.description")),
-                            )
-                            .child(
-                                Textarea::new(&self.generic_identity)
-                                    .rounded(crate::material::radius_input()),
-                            ),
-                    ),
-                )
-                .child(self.section_heading(
-                    crate::tr!("orchestrate.model_identity.title"),
-                    crate::tr!("orchestrate.model_identity.description"),
-                    Some(self.identity_model_picker.clone().into_any_element()),
-                    cx,
-                ));
+        let identities = self.store.read(cx).settings().orchestrate.model_identities;
+        let generic_reset = (self.store.read(cx).settings().orchestrate.generic_identity
+            != OrchestrateSettings::builtin_generic_identity())
+        .then(|| {
+            self.reset_button(
+                "reset-generic-orchestrator-identity",
+                cx,
+                |this, window, cx| this.reset_generic_identity(window, cx),
+            )
+        });
+        let section = v_flex()
+            .w_full()
+            .gap_3()
+            .child(self.section_heading(
+                crate::tr!("orchestrate.identity.title"),
+                crate::tr!("orchestrate.identity.description"),
+                None,
+                cx,
+            ))
+            // Generic identity: a single-row group holding the header, help and
+            // its text area — no slab fill.
+            .child(
+                crate::material::group(cx).child(
+                    v_flex()
+                        .w_full()
+                        .gap_1p5()
+                        .px_3()
+                        .py_3()
+                        .child(self.row_title(
+                            crate::tr!("orchestrate.generic_identity.title").into_owned(),
+                            generic_reset,
+                        ))
+                        .child(
+                            div()
+                                .text_size(px(13.))
+                                .text_color(cx.theme().muted_foreground)
+                                .child(crate::tr!("orchestrate.generic_identity.description")),
+                        )
+                        .child(
+                            Textarea::new(&self.generic_identity)
+                                .rounded(crate::material::radius_input()),
+                        ),
+                ),
+            )
+            .child(self.section_heading(
+                crate::tr!("orchestrate.model_identity.title"),
+                crate::tr!("orchestrate.model_identity.description"),
+                Some(self.identity_model_picker.clone().into_any_element()),
+                cx,
+            ));
 
         if self.identity_rows.is_empty() {
             return section
@@ -865,6 +910,20 @@ impl OrchestrateSettingsPanel {
             let provider = row.provider;
             let model = row.model.clone();
             let reset_model = row.model.clone();
+            // Models without a bundled specialization fall back to the factory
+            // generic text — that *is* their default.
+            let overridden = identities.get(index).is_some_and(|entry| {
+                entry.identity != OrchestrateSettings::builtin_identity_for(provider, &entry.model)
+            });
+            let reset = overridden.then(|| {
+                self.reset_button(
+                    ("reset-orchestrator-identity", index),
+                    cx,
+                    move |this, window, cx| {
+                        this.reset_model_identity(provider, &reset_model, window, cx);
+                    },
+                )
+            });
             rows.push(
                 v_flex()
                     .w_full()
@@ -881,7 +940,7 @@ impl OrchestrateSettingsPanel {
                                 v_flex()
                                     .flex_1()
                                     .min_w_0()
-                                    .child(div().text_size(px(13.)).font_medium().child(name))
+                                    .child(self.row_title(name, reset))
                                     .child(
                                         div()
                                             .font_family("monospace")
@@ -893,21 +952,6 @@ impl OrchestrateSettingsPanel {
                                                 row.model
                                             )),
                                     ),
-                            )
-                            .child(
-                                Button::new(("reset-orchestrator-identity", index))
-                                    .ghost()
-                                    .xsmall()
-                                    .icon(IconName::Undo)
-                                    .label(crate::tr!("orchestrate.restore_default"))
-                                    .on_click(cx.listener(move |this, _, window, cx| {
-                                        this.reset_model_identity(
-                                            provider,
-                                            &reset_model,
-                                            window,
-                                            cx,
-                                        );
-                                    })),
                             )
                             .child(
                                 Button::new(("remove-orchestrator-identity", index))
@@ -985,6 +1029,17 @@ impl OrchestrateSettingsPanel {
             } else {
                 format!("{} · {} · {}", provider_label(provider), row.model, effort)
             };
+            let reset = builtin_child_target(&settings.child_models, index)
+                .filter(|target| {
+                    target.effort != profile.effort || target.description != profile.description
+                })
+                .map(|_| {
+                    self.reset_button(
+                        ("reset-orchestrate-child", index),
+                        cx,
+                        move |this, window, cx| this.reset_child_definition(index, window, cx),
+                    )
+                });
             rows.push(
                 v_flex()
                     .w_full()
@@ -1001,7 +1056,7 @@ impl OrchestrateSettingsPanel {
                                 v_flex()
                                     .flex_1()
                                     .min_w_0()
-                                    .child(div().text_size(px(13.)).font_medium().child(name))
+                                    .child(self.row_title(name, reset))
                                     .child(
                                         div()
                                             .font_family("monospace")
@@ -1036,16 +1091,6 @@ impl OrchestrateSettingsPanel {
                                     })
                                     .on_click(cx.listener(move |this, checked: &bool, _, cx| {
                                         this.set_child_enabled(index, *checked, cx);
-                                    })),
-                            )
-                            .child(
-                                Button::new(("reset-orchestrate-child", index))
-                                    .ghost()
-                                    .xsmall()
-                                    .icon(IconName::Undo)
-                                    .label(crate::tr!("orchestrate.restore_default"))
-                                    .on_click(cx.listener(move |this, _, window, cx| {
-                                        this.reset_child_definition(index, window, cx);
                                     })),
                             )
                             .child(
@@ -1188,6 +1233,58 @@ impl OrchestrateSettingsPanel {
             .child(crate::material::grouped(rows, cx))
             .into_any_element()
     }
+}
+
+/// Whether two efforts name the same tier. Stored efforts are free text, so a
+/// hand-typed "Medium" must still match the bundled "medium".
+fn same_effort(left: &Option<String>, right: &Option<String>) -> bool {
+    match (left, right) {
+        (None, None) => true,
+        (Some(left), Some(right)) => left.trim().eq_ignore_ascii_case(right.trim()),
+        _ => false,
+    }
+}
+
+/// The bundled fleet entry a child row resets to, if it has one. Rows the user
+/// pointed at a custom provider profile were never bundled, and neither were
+/// models missing from [`OrchestrateSettings::default`].
+fn builtin_child_target(
+    rows: &[OrchestrateChildModel],
+    index: usize,
+) -> Option<OrchestrateChildModel> {
+    let row = rows.get(index)?;
+    if row.profile_id.is_some() {
+        return None;
+    }
+    let builtins: Vec<OrchestrateChildModel> = OrchestrateSettings::default()
+        .child_models
+        .into_iter()
+        .filter(|entry| entry.provider == row.provider && entry.model == row.model)
+        .collect();
+    if let Some(entry) = builtins
+        .iter()
+        .find(|entry| same_effort(&entry.effort, &row.effort))
+    {
+        return Some(entry.clone());
+    }
+    if builtins.len() == 1 {
+        return builtins.into_iter().next();
+    }
+    // A model bundled at several efforts whose row matches none of them (say
+    // gpt-5.6-sol retuned to "high"): claim the first tier no sibling row
+    // already occupies, so two rows never restore onto the same entry.
+    builtins
+        .iter()
+        .find(|entry| {
+            !rows.iter().enumerate().any(|(other, candidate)| {
+                other != index
+                    && candidate.provider == row.provider
+                    && candidate.model == row.model
+                    && same_effort(&entry.effort, &candidate.effort)
+            })
+        })
+        .or_else(|| builtins.first())
+        .cloned()
 }
 
 impl Render for OrchestrateSettingsPanel {

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -6,6 +6,7 @@
 //! description on the left, a control on the right), matching reference shots
 //! 40-settings.png / 41-settings-connections.png.
 
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::overlay::{DialogButtons, OverlayExt as _};
@@ -17,9 +18,9 @@ use crate::{
     sizing::Sizable as _,
 };
 use gpui::{
-    AnyElement, App, AppContext as _, Context, Entity, InteractiveElement as _, IntoElement,
-    ParentElement as _, Render, Role, SharedString, StatefulInteractiveElement as _, Styled as _,
-    Subscription, Toggled, Window, div, prelude::FluentBuilder as _, px,
+    AnyElement, App, AppContext as _, Context, Entity, FocusHandle, InteractiveElement as _,
+    IntoElement, ParentElement as _, Render, Role, SharedString, StatefulInteractiveElement as _,
+    Styled as _, Subscription, Toggled, Window, div, prelude::FluentBuilder as _, px,
 };
 use gpui_base::{StyledExt as _, v_flex};
 
@@ -39,6 +40,10 @@ use crate::time::{humanize_ago, now_secs};
 use crate::window_caption;
 use crate::window_drag_area;
 use crate::window_state::WindowState;
+use tcode_core::settings::{
+    DEFAULT_AUTO_ARCHIVE_KEEP_COUNT, DEFAULT_AUTO_ARCHIVE_MAX_IDLE_DAYS, FallbackReviewSettings,
+    TitleGenerationSettings,
+};
 
 /// Left inset so branding clears the native macOS 26 traffic lights near x=72.
 #[cfg(target_os = "macos")]
@@ -107,6 +112,10 @@ pub struct SettingsPage {
     /// Whether a Screen Recording grant looks pending-restart (a fresh grant
     /// only takes effect after tcode relaunches). Drives the restart banner.
     sr_restart_hint: bool,
+    /// One focus handle per toggle row, keyed by row id. The row owns keyboard
+    /// activation, so its capture-phase Space handler must be able to tell
+    /// "the row is focused" from "the inline reset button inside it is".
+    toggle_focus: HashMap<&'static str, FocusHandle>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -253,6 +262,7 @@ impl SettingsPage {
             auto_archive_keep_input: auto_archive_keep_input.clone(),
             perm_status,
             sr_restart_hint: false,
+            toggle_focus: HashMap::new(),
             _subscriptions: subscriptions,
         };
         page._subscriptions
@@ -321,8 +331,7 @@ impl SettingsPage {
         );
     }
 
-    /// (Re)build the provider cards from current settings — also used after
-    /// "Restore defaults", which invalidates the cards' cached settings.
+    /// (Re)build the provider cards from current settings.
     fn build_provider_cards(&mut self, cx: &mut Context<Self>) {
         let profiles = self.store.read(cx).all_provider_profiles();
         self.provider_cards = profiles
@@ -586,25 +595,16 @@ impl SettingsPage {
                 })
                 .items_center()
                 .gap_3()
-                // The title stretch carries no controls, so it doubles as the
-                // window's native drag handle where the platform needs one.
+                // The strip carries no controls at all (restoring defaults now
+                // lives at the foot of the General page), so the whole title
+                // doubles as the window's native drag handle.
                 .child(window_caption::drag_region(
                     div()
                         .flex_1()
                         .text_size(px(15.))
                         .font_medium()
                         .child(crate::tr!("settings.title")),
-                ))
-                .child(
-                    Button::new("restore-defaults")
-                        .outline()
-                        .small()
-                        .icon(IconName::Undo)
-                        .label(crate::tr!("settings.restore"))
-                        .on_click(cx.listener(|this, _, window, cx| {
-                            this.confirm_restore(window, cx);
-                        })),
-                ),
+                )),
         )
         // Painted last so the cluster stays on top of the strip.
         .children(hosts_caption.then(|| {
@@ -639,8 +639,9 @@ impl SettingsPage {
                     store.update(cx, |store, _cx| {
                         store.reset_settings();
                     });
-                    // The profile set may have changed; rebuild the rows.
-                    page.update(cx, |page, cx| page.build_provider_cards(cx));
+                    // Provider profiles and installed agents survive the reset,
+                    // so their cards need no rebuild — only the panels and
+                    // inputs holding a copy of a reset preference do.
                     page.update(cx, |page, cx| {
                         let store = page.store.clone();
                         page.orchestrate_panel =
@@ -656,10 +657,16 @@ impl SettingsPage {
                             .unwrap_or_default();
                         page.home_url_input
                             .update(cx, |input, cx| input.set_value(home_url, window, cx));
-                        page.auto_archive_idle_input
-                            .update(cx, |input, cx| input.set_value("7", window, cx));
-                        page.auto_archive_keep_input
-                            .update(cx, |input, cx| input.set_value("30", window, cx));
+                        page.auto_archive_idle_input.update(cx, |input, cx| {
+                            input.set_value(
+                                DEFAULT_AUTO_ARCHIVE_MAX_IDLE_DAYS.to_string(),
+                                window,
+                                cx,
+                            )
+                        });
+                        page.auto_archive_keep_input.update(cx, |input, cx| {
+                            input.set_value(DEFAULT_AUTO_ARCHIVE_KEEP_COUNT.to_string(), window, cx)
+                        });
                     });
                     apply_theme(ThemeMode::System, window, cx);
                     true
@@ -695,7 +702,7 @@ impl SettingsPage {
             .into_any_element()
     }
 
-    fn render_general(&self, cx: &mut Context<Self>) -> gpui::Div {
+    fn render_general(&mut self, cx: &mut Context<Self>) -> gpui::Div {
         let settings = self.store.read(cx).settings();
         // One mega-group on empty paper reads generic. Split the rows into three
         // semantic groups (System-Settings rhythm): 20-24px between groups, each
@@ -704,6 +711,36 @@ impl SettingsPage {
             self.language_row(settings.language.as_deref(), cx),
             self.theme_row(settings.theme_mode, cx),
         ];
+        let delete_confirm_reset = self.reset_action(
+            "reset-delete-confirm",
+            settings.skip_delete_confirmation,
+            cx,
+            |this, _, cx| {
+                this.dispatch_settings(|store| store.set_skip_delete_confirmation(false), cx)
+            },
+        );
+        let auto_open_task_panel_reset = self.reset_action(
+            "reset-auto-open-task-panel",
+            settings.auto_open_task_panel,
+            cx,
+            |this, _, cx| this.dispatch_settings(|store| store.set_auto_open_task_panel(false), cx),
+        );
+        let live_command_panel_reset = self.reset_action(
+            "reset-live-command-panel",
+            settings.live_command_panel_disabled,
+            cx,
+            |this, _, cx| {
+                this.dispatch_settings(|store| store.set_live_command_panel_disabled(false), cx)
+            },
+        );
+        let abort_on_fallback_reset = self.reset_action(
+            "reset-abort-on-model-fallback",
+            !settings.abort_on_model_fallback,
+            cx,
+            |this, _, cx| {
+                this.dispatch_settings(|store| store.set_abort_on_model_fallback(true), cx)
+            },
+        );
         let mut conversation = vec![
             self.title_generation_row(cx),
             self.toggle_row(
@@ -711,6 +748,7 @@ impl SettingsPage {
                 crate::tr!("settings.delete_confirmation.title"),
                 crate::tr!("settings.delete_confirmation.description"),
                 !settings.skip_delete_confirmation,
+                delete_confirm_reset,
                 cx,
                 |store, checked| store.set_skip_delete_confirmation(!checked),
             ),
@@ -719,6 +757,7 @@ impl SettingsPage {
                 crate::tr!("settings.auto_open_task_panel.title"),
                 crate::tr!("settings.auto_open_task_panel.description"),
                 settings.auto_open_task_panel,
+                auto_open_task_panel_reset,
                 cx,
                 WorkspaceStore::set_auto_open_task_panel,
             ),
@@ -727,6 +766,7 @@ impl SettingsPage {
                 crate::tr!("settings.live_command_panel.title"),
                 crate::tr!("settings.live_command_panel.description"),
                 !settings.live_command_panel_disabled,
+                live_command_panel_reset,
                 cx,
                 |store, checked| store.set_live_command_panel_disabled(!checked),
             ),
@@ -735,27 +775,63 @@ impl SettingsPage {
                 crate::tr!("settings.abort_on_model_fallback.title"),
                 crate::tr!("settings.abort_on_model_fallback.description"),
                 settings.abort_on_model_fallback,
+                abort_on_fallback_reset,
                 cx,
                 WorkspaceStore::set_abort_on_model_fallback,
             ),
         ];
         if settings.abort_on_model_fallback {
+            let advisor_reset = self.reset_action(
+                "reset-fallback-review-advisor",
+                settings.fallback_review_advisor,
+                cx,
+                |this, _, cx| {
+                    this.dispatch_settings(|store| store.set_fallback_review_advisor(false), cx)
+                },
+            );
             conversation.push(self.toggle_row(
                 "fallback-review-advisor",
                 crate::tr!("settings.fallback_review_advisor.title"),
                 crate::tr!("settings.fallback_review_advisor.description"),
                 settings.fallback_review_advisor,
+                advisor_reset,
                 cx,
                 WorkspaceStore::set_fallback_review_advisor,
             ));
             conversation.push(self.fallback_review_model_row(cx));
         }
+        let word_wrap_reset = self.reset_action(
+            "reset-word-wrap",
+            settings.word_wrap_diffs,
+            cx,
+            |this, _, cx| this.dispatch_settings(|store| store.set_word_wrap_diffs(false), cx),
+        );
+        let provider_updates_reset = self.reset_action(
+            "reset-provider-update-checks",
+            settings.provider_update_checks_disabled,
+            cx,
+            |this, _, cx| {
+                this.dispatch_settings(|store| store.set_provider_update_checks_disabled(false), cx)
+            },
+        );
+        let frame_throttle_reset = self.reset_action(
+            "reset-inactive-frame-throttle",
+            settings.inactive_frame_throttle_disabled,
+            cx,
+            |this, _, cx| {
+                this.dispatch_settings(
+                    |store| store.set_inactive_frame_throttle_disabled(false),
+                    cx,
+                )
+            },
+        );
         let workspace = vec![
             self.toggle_row(
                 "word-wrap",
                 crate::tr!("settings.word_wrap.title"),
                 crate::tr!("settings.word_wrap.description"),
                 settings.word_wrap_diffs,
+                word_wrap_reset,
                 cx,
                 WorkspaceStore::set_word_wrap_diffs,
             ),
@@ -765,6 +841,7 @@ impl SettingsPage {
                 crate::tr!("settings.provider_updates.description"),
                 // Stored inverted: checked = enabled.
                 !settings.provider_update_checks_disabled,
+                provider_updates_reset,
                 cx,
                 |store, checked| store.set_provider_update_checks_disabled(!checked),
             ),
@@ -774,6 +851,7 @@ impl SettingsPage {
                 crate::tr!("settings.inactive_frame_throttle.description"),
                 // Stored inverted: checked = enabled.
                 !settings.inactive_frame_throttle_disabled,
+                frame_throttle_reset,
                 cx,
                 |store, checked| store.set_inactive_frame_throttle_disabled(!checked),
             ),
@@ -795,13 +873,58 @@ impl SettingsPage {
                     .child(self.section_label(crate::tr!("settings.workspace_section"), cx))
                     .child(self.grouped_plain(workspace, cx)),
             )
+            .child(
+                v_flex()
+                    .child(self.section_label(crate::tr!("settings.reset_section"), cx))
+                    .child(self.grouped_plain(vec![self.restore_all_row(cx)], cx)),
+            )
+    }
+
+    /// The whole-app escape hatch, parked at the foot of General: the per-item
+    /// buttons cover single settings, this one covers the rest and keeps its
+    /// confirm dialog.
+    fn restore_all_row(&self, cx: &mut Context<Self>) -> AnyElement {
+        self.row_frame(cx)
+            .child(self.row_labels(
+                crate::tr!("settings.reset_all"),
+                crate::tr!("settings.restore_description"),
+                None,
+                cx,
+            ))
+            .child(
+                Button::new("restore-defaults")
+                    .danger()
+                    .outline()
+                    .small()
+                    .label(crate::tr!("settings.restore"))
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        this.confirm_restore(window, cx);
+                    })),
+            )
+            .into_any_element()
     }
 
     fn title_generation_row(&self, cx: &mut Context<Self>) -> AnyElement {
+        // Provider, model and profile are one setting to the user, so they
+        // reset together; the picker follows through the store observer.
+        let overridden =
+            self.store.read(cx).settings().title_generation != TitleGenerationSettings::default();
+        let reset = self.reset_action("reset-title-generation", overridden, cx, |this, _, cx| {
+            let default = TitleGenerationSettings::default();
+            this.dispatch_settings(
+                move |store| {
+                    store.set_title_generation_provider(default.provider);
+                    store.set_title_generation_model(default.model);
+                    store.set_title_generation_profile_id(default.profile_id);
+                },
+                cx,
+            );
+        });
         self.row_frame(cx)
             .child(self.row_labels(
                 crate::tr!("settings.title_generation.title"),
                 crate::tr!("settings.title_generation.description"),
+                reset,
                 cx,
             ))
             .child(self.title_model_picker.clone())
@@ -809,10 +932,29 @@ impl SettingsPage {
     }
 
     fn fallback_review_model_row(&self, cx: &mut Context<Self>) -> AnyElement {
+        let overridden =
+            self.store.read(cx).settings().fallback_review != FallbackReviewSettings::default();
+        let reset = self.reset_action(
+            "reset-fallback-review-model",
+            overridden,
+            cx,
+            |this, _, cx| {
+                let default = FallbackReviewSettings::default();
+                this.dispatch_settings(
+                    move |store| {
+                        store.set_fallback_review_provider(default.provider);
+                        store.set_fallback_review_model(default.model);
+                        store.set_fallback_review_profile_id(default.profile_id);
+                    },
+                    cx,
+                );
+            },
+        );
         self.row_frame(cx)
             .child(self.row_labels(
                 crate::tr!("settings.fallback_review_model.title"),
                 crate::tr!("settings.fallback_review_model.description"),
+                reset,
                 cx,
             ))
             .child(self.fallback_review_model_picker.clone())
@@ -962,54 +1104,93 @@ impl SettingsPage {
 
     /// Archived Threads: archived sessions grouped by project, each with
     /// Unarchive + Delete-permanently controls (Group A).
-    fn render_archived(&self, cx: &mut Context<Self>) -> gpui::Div {
+    fn render_archived(&mut self, cx: &mut Context<Self>) -> gpui::Div {
         let groups = self.store.read(cx).archived_groups();
         let settings = self.store.read(cx).settings();
         let days = settings.auto_archive_max_idle_days.max(1);
         let keep = settings.auto_archive_keep_count.max(1);
+        let auto_archive_reset = self.reset_action(
+            "reset-auto-archive",
+            settings.auto_archive_disabled,
+            cx,
+            |this, _, cx| {
+                this.dispatch_settings(|store| store.set_auto_archive_disabled(false), cx)
+            },
+        );
+        let idle_days_reset = self.reset_action(
+            "reset-auto-archive-idle-days",
+            settings.auto_archive_max_idle_days != DEFAULT_AUTO_ARCHIVE_MAX_IDLE_DAYS,
+            cx,
+            |this, window, cx| {
+                this.dispatch_settings(
+                    |store| {
+                        store.set_auto_archive_max_idle_days(DEFAULT_AUTO_ARCHIVE_MAX_IDLE_DAYS)
+                    },
+                    cx,
+                );
+                this.auto_archive_idle_input.update(cx, |input, cx| {
+                    input.set_value(DEFAULT_AUTO_ARCHIVE_MAX_IDLE_DAYS.to_string(), window, cx)
+                });
+            },
+        );
+        let keep_count_reset = self.reset_action(
+            "reset-auto-archive-keep-count",
+            settings.auto_archive_keep_count != DEFAULT_AUTO_ARCHIVE_KEEP_COUNT,
+            cx,
+            |this, window, cx| {
+                this.dispatch_settings(
+                    |store| store.set_auto_archive_keep_count(DEFAULT_AUTO_ARCHIVE_KEEP_COUNT),
+                    cx,
+                );
+                this.auto_archive_keep_input.update(cx, |input, cx| {
+                    input.set_value(DEFAULT_AUTO_ARCHIVE_KEEP_COUNT.to_string(), window, cx)
+                });
+            },
+        );
+        let rows = vec![
+            self.toggle_row(
+                "auto-archive",
+                crate::tr!("settings.auto_archive.title"),
+                crate::tr!(
+                    "settings.auto_archive.description",
+                    days = days,
+                    keep = keep
+                ),
+                !settings.auto_archive_disabled,
+                auto_archive_reset,
+                cx,
+                |store, checked| store.set_auto_archive_disabled(!checked),
+            ),
+            self.row_frame(cx)
+                .child(self.row_labels(
+                    crate::tr!("settings.auto_archive.idle_days"),
+                    crate::tr!("settings.auto_archive.idle_days_description"),
+                    idle_days_reset,
+                    cx,
+                ))
+                .child(
+                    Input::new(&self.auto_archive_idle_input)
+                        .w(px(72.))
+                        .rounded(crate::material::radius_input()),
+                )
+                .into_any_element(),
+            self.row_frame(cx)
+                .child(self.row_labels(
+                    crate::tr!("settings.auto_archive.keep_count"),
+                    crate::tr!("settings.auto_archive.keep_count_description"),
+                    keep_count_reset,
+                    cx,
+                ))
+                .child(
+                    Input::new(&self.auto_archive_keep_input)
+                        .w(px(72.))
+                        .rounded(crate::material::radius_input()),
+                )
+                .into_any_element(),
+        ];
         let controls = v_flex()
             .child(self.section_label(crate::tr!("settings.auto_archive.section"), cx))
-            .child(self.grouped_plain(
-                vec![
-                    self.toggle_row(
-                        "auto-archive",
-                        crate::tr!("settings.auto_archive.title"),
-                        crate::tr!(
-                            "settings.auto_archive.description",
-                            days = days,
-                            keep = keep
-                        ),
-                        !settings.auto_archive_disabled,
-                        cx,
-                        |store, checked| store.set_auto_archive_disabled(!checked),
-                    ),
-                    self.row_frame(cx)
-                        .child(self.row_labels(
-                            crate::tr!("settings.auto_archive.idle_days"),
-                            crate::tr!("settings.auto_archive.idle_days_description"),
-                            cx,
-                        ))
-                        .child(
-                            Input::new(&self.auto_archive_idle_input)
-                                .w(px(72.))
-                                .rounded(crate::material::radius_input()),
-                        )
-                        .into_any_element(),
-                    self.row_frame(cx)
-                        .child(self.row_labels(
-                            crate::tr!("settings.auto_archive.keep_count"),
-                            crate::tr!("settings.auto_archive.keep_count_description"),
-                            cx,
-                        ))
-                        .child(
-                            Input::new(&self.auto_archive_keep_input)
-                                .w(px(72.))
-                                .rounded(crate::material::radius_input()),
-                        )
-                        .into_any_element(),
-                ],
-                cx,
-            ));
+            .child(self.grouped_plain(rows, cx));
 
         if groups.is_empty() {
             return v_flex()
@@ -1060,7 +1241,7 @@ impl SettingsPage {
                 let title = meta.title.clone();
                 rows.push(
                     self.row_frame(cx)
-                        .child(self.row_labels(meta.title.clone(), desc, cx))
+                        .child(self.row_labels(meta.title.clone(), desc, None, cx))
                         .child(
                             gpui_base::h_flex()
                                 .flex_none()
@@ -1137,14 +1318,29 @@ impl SettingsPage {
 
     // -- Computer Use & Browser pages --------------------------------------
 
-    fn render_computer_use(&self, cx: &mut Context<Self>) -> gpui::Div {
+    fn render_computer_use(&mut self, cx: &mut Context<Self>) -> gpui::Div {
         let settings = self.store.read(cx).settings();
+        let enabled_reset = self.reset_action(
+            "reset-cu-enabled",
+            settings.computer_use.enabled,
+            cx,
+            |this, _, cx| this.dispatch_settings(|store| store.set_computer_use_enabled(false), cx),
+        );
+        let allow_input_reset = self.reset_action(
+            "reset-cu-allow-input",
+            !settings.computer_use.allow_input,
+            cx,
+            |this, _, cx| {
+                this.dispatch_settings(|store| store.set_computer_use_allow_input(true), cx)
+            },
+        );
         let rows = vec![
             self.toggle_row(
                 "cu-enabled",
                 crate::tr!("computer_use.enable.title"),
                 crate::tr!("computer_use.enable.description"),
                 settings.computer_use.enabled,
+                enabled_reset,
                 cx,
                 WorkspaceStore::set_computer_use_enabled,
             ),
@@ -1154,6 +1350,7 @@ impl SettingsPage {
                 crate::tr!("computer_use.allow_input.title"),
                 crate::tr!("computer_use.allow_input.description"),
                 settings.computer_use.allow_input,
+                allow_input_reset,
                 cx,
                 WorkspaceStore::set_computer_use_allow_input,
             ),
@@ -1174,14 +1371,29 @@ impl SettingsPage {
             ))
     }
 
-    fn render_browser(&self, cx: &mut Context<Self>) -> gpui::Div {
+    fn render_browser(&mut self, cx: &mut Context<Self>) -> gpui::Div {
         let settings = self.store.read(cx).settings();
+        let enabled_reset = self.reset_action(
+            "reset-browser-enabled",
+            !settings.browser.enabled,
+            cx,
+            |this, _, cx| this.dispatch_settings(|store| store.set_browser_enabled(true), cx),
+        );
+        let allow_eval_reset = self.reset_action(
+            "reset-browser-allow-eval",
+            !settings.browser.allow_evaluate,
+            cx,
+            |this, _, cx| {
+                this.dispatch_settings(|store| store.set_browser_allow_evaluate(true), cx)
+            },
+        );
         let rows = vec![
             self.toggle_row(
                 "browser-enabled",
                 crate::tr!("browser.enable.title"),
                 crate::tr!("browser.enable.description"),
                 settings.browser.enabled,
+                enabled_reset,
                 cx,
                 WorkspaceStore::set_browser_enabled,
             ),
@@ -1191,6 +1403,7 @@ impl SettingsPage {
                 crate::tr!("browser.allow_evaluate.title"),
                 crate::tr!("browser.allow_evaluate.description"),
                 settings.browser.allow_evaluate,
+                allow_eval_reset,
                 cx,
                 WorkspaceStore::set_browser_allow_evaluate,
             ),
@@ -1203,10 +1416,22 @@ impl SettingsPage {
     }
 
     fn home_url_row(&self, cx: &mut Context<Self>) -> AnyElement {
+        let overridden = self.store.read(cx).settings().browser.home_url.is_some();
+        let reset = self.reset_action(
+            "reset-browser-home-url",
+            overridden,
+            cx,
+            |this, window, cx| {
+                this.dispatch_settings(|store| store.set_browser_home_url(None), cx);
+                this.home_url_input
+                    .update(cx, |input, cx| input.set_value("", window, cx));
+            },
+        );
         self.row_frame(cx)
             .child(self.row_labels(
                 crate::tr!("browser.home_url.title"),
                 crate::tr!("browser.home_url.description"),
+                reset,
                 cx,
             ))
             .child(
@@ -1220,6 +1445,17 @@ impl SettingsPage {
     }
 
     fn image_mode_row(&self, mode: ImageMode, cx: &mut Context<Self>) -> AnyElement {
+        let reset = self.reset_action(
+            "reset-cu-image-mode",
+            mode != ImageMode::Auto,
+            cx,
+            |this, _, cx| {
+                this.dispatch_settings(
+                    |store| store.set_computer_use_image_mode(ImageMode::Auto),
+                    cx,
+                );
+            },
+        );
         let label = match mode {
             ImageMode::Auto => crate::tr!("computer_use.image_mode.auto"),
             ImageMode::Always => crate::tr!("computer_use.image_mode.always"),
@@ -1261,6 +1497,7 @@ impl SettingsPage {
                     "computer_use.image_mode.never_desc",
                 ),
             ],
+            reset,
             |mode, page, _, cx| {
                 page.update(cx, |page, cx| {
                     page.dispatch_settings(|store| store.set_computer_use_image_mode(mode), cx)
@@ -1348,8 +1585,9 @@ impl SettingsPage {
                         })),
                 );
         }
+        // No reset affordance: the grant lives in the OS, not in settings.json.
         self.row_frame(cx)
-            .child(self.row_labels(crate::tr!(name_key), crate::tr!(why_key), cx))
+            .child(self.row_labels(crate::tr!(name_key), crate::tr!(why_key), None, cx))
             .child(controls)
             .into_any_element()
     }
@@ -1468,24 +1706,65 @@ impl SettingsPage {
         group
     }
 
-    /// Left description block (bold title + muted description).
+    /// Left description block (bold title + muted description). `reset` is the
+    /// per-item "restore default" affordance and rides inline right after the
+    /// title, so it reads as belonging to that setting rather than to the row's
+    /// control on the far right.
     fn row_labels(
         &self,
         title: impl Into<SharedString>,
         desc: impl Into<SharedString>,
+        reset: Option<AnyElement>,
         cx: &Context<Self>,
     ) -> gpui::Div {
         v_flex()
             .flex_1()
             .min_w_0()
             .gap_0p5()
-            .child(div().text_size(px(15.)).font_medium().child(title.into()))
+            .child(
+                gpui_base::h_flex()
+                    .items_center()
+                    .gap_1()
+                    .child(div().text_size(px(15.)).font_medium().child(title.into()))
+                    .children(reset),
+            )
             .child(
                 div()
                     .text_size(px(13.))
                     .text_color(cx.theme().muted_foreground)
                     .child(desc.into()),
             )
+    }
+
+    /// The per-item "restore default" button: icon-only, ghost, and rendered
+    /// only while `overridden` — a row showing its factory value has nothing to
+    /// restore, so the affordance would just be noise.
+    fn reset_action(
+        &self,
+        id: &'static str,
+        overridden: bool,
+        cx: &mut Context<Self>,
+        on_reset: impl Fn(&mut Self, &mut Window, &mut Context<Self>) + 'static,
+    ) -> Option<AnyElement> {
+        if !overridden {
+            return None;
+        }
+        let label = crate::tr!("settings.reset_item").into_owned();
+        Some(
+            Button::new(id)
+                .ghost()
+                .xsmall()
+                .icon(IconName::Undo)
+                .tooltip(label.clone())
+                .aria_label(label)
+                .on_click(cx.listener(move |this, _, window, cx| {
+                    // Toggle rows are clickable as a whole; a click that lands
+                    // on this button must not also flip the switch.
+                    cx.stop_propagation();
+                    on_reset(this, window, cx);
+                }))
+                .into_any_element(),
+        )
     }
 
     /// A single group row: transparent, ~44px min height, label left / control
@@ -1502,17 +1781,28 @@ impl SettingsPage {
             .items_center()
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn toggle_row(
-        &self,
+        &mut self,
         id: &'static str,
         title: impl Into<SharedString>,
         desc: impl Into<SharedString>,
         checked: bool,
+        reset: Option<AnyElement>,
         cx: &mut Context<Self>,
         intent: fn(&mut WorkspaceStore, bool),
     ) -> AnyElement {
         let title = title.into();
         let desc = desc.into();
+        // The row is the tab stop, but the inline reset button is one too, so
+        // the row owns an explicit handle (`accessible_clickable`'s implicit one
+        // cannot be queried) and applies the tab order to it by hand.
+        let focus = self
+            .toggle_focus
+            .entry(id)
+            .or_insert_with(|| cx.focus_handle().tab_stop(true).tab_index(0))
+            .clone();
+        let row_focus = focus.clone();
         crate::material::accessible_clickable(
             self.row_frame(cx),
             SharedString::from(format!("{id}-row")),
@@ -1520,6 +1810,7 @@ impl SettingsPage {
             title.clone(),
             cx,
         )
+        .track_focus(&focus)
         .aria_toggled(if checked {
             Toggled::True
         } else {
@@ -1531,6 +1822,11 @@ impl SettingsPage {
         // Enter continues to use GPUI's standard focused-click behavior.
         .capture_key_down(
             cx.listener(move |this, event: &gpui::KeyDownEvent, window, cx| {
+                // Capture runs from the root down, so without this guard the row
+                // would swallow Space aimed at the reset button inside it.
+                if !row_focus.is_focused(window) {
+                    return;
+                }
                 if event.keystroke.key == "space"
                     && !event.is_held
                     && !event.keystroke.modifiers.modified()
@@ -1544,7 +1840,7 @@ impl SettingsPage {
         .on_click(cx.listener(move |this, _, _, cx| {
             this.dispatch_settings(|store| intent(store, !checked), cx);
         }))
-        .child(self.row_labels(title, desc, cx))
+        .child(self.row_labels(title, desc, reset, cx))
         // The Switch is intentionally visual here; the semantic row above
         // owns click, focus, keyboard activation, and the toggled state.
         .child(Switch::new(id).checked(checked))
@@ -1587,6 +1883,7 @@ impl SettingsPage {
         description: SharedString,
         selected_label: SharedString,
         options: Vec<SelectRowOption<T>>,
+        reset: Option<AnyElement>,
         on_select: impl Fn(T, &Entity<SettingsPage>, &mut Window, &mut App) + 'static,
         cx: &mut Context<Self>,
     ) -> AnyElement {
@@ -1653,12 +1950,21 @@ impl SettingsPage {
             });
 
         self.row_frame(cx)
-            .child(self.row_labels(title, description, cx))
+            .child(self.row_labels(title, description, reset, cx))
             .child(dropdown)
             .into_any_element()
     }
 
     fn theme_row(&self, mode: ThemeMode, cx: &mut Context<Self>) -> AnyElement {
+        let reset = self.reset_action(
+            "reset-theme",
+            mode != ThemeMode::System,
+            cx,
+            |this, window, cx| {
+                this.dispatch_settings(|store| store.set_theme_mode(ThemeMode::System), cx);
+                apply_theme(ThemeMode::System, window, cx);
+            },
+        );
         let label = match mode {
             ThemeMode::System => crate::tr!("settings.theme.system"),
             ThemeMode::Light => crate::tr!("settings.theme.light"),
@@ -1692,6 +1998,7 @@ impl SettingsPage {
                 ),
                 option(ThemeMode::Dark, "theme-option-dark", "settings.theme.dark"),
             ],
+            reset,
             |mode, page, window, cx| {
                 page.update(cx, |page, cx| {
                     page.dispatch_settings(|store| store.set_theme_mode(mode), cx)
@@ -1704,6 +2011,9 @@ impl SettingsPage {
 
     fn language_row(&self, language: Option<&str>, cx: &mut Context<Self>) -> AnyElement {
         let selected = language.map(str::to_owned);
+        let reset = self.reset_action("reset-language", language.is_some(), cx, |this, _, cx| {
+            this.dispatch_settings(|store| store.set_language(None), cx);
+        });
         let label = match language {
             Some(LANGUAGE_ENGLISH) => crate::tr!("settings.language.english"),
             Some(LANGUAGE_SIMPLIFIED_CHINESE) => crate::tr!("settings.language.chinese"),
@@ -1734,6 +2044,7 @@ impl SettingsPage {
                     "settings.language.chinese",
                 ),
             ],
+            reset,
             |language, page, _, cx| {
                 page.update(cx, |page, cx| {
                     page.dispatch_settings(

--- a/crates/ui/src/widgets/button.rs
+++ b/crates/ui/src/widgets/button.rs
@@ -73,6 +73,9 @@ pub struct Button {
     loading: bool,
     size: Size,
     tooltip: Option<SharedString>,
+    /// Accessible name for icon-only buttons, which have no visible label to
+    /// derive one from.
+    aria_label: Option<SharedString>,
     on_click: Option<ClickHandler>,
     on_hover: Option<super::ToggleHandler>,
 }
@@ -95,6 +98,7 @@ impl Button {
             loading: false,
             size: Size::Medium,
             tooltip: None,
+            aria_label: None,
             on_click: None,
             on_hover: None,
         }
@@ -117,6 +121,12 @@ impl Button {
     }
     pub fn tooltip(mut self, tooltip: impl Into<SharedString>) -> Self {
         self.tooltip = Some(tooltip.into());
+        self
+    }
+    /// Name an icon-only button for assistive technology. Buttons with a
+    /// visible label already announce it and need no override.
+    pub fn aria_label(mut self, label: impl Into<SharedString>) -> Self {
+        self.aria_label = Some(label.into());
         self
     }
     pub fn compact(mut self) -> Self {
@@ -252,7 +262,7 @@ impl RenderOnce for Button {
             Size::Size(v) => Size::Size(v * 0.75),
             size => size,
         };
-        let accessibility_label = self.label.clone();
+        let accessibility_label = self.aria_label.clone().or_else(|| self.label.clone());
         let content = gpui_base::h_flex()
             .size_full()
             .items_center()

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -193,7 +193,9 @@ settings:
   back: "Back"
   restore: "Restore defaults"
   restore_title: "Restore default settings?"
-  restore_description: "Reset language, theme, thread-title model, diff, provider, and orchestrate settings to their defaults. Your projects and conversations will not be changed."
+  restore_description: "Reset language, theme, thread-title model, diff, and orchestrate settings to their defaults. Your provider configuration, installed agents, projects, and conversations are kept."
+  reset_item: "Restore default"
+  reset_all: "Restore all defaults"
   cancel: "Cancel"
   save: "Save"
   general_section: "GENERAL"
@@ -202,6 +204,7 @@ settings:
   workspace_section: "WORKSPACE"
   providers_section: "PROVIDERS"
   orchestrate_section: "ORCHESTRATE"
+  reset_section: "RESET"
   language:
     title: "Language"
     description: "Choose the language used across tcode."
@@ -295,7 +298,6 @@ permissions:
     name: "Screen Recording"
     why: "Capture window screenshots for computer-use observations."
 orchestrate:
-  restore_default: "Restore default"
   child_approval:
     title: "Child approvals"
     description: "Who answers when a dispatched child thread hits a permission gate. Decision-layer routes the request to the lead model, which answers with the approve tool; Always allow auto-approves for the session; Manual waits for you to answer in the child thread."

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -193,7 +193,9 @@ settings:
   back: "返回"
   restore: "恢复默认设置"
   restore_title: "恢复默认设置？"
-  restore_description: "将语言、主题、对话命名模型、diff、提供商和 Orchestrate 设置恢复为默认值。项目和对话不会受到影响。"
+  restore_description: "将语言、主题、对话命名模型、diff 和 Orchestrate 设置恢复为默认值。提供商配置、已安装的智能体、项目和对话都会保留。"
+  reset_item: "恢复默认"
+  reset_all: "恢复全部默认设置"
   cancel: "取消"
   save: "保存"
   general_section: "通用"
@@ -202,6 +204,7 @@ settings:
   workspace_section: "工作区"
   providers_section: "提供商"
   orchestrate_section: "ORCHESTRATE"
+  reset_section: "重置"
   language:
     title: "语言"
     description: "选择 tcode 的界面语言。"
@@ -295,7 +298,6 @@ permissions:
     name: "屏幕录制"
     why: "为计算机使用观察结果截取窗口截图。"
 orchestrate:
-  restore_default: "恢复默认"
   child_approval:
     title: "子线程审批"
     description: "派发的子线程遇到权限门槛时由谁来审批。决策层审批会将请求转交主线程模型,由其通过 approve 工具决定;永久允许会在会话内自动批准;手动审批则等待你在子线程中亲自处理。"


### PR DESCRIPTION
## What

- **Per-item reset**: every settings row (General, Browser, Computer Use, Archived auto-archive, Orchestrate) carries an icon-only Undo button right after its title, rendered only while the stored value differs from its factory default. Clicking resets just that item — no confirm dialog. Tooltip + aria label included.
- **Global reset relocated & narrowed**: the header "Restore defaults" button moves to a Reset group at the foot of General (confirm dialog kept). Its scope narrows to preferences: provider profiles and credentials, legacy binary overrides, installed ACP agents, sidebar/UI state, and unknown forward-compat keys all survive. Dialog copy updated in both locales.
- **Orchestrate**: the three labelled restore buttons collapse into the same inline pattern. Fleet rows restore effort and definition together from the bundled entry they map to (case-insensitive effort matching; ambiguous multi-tier models claim the first tier no sibling row occupies). User-added models / custom provider profiles have no bundled default and show no button.

## Details

- Composite rows (thread-title model, fallback-review model) reset provider/model/profile together; theme reset re-applies to the window; text-input rows sync their InputState.
- Stored-inverted toggles compare stored fields, not displayed state.
- Toggle rows are fully clickable and capture Space, so each row now owns an explicit `FocusHandle` and only handles Space while itself focused; the inline button stops click propagation.
- `ui::Button` gains a 4-line `aria_label` setter so icon-only buttons have an accessible name.
- Dead `orchestrate.restore_default` locale key removed; new keys `settings.reset_item` / `reset_all` / `reset_section` added to en + zh-CN.
- Rebased over #290: the fleet effort dropdown reads straight from settings, so reset only writes the store and syncs the description textarea.

## Tests

- New: `reset_settings_clears_preferences_but_keeps_credentials_installs_and_unknown_keys` (runtime).
- `cargo check --workspace`, `cargo test -p tcode-core -p tcode-runtime -p tcode-ui` (120/125/284 pass), clippy clean, fmt clean.
- Not covered by automation: pointer/keyboard interplay of the inline button inside clickable toggle rows (no UI harness for this page) — worth one manual click-through.