### PR TITLE
feat(chat): keep recent live activities visible

### DIFF
--- a/crates/ui/src/chat/components/work_log.rs
+++ b/crates/ui/src/chat/components/work_log.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
 
 use crate::icon::{Icon, IconName};
+use crate::sizing::Sizable as _;
 use crate::theme::ActiveTheme as _;
+use crate::widgets::spinner::Spinner;
 use agent::TurnStatus;
 use gpui::{
     AnyElement, App, ClickEvent, InteractiveElement as _, IntoElement as _, ParentElement as _,
@@ -72,6 +74,9 @@ pub(crate) fn work_log(
     .on_click(on_toggle)
     .child(Icon::new(chevron(expanded)).size(px(12.)).text_color(muted))
     .child(capsule_label)
+    .when(running, |row| {
+        row.child(Spinner::new().xsmall().color(cx.theme().primary))
+    })
     .when(!running, |row| {
         // A settled run needs no badge; only a bad ending is called out.
         let failure = match outcome {

--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -48,11 +48,10 @@ use self::components::assistant::MdState;
 use self::components::command_panel::CommandPanelCache;
 use self::model::{
     ListSync, Segment, TurnIndexCache, TurnListItem, TurnRenderArgs, activity_run_duration_ms,
-    auto_expanded, displayed_error_text, divergent_served_model, format_span, latest_message_ids,
-    live_activity_segment, live_edit_rows, manual_override_key, plain_text_as_markdown,
+    displayed_error_text, divergent_served_model, format_span, latest_message_ids,
+    live_activity_segment, live_edit_rows, partition_activity_run, plain_text_as_markdown,
     segment_entries, start_hub_projects, timeline_overdraw, user_content, user_visible_text,
-    work_log_auto_expands, work_log_capsule_label, work_log_counts, work_log_outcome,
-    work_log_row_entries,
+    work_log_capsule_label, work_log_counts, work_log_outcome,
 };
 use self::residency::{
     MarkdownEntry, ResidencyInput, ResidencyScope, decide, tail_turn_window, viewport_turn_window,
@@ -615,33 +614,6 @@ impl ChatView {
         cx.notify();
     }
 
-    fn toggle_auto_expanded(
-        &mut self,
-        turn: usize,
-        key: &str,
-        automatic: bool,
-        cx: &mut Context<Self>,
-    ) {
-        let was_expanded = auto_expanded(&self.expanded, key, automatic);
-        self.expanded.insert(manual_override_key(key));
-        if was_expanded {
-            self.expanded.remove(key);
-        } else {
-            self.expanded.insert(key.to_string());
-        }
-        self.sync_markdown_states(cx);
-        self.list_state.remeasure_items(turn..turn + 1);
-        cx.notify();
-    }
-
-    fn promote_auto_expanded(&mut self, turn: usize, key: &str, cx: &mut Context<Self>) {
-        self.expanded.insert(manual_override_key(key));
-        self.expanded.insert(key.to_string());
-        self.sync_markdown_states(cx);
-        self.list_state.remeasure_items(turn..turn + 1);
-        cx.notify();
-    }
-
     // -- turn rendering -----------------------------------------------------
 
     /// Render one turn as chronological messages, errors, and Work Log runs.
@@ -1055,69 +1027,95 @@ impl ChatView {
         let (index, segment_id, turn, cwd, activities, is_last) = args;
         let section_key = format!("worklog-{index}-{segment_id}");
         let running = is_last && turn.running;
-        let automatic = work_log_auto_expands(activities, turn.running, is_last);
-        let expanded = auto_expanded(&self.expanded, &section_key, automatic);
-        let manually_expanded =
-            expanded && (self.expanded.contains(&manual_override_key(&section_key)) || !automatic);
-        let segment_counts = work_log_counts(activities);
-        let mut capsule_label = work_log_capsule_label(&segment_counts, activities.len());
-        if capsule_label.is_empty() {
-            capsule_label = crate::tr!("chat.work_log").into_owned();
+        let (folded, visible) = partition_activity_run(activities, running);
+        let expanded = self.expanded.contains(&section_key);
+        let live_reasoning_id = running
+            .then(|| activities.last().copied())
+            .flatten()
+            .filter(|entry| {
+                matches!(
+                    entry.content,
+                    EntryContent::Item(ItemContent::Reasoning { .. })
+                )
+            })
+            .map(|entry| entry.id.as_str());
+
+        let mut flow = v_flex().w_full().gap_1();
+        if !folded.is_empty() {
+            let segment_counts = work_log_counts(folded);
+            let mut capsule_label = work_log_capsule_label(&segment_counts, folded.len());
+            if capsule_label.is_empty() {
+                capsule_label = crate::tr!("chat.work_log").into_owned();
+            }
+            let duration =
+                format_span((activity_run_duration_ms(folded, turn, is_last) + 500) / 1000);
+            let outcome = work_log_outcome(turn, folded, is_last);
+            let rows = if expanded {
+                self.compose_work_log_rows(folded, cwd, live_reasoning_id, cx)
+            } else {
+                Vec::new()
+            };
+
+            let toggle_section_key = section_key;
+            flow = flow.child(components::work_log::work_log(
+                components::work_log::WorkLogData {
+                    index,
+                    segment_id: segment_id.to_string(),
+                    capsule_label,
+                    duration,
+                    outcome,
+                    expanded,
+                    running,
+                    rows,
+                },
+                cx.listener(move |this, _, _, cx| {
+                    this.toggle_expanded(index, &toggle_section_key, cx);
+                }),
+                cx,
+            ));
         }
-        let duration =
-            format_span((activity_run_duration_ms(activities, turn, is_last) + 500) / 1000);
-        let outcome = work_log_outcome(turn, activities, is_last);
 
+        if !visible.is_empty() {
+            flow = flow.child(
+                v_flex()
+                    .w_full()
+                    .gap_1()
+                    .children(self.compose_work_log_rows(visible, cwd, live_reasoning_id, cx)),
+            );
+        }
+
+        flow.into_any_element()
+    }
+
+    fn compose_work_log_rows(
+        &mut self,
+        activities: &[&TimelineEntry],
+        cwd: &Path,
+        live_reasoning_id: Option<&str>,
+        cx: &mut Context<Self>,
+    ) -> Vec<AnyElement> {
         let mut rows = Vec::new();
-        if expanded {
-            let visible = work_log_row_entries(activities, !manually_expanded);
-
-            for entry in &visible {
-                if let EntryContent::Item(ItemContent::FileChange { changes, .. }) = &entry.content
-                {
-                    for row in live_edit_rows(changes, cwd) {
-                        rows.push(
-                            components::changed_files::file_edit_row(
-                                &row,
-                                &components::changed_files::FileEditRowStyle::from_theme(cx),
-                            )
-                            .into_any_element(),
-                        );
-                    }
-                } else {
-                    let live_reasoning = running
-                        && activities.last().is_some_and(|last| last.id == entry.id)
-                        && matches!(
-                            entry.content,
-                            EntryContent::Item(ItemContent::Reasoning { .. })
-                        );
-                    rows.push(self.compose_activity_row(entry, false, live_reasoning, cx));
+        for entry in activities {
+            if let EntryContent::Item(ItemContent::FileChange { changes, .. }) = &entry.content {
+                for row in live_edit_rows(changes, cwd) {
+                    rows.push(
+                        components::changed_files::file_edit_row(
+                            &row,
+                            &components::changed_files::FileEditRowStyle::from_theme(cx),
+                        )
+                        .into_any_element(),
+                    );
                 }
+            } else {
+                rows.push(self.compose_activity_row(
+                    entry,
+                    false,
+                    live_reasoning_id == Some(entry.id.as_str()),
+                    cx,
+                ));
             }
         }
-
-        let toggle_section_key = section_key;
-        let ticker_expanded = expanded && !manually_expanded;
-        components::work_log::work_log(
-            components::work_log::WorkLogData {
-                index,
-                segment_id: segment_id.to_string(),
-                capsule_label,
-                duration,
-                outcome,
-                expanded,
-                running,
-                rows,
-            },
-            cx.listener(move |this, _, _, cx| {
-                if ticker_expanded {
-                    this.promote_auto_expanded(index, &toggle_section_key, cx);
-                } else {
-                    this.toggle_auto_expanded(index, &toggle_section_key, automatic, cx);
-                }
-            }),
-            cx,
-        )
+        rows
     }
 
     /// Prepare one stateless Work Log activity component.

--- a/crates/ui/src/chat/model.rs
+++ b/crates/ui/src/chat/model.rs
@@ -280,18 +280,6 @@ pub(crate) fn work_log_outcome(
     }
 }
 
-pub(crate) fn manual_override_key(key: &str) -> String {
-    format!("manual-{key}")
-}
-
-pub(crate) fn auto_expanded(expanded: &HashSet<String>, key: &str, automatic: bool) -> bool {
-    if expanded.contains(&manual_override_key(key)) {
-        expanded.contains(key)
-    } else {
-        automatic
-    }
-}
-
 /// `text` collapsed to a single spaced line: every whitespace run (newlines
 /// included) becomes one space, so a multi-line command shows its full content
 /// in a one-line preview instead of just its first line. Clipped to more
@@ -558,33 +546,21 @@ pub(crate) fn live_edit_rows(changes: &[FileChange], cwd: &Path) -> Vec<LiveEdit
         .collect()
 }
 
-/// Whether a Work Log segment opens on its own, before any user toggle.
-///
-/// Only the final segment of a running turn is live. As soon as later prose
-/// starts, an earlier segment settles and folds; file evidence remains visible
-/// in the separate changed-file chip row. Manual overrides still win via
-/// [`auto_expanded`].
-pub(crate) fn work_log_auto_expands(
-    _activities: &[&TimelineEntry],
-    turn_running: bool,
-    is_last: bool,
-) -> bool {
-    turn_running && is_last
-}
+/// Maximum number of entries kept directly visible at the tail of a live
+/// activity run. Older entries move into a separate collapsed Work Log; once
+/// prose ends the run, the full run becomes that settled Work Log instead.
+pub(crate) const LIVE_ACTIVITY_WINDOW: usize = 5;
 
-/// The activity entries a Work Log segment renders as rows.
-///
-/// An automatically expanded live run is a two-row ticker. Manual expansion
-/// returns every activity in the segment, including file changes.
-pub(crate) fn work_log_row_entries<'a>(
-    activities: &[&'a TimelineEntry],
-    automatic_expansion: bool,
-) -> Vec<&'a TimelineEntry> {
-    if automatic_expansion {
-        activities[activities.len().saturating_sub(2)..].to_vec()
+pub(crate) fn partition_activity_run<'a>(
+    activities: &'a [&'a TimelineEntry],
+    live: bool,
+) -> (&'a [&'a TimelineEntry], &'a [&'a TimelineEntry]) {
+    let visible = if live {
+        activities.len().min(LIVE_ACTIVITY_WINDOW)
     } else {
-        activities.to_vec()
-    }
+        0
+    };
+    activities.split_at(activities.len() - visible)
 }
 
 /// Format a unix-ms timestamp as a local 12-hour clock, e.g. "2:39 AM".
@@ -1873,30 +1849,44 @@ mod tests {
     }
 
     #[test]
-    fn work_log_rows_use_a_ticker_only_for_automatic_expansion() {
+    fn live_activity_run_keeps_five_entries_outside_the_folded_prefix() {
         let entries = [
             command("cargo check"),
             file_change("edit", &["src/foo.rs"]),
             command("cargo test"),
             command("cargo clippy"),
+            command("cargo fmt"),
+            command("cargo nextest"),
         ];
         let activities = refs(&entries);
-        let ids = |rows: Vec<&TimelineEntry>| {
+        let ids = |rows: &[&TimelineEntry]| {
             rows.iter()
                 .map(|entry| entry.id.clone())
                 .collect::<Vec<String>>()
         };
 
+        let (folded, visible) = partition_activity_run(&activities, true);
+        assert_eq!(ids(folded), ["cargo check"]);
         assert_eq!(
-            ids(work_log_row_entries(&activities, true)),
-            ["cargo test", "cargo clippy"]
+            ids(visible),
+            [
+                "edit",
+                "cargo test",
+                "cargo clippy",
+                "cargo fmt",
+                "cargo nextest"
+            ]
         );
-        assert_eq!(
-            ids(work_log_row_entries(&activities, false)),
-            ["cargo check", "edit", "cargo test", "cargo clippy"]
-        );
-        // Row selection never touches the summary counts.
-        assert_eq!(work_log_counts(&activities).files, 1);
+
+        let (folded, visible) = partition_activity_run(&activities[..5], true);
+        assert!(folded.is_empty());
+        assert_eq!(ids(visible), ids(&activities[..5]));
+
+        // Assistant prose settles the run: the same six entries are now all
+        // represented by one collapsed Work Log and none remain loose.
+        let (folded, visible) = partition_activity_run(&activities, false);
+        assert_eq!(ids(folded), ids(&activities));
+        assert!(visible.is_empty());
     }
 
     #[test]
@@ -1988,27 +1978,6 @@ mod tests {
                 },
             ]
         );
-    }
-
-    #[test]
-    fn earlier_file_change_segments_settle_after_prose_starts() {
-        let file_edits = [command("cargo check"), file_change("edit", &["src/a.rs"])];
-        let ordinary = [command("cargo check"), command("cargo test")];
-        let file_edits = refs(&file_edits);
-        let ordinary = refs(&ordinary);
-
-        // Live, no longer the final segment: every run settles.
-        assert!(!work_log_auto_expands(&file_edits, true, false));
-        assert!(!work_log_auto_expands(&ordinary, true, false));
-
-        // The final live segment keeps opening on its own, as it always did.
-        assert!(work_log_auto_expands(&file_edits, true, true));
-        assert!(work_log_auto_expands(&ordinary, true, true));
-
-        // Finished turns force nothing open; CHANGED FILES takes over.
-        assert!(!work_log_auto_expands(&file_edits, false, true));
-        assert!(!work_log_auto_expands(&file_edits, false, false));
-        assert!(!work_log_auto_expands(&ordinary, false, true));
     }
 
     #[test]

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -142,15 +142,17 @@ platform pays that inset.
   typographic step down from the 15px bubble to the muted activity summary.
 - Turn activity = collapsible "Work Log" sections: an expanded section starts
   with an 11px uppercase muted label, followed by activity rows (muted ✓ +
-  one-line summary; command/tool/subagent/reasoning); >2 rows → last 2 +
-  "+N previous log entries" expander. Once expanded, that row becomes "Hide N
-  previous log entries" with an upward chevron so the rows can be collapsed
-  again. A completed section's toggle summarizes only its real, nonzero events
+  one-line summary; command/tool/subagent/reasoning). While a turn is running,
+  the latest five activities remain directly visible. Once a sixth arrives,
+  only the older prefix is summarized by a collapsed Work Log row (with a
+  working spinner on its right); those five visible activities are excluded
+  from that row's counts. Assistant prose settles the run, folding every
+  activity in it under one summary row. A completed section's toggle summarizes
+  only its real, nonzero events
   (commands, unique edited files, tool calls, subagents, and compactions); an
   earlier section uses its own counts and the final section uses turn-wide
   counts, prefixed once with Chinese “共” to make the aggregate scope explicit.
-  A zero-event summary is omitted. The active section stays expanded with "•••
-  Working for Ns" ticking.
+  A zero-event summary is omitted.
 - Assistant markdown 15px, relaxed line-height, inline code chips (mono 13,
   muted bg, 4px radius). Streaming appends via push_str with
   follow-when-near-bottom.


### PR DESCRIPTION
## Summary
- keep the latest five activities directly visible while a turn is running
- collapse only the older live prefix into a separately counted Work Log row
- fold the complete activity run after assistant prose splits it, and show a spinner on a running folded row
- update the Chatview design notes for the new lifecycle

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`