### PR TITLE
fix(orchestrate): show the Fast switch for every model whose catalog offers fast mode

### DIFF
--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -3148,7 +3148,6 @@ fn built_in_models() -> Vec<ModelSpec> {
                     &["low", "medium", "high", "xhigh", "max", "ultrathink"],
                     "xhigh",
                 ),
-                boolean("fastMode", "Fast Mode"),
                 context_window("1m"),
             ],
         ),
@@ -3157,17 +3156,13 @@ fn built_in_models() -> Vec<ModelSpec> {
             "Claude Opus 4.6",
             vec![
                 reasoning(&["low", "medium", "high", "max", "ultrathink"], "high"),
-                boolean("fastMode", "Fast Mode"),
                 context_window("200k"),
             ],
         ),
         model(
             "claude-opus-4-5",
             "Claude Opus 4.5",
-            vec![
-                reasoning(&["low", "medium", "high", "max"], "high"),
-                boolean("fastMode", "Fast Mode"),
-            ],
+            vec![reasoning(&["low", "medium", "high", "max"], "high")],
         ),
         model(
             "claude-sonnet-5",
@@ -3640,6 +3635,21 @@ mod tests {
         assert!(!ids(Some((2, 1, 218))).contains(&"claude-opus-5".to_string()));
         // Unknown version hides gated models.
         assert!(!ids(None).contains(&"claude-fable-5".to_string()));
+    }
+
+    #[test]
+    fn fast_mode_models_match_supported_opus_versions() {
+        let ids: Vec<String> = built_in_models()
+            .into_iter()
+            .filter(|model| {
+                model.options.iter().any(
+                    |option| matches!(option, OptionDescriptor::Boolean { id, .. } if id == "fastMode"),
+                )
+            })
+            .map(|model| model.id)
+            .collect();
+
+        assert_eq!(ids, ["claude-opus-5", "claude-opus-4-8"]);
     }
 
     #[test]

--- a/crates/ui/src/orchestrate_settings.rs
+++ b/crates/ui/src/orchestrate_settings.rs
@@ -86,13 +86,16 @@ impl OrchestrateSettingsPanel {
             cx.subscribe_in(
                 &store,
                 window,
-                |this, _, change: &StoreChange, window, cx| {
-                    if change.topic == TopicKind::Settings {
+                |this, _, change: &StoreChange, window, cx| match change.topic {
+                    TopicKind::Settings => {
                         if !this.rows_match_settings(cx) {
                             this.rebuild_rows(window, cx);
                         }
                         cx.notify();
                     }
+                    // Fast/effort controls read the provider catalogs.
+                    TopicKind::Providers => cx.notify(),
+                    _ => {}
                 },
             ),
             cx.subscribe_in(&identity_model_picker, window, |this, _, event, _, cx| {
@@ -306,19 +309,7 @@ impl OrchestrateSettingsPanel {
     /// Whether the provider catalog declares a fast mode for a model: Claude's
     /// `fastMode` boolean or a Codex `serviceTier` selector offering `fast`.
     fn child_fast_supported(&self, provider: ProviderKind, model: &str, cx: &App) -> bool {
-        self.store
-            .read(cx)
-            .provider_model_catalog(provider)
-            .into_iter()
-            .find(|spec| spec.id == model)
-            .into_iter()
-            .flat_map(|spec| spec.options)
-            .any(|option| match option {
-                OptionDescriptor::Boolean { id, .. } => id == "fastMode",
-                OptionDescriptor::Select { id, options, .. } => {
-                    id == "serviceTier" && options.iter().any(|choice| choice.value == "fast")
-                }
-            })
+        model_fast_supported(&self.store.read(cx).provider_model_catalog(provider), model)
     }
 
     /// The valid `reasoningEffort` choices the provider catalog declares for a
@@ -1319,6 +1310,23 @@ impl OrchestrateSettingsPanel {
     }
 }
 
+fn model_fast_supported(catalog: &[agent::ModelSpec], model: &str) -> bool {
+    catalog
+        .iter()
+        .find(|spec| spec.id == model)
+        .into_iter()
+        .flat_map(|spec| &spec.options)
+        .any(|option| match option {
+            OptionDescriptor::Boolean { id, .. } => id == "fastMode",
+            OptionDescriptor::Select { id, options, .. } => {
+                id == "serviceTier"
+                    && options.iter().any(|choice| {
+                        choice.value == "fast" || choice.label.eq_ignore_ascii_case("fast")
+                    })
+            }
+        })
+}
+
 /// Whether two efforts name the same tier. Stored efforts are free text, so a
 /// hand-typed "Medium" must still match the bundled "medium".
 fn same_effort(left: &Option<String>, right: &Option<String>) -> bool {
@@ -1390,5 +1398,31 @@ impl Render for OrchestrateSettingsPanel {
             .child(self.render_auto_archive(cx))
             .child(self.render_identities(cx))
             .child(self.render_children(cx))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_fast_support_accepts_the_model_list_priority_tier() {
+        let catalog = vec![agent::ModelSpec {
+            id: "gpt-6-astra".into(),
+            display_name: "GPT-6 Astra".into(),
+            is_default: true,
+            options: vec![OptionDescriptor::Select {
+                id: "serviceTier".into(),
+                label: "Service Tier".into(),
+                options: vec![SelectOption {
+                    value: "priority".into(),
+                    label: "Fast".into(),
+                    description: None,
+                }],
+                default_value: Some("default".into()),
+            }],
+        }];
+
+        assert!(model_fast_supported(&catalog, "gpt-6-astra"));
     }
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -337,8 +337,11 @@ optional per-model multiline identity overrides, and models without an override
 inherit the generic text. Each editor has a compact "Restore default" action.
 Allowed child models are retained as provider/model profiles with one multiline
 routing-definition editor, an independent dispatch switch, restore and delete
-actions. Built-in ratings and recommended effort live inside the default text,
-not separate controls. Add-model popovers keep provider tabs fixed above a
+actions. Each row exposes the catalog's reasoning choices and shows a Fast
+switch only when the model catalog declares Claude fast mode or a Codex Fast
+service tier (or when a stored Fast value must remain available to turn off).
+Built-in ratings and recommended effort live inside the default text, not
+separate controls. Add-model popovers keep provider tabs fixed above a
 300px scrollable model list so large catalogs never grow past the viewport.
 That provider/model picker is one shared component also used by the General
 page's thread-title setting, so catalog resolution and provider switching stay


### PR DESCRIPTION
## Problem
In Settings → Orchestrate the Fast switch appeared only on some rows.

Two causes:

- **Claude catalog out of date.** `built_in_models` declared `fastMode` on Opus 4.7, 4.6 and 4.5. Claude Code's fast mode is supported on Opus 5 and Opus 4.8 only (4.7 support was removed on 2026‑07‑24; Sonnet and Haiku never had it).
- **Codex rows never qualified.** `model/list` advertises the fast tier as `serviceTiers: [{id: "priority", name: "Fast", …}]` (plus `additionalSpeedTiers: ["fast"]`, which the catalog mapper drops when `serviceTiers` is non-empty). The switch predicate only accepted a choice whose *value* is literally `fast`, so gpt‑5.6‑sol and gpt‑6‑astra never showed it.

Reproduced with a copy of the reporter's settings in a throwaway data dir and the raw `model/list` output from `codex app-server`.

## Fix
- `crates/agent/src/claude.rs`: `fastMode` on exactly `claude-opus-5` and `claude-opus-4-8`; a test pins that list.
- `crates/ui/src/orchestrate_settings.rs`: capability check extracted to a pure `model_fast_supported`, which also accepts a `serviceTier` choice labelled "Fast"; the panel now re-renders on the Providers topic so rows update once catalogs finish loading. Test covers the real `priority`/`Fast` descriptor shape.
- `docs/DESIGN.md`: visual contract for the Fast switch.

With the reporter's fleet the switch now shows on gpt‑5.6‑sol (both efforts), gpt‑6‑astra (both efforts), claude‑opus‑5 and claude‑opus‑4‑8, and not on claude‑sonnet‑5 or claude‑fable‑5.

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build`, `cargo test --workspace` pass locally.