### PR TITLE
feat(orchestrate): per-profile fast mode for child models

### DIFF
--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -264,6 +264,10 @@ pub struct OrchestrateChildModel {
         alias = "default_effort"
     )]
     pub effort: Option<String>,
+    /// Dispatch with the provider's fast mode (Claude `fastMode`, Codex `fast`
+    /// service tier). Ignored by providers without one.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub fast: bool,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
 }
@@ -361,6 +365,7 @@ impl Default for OrchestrateSettings {
                     profile_id: None,
                     enabled: true,
                     effort: Some("medium".into()),
+                    fast: false,
                     description: DEFAULT_GPT_MEDIUM_CHILD_DEFINITION.into(),
                 },
                 OrchestrateChildModel {
@@ -369,6 +374,7 @@ impl Default for OrchestrateSettings {
                     profile_id: None,
                     enabled: true,
                     effort: Some("max".into()),
+                    fast: false,
                     description: DEFAULT_GPT_MAX_CHILD_DEFINITION.into(),
                 },
                 OrchestrateChildModel {
@@ -377,6 +383,7 @@ impl Default for OrchestrateSettings {
                     profile_id: None,
                     enabled: true,
                     effort: Some("high".into()),
+                    fast: false,
                     description: DEFAULT_SONNET_CHILD_DEFINITION.into(),
                 },
                 OrchestrateChildModel {
@@ -385,6 +392,7 @@ impl Default for OrchestrateSettings {
                     profile_id: None,
                     enabled: true,
                     effort: Some("high".into()),
+                    fast: false,
                     description: DEFAULT_OPUS_CHILD_DEFINITION.into(),
                 },
                 OrchestrateChildModel {
@@ -393,6 +401,7 @@ impl Default for OrchestrateSettings {
                     profile_id: None,
                     enabled: true,
                     effort: Some("high".into()),
+                    fast: false,
                     description: DEFAULT_FABLE_CHILD_DEFINITION.into(),
                 },
             ],
@@ -1407,6 +1416,7 @@ mod tests {
             profile_id: None,
             enabled: true,
             effort: Some("High".into()),
+            fast: false,
             description: String::new(),
         };
         assert!(profile.matches_effort(Some("high")));
@@ -1452,6 +1462,7 @@ mod tests {
         let child: OrchestrateChildModel =
             serde_json::from_str(r#"{"provider":"codex","model":"m","enabled":true}"#).unwrap();
         assert_eq!(child.profile_id, None);
+        assert!(!child.fast, "legacy profiles dispatch without fast mode");
 
         let title: TitleGenerationSettings =
             serde_json::from_str(r#"{"provider":"codex","model":"m"}"#).unwrap();
@@ -1459,6 +1470,7 @@ mod tests {
 
         let child = OrchestrateChildModel {
             profile_id: Some("kimi".into()),
+            fast: true,
             ..child
         };
         let child_back: OrchestrateChildModel =

--- a/crates/runtime/src/app/orchestrate.rs
+++ b/crates/runtime/src/app/orchestrate.rs
@@ -231,6 +231,7 @@ impl AppState {
         provider: ProviderKind,
         model: Option<String>,
         effort: Option<String>,
+        fast: bool,
         profile_id: Option<String>,
         approval_mode: ApprovalMode,
         title: String,
@@ -249,6 +250,7 @@ impl AppState {
             provider,
             model,
             effort,
+            fast,
             profile_id,
             approval_mode,
             cwd,
@@ -334,7 +336,7 @@ impl AppState {
                 result_max_chars,
             } => {
                 let resolved = (|| {
-                    let (provider, model, effort, profile_id) = resolve_orchestrate_dispatch(
+                    let (provider, model, effort, fast, profile_id) = resolve_orchestrate_dispatch(
                         &self.settings.orchestrate,
                         &provider,
                         model.as_deref(),
@@ -347,9 +349,9 @@ impl AppState {
                         return Err(format!("unknown profile: {id}"));
                     }
                     let approval_mode = resolve_dispatch_access(access.as_deref())?;
-                    Ok((provider, model, effort, profile_id, approval_mode))
+                    Ok((provider, model, effort, fast, profile_id, approval_mode))
                 })();
-                let (provider, model, effort, profile_id, approval_mode) = match resolved {
+                let (provider, model, effort, fast, profile_id, approval_mode) = match resolved {
                     Ok(resolved) => resolved,
                     Err(err) => {
                         let _ = reply.try_send(Err(err));
@@ -366,6 +368,7 @@ impl AppState {
                             provider,
                             Some(model),
                             effort,
+                            fast,
                             profile_id,
                             approval_mode,
                             title,
@@ -396,6 +399,7 @@ impl AppState {
                     provider,
                     Some(model),
                     effort,
+                    fast,
                     profile_id,
                     approval_mode,
                     path.clone(),
@@ -1133,21 +1137,24 @@ pub(super) fn render_orchestrate_configuration(
     for child in settings.child_models.iter().filter(|child| child.enabled) {
         let provider = provider_name(child.provider);
         let effort = child.effort.as_deref().unwrap_or("provider default");
+        let fast = if child.fast { " — fast mode" } else { "" };
         if let Some(profile_id) = child.profile_id.as_deref() {
             text.push_str(&format!(
-                "\n#### `{}` / `{}` — effort `{}` — profile `{}`\n\n{}\n",
+                "\n#### `{}` / `{}` — effort `{}`{} — profile `{}`\n\n{}\n",
                 escape_markdown_inline(provider),
                 escape_markdown_inline(&child.model),
                 escape_markdown_inline(effort),
+                fast,
                 escape_markdown_inline(profile_id),
                 child.description.trim(),
             ));
         } else {
             text.push_str(&format!(
-                "\n#### `{}` / `{}` — effort `{}`\n\n{}\n",
+                "\n#### `{}` / `{}` — effort `{}`{}\n\n{}\n",
                 escape_markdown_inline(provider),
                 escape_markdown_inline(&child.model),
                 escape_markdown_inline(effort),
+                fast,
                 child.description.trim(),
             ));
         }
@@ -1159,6 +1166,10 @@ pub(super) fn escape_markdown_inline(value: &str) -> String {
     value.replace('`', "\\`").replace(['\r', '\n'], " ")
 }
 
+/// `(provider, model, effort, fast, profile_id)` of the child profile a
+/// dispatch resolved to.
+pub(super) type ResolvedDispatch = (ProviderKind, String, Option<String>, bool, Option<String>);
+
 /// Validate an MCP dispatch against the configured child-model allow list and
 /// fill in its model/default effort. The main model is unrestricted; this gate
 /// applies only to newly-created child sessions.
@@ -1168,7 +1179,7 @@ pub(super) fn resolve_orchestrate_dispatch(
     model: Option<&str>,
     effort: Option<&str>,
     profile: Option<&str>,
-) -> Result<(ProviderKind, String, Option<String>, Option<String>), String> {
+) -> Result<ResolvedDispatch, String> {
     let provider = match provider.trim().to_ascii_lowercase().as_str() {
         "claude" | "claude_code" | "claude-code" => ProviderKind::ClaudeCode,
         "codex" => ProviderKind::Codex,
@@ -1240,6 +1251,7 @@ pub(super) fn resolve_orchestrate_dispatch(
         provider,
         child.model.clone(),
         child.effort.clone(),
+        child.fast,
         child.profile_id.clone(),
     ))
 }
@@ -1315,6 +1327,7 @@ pub(super) fn build_child_meta(
     provider: ProviderKind,
     model: Option<String>,
     effort: Option<String>,
+    fast: bool,
     profile_id: Option<String>,
     approval_mode: ApprovalMode,
     cwd: PathBuf,
@@ -1334,7 +1347,24 @@ pub(super) fn build_child_meta(
             value: serde_json::Value::String(effort),
         });
     }
+    if fast && let Some((id, value)) = fast_selection(provider) {
+        meta.option_selections.push(OptionSelection {
+            id: id.into(),
+            value,
+        });
+    }
     meta
+}
+
+/// The option selection that turns on a provider's fast mode: Claude's
+/// `fastMode` launch setting, Codex's `fast` service tier. `None` for
+/// providers without one.
+fn fast_selection(provider: ProviderKind) -> Option<(&'static str, serde_json::Value)> {
+    match provider {
+        ProviderKind::ClaudeCode => Some(("fastMode", serde_json::Value::Bool(true))),
+        ProviderKind::Codex => Some(("serviceTier", serde_json::Value::String("fast".into()))),
+        _ => None,
+    }
 }
 
 pub(super) fn final_assistant_message(timeline: &Timeline) -> String {

--- a/crates/runtime/src/app/tests.rs
+++ b/crates/runtime/src/app/tests.rs
@@ -1154,6 +1154,7 @@ fn orchestrate_dispatch_enforces_child_allow_list_and_defaults() {
             ProviderKind::Codex,
             "gpt-5.6-sol".into(),
             Some("medium".into()),
+            false,
             None
         )
     );
@@ -1170,6 +1171,7 @@ fn orchestrate_dispatch_enforces_child_allow_list_and_defaults() {
             ProviderKind::Codex,
             "gpt-5.6-sol".into(),
             Some("medium".into()),
+            false,
             Some("kimi".into()),
         )
     );
@@ -1196,6 +1198,7 @@ fn orchestrate_dispatch_enforces_child_allow_list_and_defaults() {
             ProviderKind::ClaudeCode,
             "claude-opus-4-8".into(),
             Some("high".into()),
+            false,
             None
         )
     );
@@ -2242,6 +2245,7 @@ fn child_meta_links_parent_project_and_maps_effort() {
         ProviderKind::Codex,
         Some("gpt-test".into()),
         Some("high".into()),
+        true,
         Some("work-codex".into()),
         ApprovalMode::AutoAcceptEdits,
         PathBuf::from("/p/sub"),
@@ -2255,9 +2259,41 @@ fn child_meta_links_parent_project_and_maps_effort() {
     assert_eq!(child.approval_mode, ApprovalMode::AutoAcceptEdits);
     assert!(child.archive_on_complete);
     assert_eq!(child.result_max_chars, Some(2400));
-    assert_eq!(child.option_selections.len(), 1);
+    assert_eq!(child.option_selections.len(), 2);
     assert_eq!(child.option_selections[0].id, "reasoningEffort");
     assert_eq!(child.option_selections[0].value, serde_json::json!("high"));
+    assert_eq!(child.option_selections[1].id, "serviceTier");
+    assert_eq!(child.option_selections[1].value, serde_json::json!("fast"));
+
+    let claude = build_child_meta(
+        &parent,
+        ProviderKind::ClaudeCode,
+        None,
+        None,
+        true,
+        None,
+        ApprovalMode::FullAccess,
+        PathBuf::from("/p"),
+        false,
+        None,
+    );
+    assert_eq!(claude.option_selections.len(), 1);
+    assert_eq!(claude.option_selections[0].id, "fastMode");
+    assert_eq!(claude.option_selections[0].value, serde_json::json!(true));
+
+    let pi = build_child_meta(
+        &parent,
+        ProviderKind::Pi,
+        None,
+        None,
+        true,
+        None,
+        ApprovalMode::FullAccess,
+        PathBuf::from("/p"),
+        false,
+        None,
+    );
+    assert!(pi.option_selections.is_empty());
 }
 
 #[test]
@@ -2448,6 +2484,7 @@ fn dispatched_brief_carries_report_contract_footer() {
                 ProviderKind::Codex,
                 Some("gpt-test".into()),
                 None,
+                false,
                 None,
                 ApprovalMode::FullAccess,
                 "Child".into(),

--- a/crates/ui/src/orchestrate_settings.rs
+++ b/crates/ui/src/orchestrate_settings.rs
@@ -263,6 +263,35 @@ impl OrchestrateSettingsPanel {
         );
     }
 
+    fn set_child_fast(&self, index: usize, fast: bool, cx: &mut Context<Self>) {
+        self.update_child_models(
+            move |models| {
+                if let Some(entry) = models.get_mut(index) {
+                    entry.fast = fast;
+                }
+            },
+            cx,
+        );
+    }
+
+    /// Whether the provider catalog declares a fast mode for a model: Claude's
+    /// `fastMode` boolean or a Codex `serviceTier` selector offering `fast`.
+    fn child_fast_supported(&self, provider: ProviderKind, model: &str, cx: &App) -> bool {
+        self.store
+            .read(cx)
+            .provider_model_catalog(provider)
+            .into_iter()
+            .find(|spec| spec.id == model)
+            .into_iter()
+            .flat_map(|spec| spec.options)
+            .any(|option| match option {
+                OptionDescriptor::Boolean { id, .. } => id == "fastMode",
+                OptionDescriptor::Select { id, options, .. } => {
+                    id == "serviceTier" && options.iter().any(|choice| choice.value == "fast")
+                }
+            })
+    }
+
     /// The valid `reasoningEffort` choices the provider catalog declares for a
     /// model; empty when the model has no reasoning selector.
     fn child_effort_options(
@@ -341,6 +370,7 @@ impl OrchestrateSettingsPanel {
             profile_id: option.profile_id.clone(),
             enabled: true,
             effort: option.effort.clone(),
+            fast: false,
             description: OrchestrateSettings::builtin_child_definition(
                 option.provider,
                 &option.id,
@@ -1007,10 +1037,14 @@ impl OrchestrateSettingsPanel {
             };
             let provider = row.provider;
             let name = self.model_name(provider, &row.model, row.profile_id.as_deref(), cx);
-            let effort = profile
+            let mut effort = profile
                 .effort
                 .clone()
                 .unwrap_or_else(|| crate::tr!("orchestrate.children.effort_default").into_owned());
+            if profile.fast {
+                effort.push_str(" · ");
+                effort.push_str(&crate::tr!("orchestrate.children.fast_label"));
+            }
             let subtitle = if let Some(id) = row.profile_id.as_deref() {
                 let profile_settings = self.store.read(cx).provider_profile_settings(id);
                 let profile_name = profile_settings
@@ -1210,16 +1244,51 @@ impl OrchestrateSettingsPanel {
                             }
                             list
                         });
-                        v_flex()
-                            .gap_1()
-                            .items_start()
+                        let fast_supported = self.child_fast_supported(provider, &row.model, cx);
+                        h_flex()
+                            .gap_4()
+                            .items_end()
                             .child(
-                                div()
-                                    .text_size(px(11.))
-                                    .text_color(cx.theme().muted_foreground)
-                                    .child(crate::tr!("orchestrate.children.effort_label")),
+                                v_flex()
+                                    .gap_1()
+                                    .items_start()
+                                    .child(
+                                        div()
+                                            .text_size(px(11.))
+                                            .text_color(cx.theme().muted_foreground)
+                                            .child(crate::tr!("orchestrate.children.effort_label")),
+                                    )
+                                    .child(dropdown),
                             )
-                            .child(dropdown)
+                            // Keep a stored `fast` visible even when the catalog no
+                            // longer declares support, so it can be switched off.
+                            .when(fast_supported || profile.fast, |row| {
+                                row.child(
+                                    v_flex()
+                                        .gap_1()
+                                        .items_start()
+                                        .child(
+                                            div()
+                                                .text_size(px(11.))
+                                                .text_color(cx.theme().muted_foreground)
+                                                .child(crate::tr!(
+                                                    "orchestrate.children.fast_label"
+                                                )),
+                                        )
+                                        .child(
+                                            Switch::new(("orchestrate-child-fast", index))
+                                                .checked(profile.fast)
+                                                .tooltip(crate::tr!(
+                                                    "orchestrate.children.fast_hint"
+                                                ))
+                                                .on_click(cx.listener(
+                                                    move |this, checked: &bool, _, cx| {
+                                                        this.set_child_fast(index, *checked, cx);
+                                                    },
+                                                )),
+                                        ),
+                                )
+                            })
                     })
                     .child(
                         Textarea::new(&row.description)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -348,6 +348,8 @@ orchestrate:
     disable: "Pause dispatch while keeping this model's definition"
     effort_label: "Dispatch effort"
     effort_default: "provider default"
+    fast_label: "Fast mode"
+    fast_hint: "Dispatch with the provider's fast mode (Claude fastMode, Codex fast service tier)"
     description_placeholder: "Define this model's ratings, strengths, best-fit tasks, caveats, recommended effort, and escalation role…"
     remove: "Delete this child-model profile"
   no_more_models: "All available provider models are already configured. Add custom model slugs under Providers to expose more choices."

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -348,6 +348,8 @@ orchestrate:
     disable: "暂停派发，但保留这个模型的定义"
     effort_label: "派发推理强度"
     effort_default: "模型默认"
+    fast_label: "快速模式"
+    fast_hint: "派发时启用提供方的快速模式（Claude fastMode、Codex fast 服务档位）"
     description_placeholder: "定义该模型的评分、优势、适合任务、注意事项、推荐 effort 和升级定位…"
     remove: "删除这个子模型配置"
   no_more_models: "所有可用的提供商模型都已配置。可先在“提供商”中添加自定义模型标识。"


### PR DESCRIPTION
Add a `fast` flag to each Orchestrate child-model profile. When on, a
dispatch to that profile launches the child with the provider's fast
mode: Claude gets the `fastMode` launch setting, Codex the `fast`
service tier. Providers without one (Pi, OpenCode) ignore the flag.

Settings → Orchestrate shows a "Fast mode" switch next to the dispatch
effort dropdown, only for models whose catalog declares support (a
`fastMode` boolean or a `serviceTier` selector offering `fast`); a
stored true value stays visible so it can be switched off. The fleet
table handed to the lead model marks fast profiles.

The flag defaults to false and is omitted from JSON when unset, so
existing settings files load unchanged.

Verified: clippy clean, cargo test for core, runtime, and ui green.