### PR TITLE
feat(chat): resume the task when the Claude Code usage limit resets

### DIFF
--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -1178,6 +1178,8 @@ pub(crate) struct Mapper {
     stop_reason: Option<String>,
     /// Classifier category captured from the active turn's structured refusal details.
     pending_refusal_category: Option<ClassifierCategory>,
+    /// Reset time reported for a rejected usage window in the active turn.
+    limit_resets_at: Option<u64>,
     /// Warning-bearing stop reason already emitted for this occurrence.
     warned_stop_reason: Option<String>,
 }
@@ -1240,6 +1242,7 @@ impl Mapper {
             fallback_detected: false,
             stop_reason: None,
             pending_refusal_category: None,
+            limit_resets_at: None,
             warned_stop_reason: None,
         }
     }
@@ -1482,12 +1485,22 @@ impl Mapper {
             Some("user") => self.on_user(&msg),
             Some("control_request") => self.on_control_request(&msg),
             Some("control_response") => self.on_control_response(&msg),
+            Some("rate_limit_event") => self.on_rate_limit_event(&msg),
             Some("result") => self.on_result(&msg),
             other => {
                 log::debug!("claude: ignoring message type {other:?}");
                 Vec::new()
             }
         }
+    }
+
+    fn on_rate_limit_event(&mut self, msg: &Value) -> Vec<AgentEvent> {
+        let info = msg.get("rate_limit_info");
+        self.limit_resets_at = info
+            .filter(|info| info.get("status").and_then(Value::as_str) == Some("rejected"))
+            .and_then(|info| info.get("resetsAt"))
+            .and_then(Value::as_u64);
+        Vec::new()
     }
 
     fn synthesized_turn_started(&mut self) -> Vec<AgentEvent> {
@@ -2430,7 +2443,11 @@ impl Mapper {
                 message: format!("claude turn failed ({subtype}): {detail}"),
                 fatal: false,
             });
+            if let Some(resets_at) = self.limit_resets_at.take() {
+                events.push(AgentEvent::UsageLimitReached { resets_at });
+            }
         }
+        self.limit_resets_at = None;
         if self.stop_reason.as_deref() == Some("refusal") {
             let detail = msg
                 .get("result")
@@ -4091,6 +4108,50 @@ mod tests {
         }
         // Second init is ignored.
         assert!(feed(&mut m, line).is_empty());
+    }
+
+    #[test]
+    fn rejected_rate_limit_is_emitted_after_failed_result_error() {
+        let mut m = Mapper::new();
+        assert!(feed(
+            &mut m,
+            r#"{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetsAt":1800000000,"rateLimitType":"five_hour","utilization":1.0}}"#,
+        )
+        .is_empty());
+
+        let events = feed(
+            &mut m,
+            r#"{"type":"result","subtype":"error_during_execution","is_error":true,"result":"You've hit your limit","session_id":"sess-1"}"#,
+        );
+        let error_index = events
+            .iter()
+            .position(|event| matches!(event, AgentEvent::Error { .. }))
+            .expect("failed result error");
+        assert!(matches!(
+            events.get(error_index + 1),
+            Some(AgentEvent::UsageLimitReached {
+                resets_at: 1_800_000_000
+            })
+        ));
+    }
+
+    #[test]
+    fn rejected_rate_limit_is_cleared_by_successful_result() {
+        let mut m = Mapper::new();
+        feed(
+            &mut m,
+            r#"{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetsAt":1800000000,"rateLimitType":"five_hour","utilization":1.0}}"#,
+        );
+
+        let events = feed(
+            &mut m,
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"done","session_id":"sess-1"}"#,
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, AgentEvent::UsageLimitReached { .. }))
+        );
     }
 
     #[test]

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1203,6 +1203,11 @@ pub enum AgentEvent {
         message: String,
         fatal: bool,
     },
+    /// Emitted after the [`AgentEvent::Error`] of a turn Claude Code rejected
+    /// for an exhausted usage window. `resets_at` is unix seconds.
+    UsageLimitReached {
+        resets_at: u64,
+    },
     SessionClosed {
         reason: Option<String>,
     },

--- a/crates/core/src/relay.rs
+++ b/crates/core/src/relay.rs
@@ -216,7 +216,7 @@ fn render_turn(number: usize, entries: &[&TimelineEntry], timeline: &Timeline) -
                 let outcome = status_outcome(*status, summary.as_deref().unwrap_or(""));
                 activity(&mut body, agent_type, &one_line(description), &outcome);
             }
-            EntryContent::Error { message }
+            EntryContent::Error { message, .. }
             | EntryContent::ProviderStartError { error: message } => {
                 activity(&mut body, "error", "provider", &one_line(message));
             }

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -14,6 +14,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::git::merge_file_changes_by_path;
 
+/// Claude Code's own prompt for resuming work after a usage-window reset.
+pub const RESUME_PROMPT: &str = "Continue from where you left off.";
+
 /// A local review note attached to a range in the diff panel. These live in
 /// the composer draft until the next send; they are never written to session
 /// history as separate events.
@@ -410,6 +413,8 @@ pub enum EntryContent {
     },
     Error {
         message: String,
+        /// Unix seconds when the turn failed because the usage window is exhausted.
+        limit_resets_at: Option<u64>,
     },
     #[rustfmt::skip]
     ProviderStartError { error: String },
@@ -782,10 +787,34 @@ impl Timeline {
                     id,
                     content: EntryContent::Error {
                         message: message.clone(),
+                        limit_resets_at: None,
                     },
                     ts,
                     turn,
                 }));
+            }
+            AgentEvent::UsageLimitReached { resets_at } => {
+                let Some((index, entry)) = self
+                    .entries
+                    .iter()
+                    .enumerate()
+                    .rev()
+                    .find(|(_, entry)| matches!(entry.content, EntryContent::Error { .. }))
+                else {
+                    return;
+                };
+                let EntryContent::Error { message, .. } = &entry.content else {
+                    unreachable!();
+                };
+                self.entries[index] = Arc::new(TimelineEntry {
+                    id: entry.id.clone(),
+                    content: EntryContent::Error {
+                        message: message.clone(),
+                        limit_resets_at: Some(*resets_at),
+                    },
+                    ts: entry.ts,
+                    turn: entry.turn,
+                });
             }
             AgentEvent::SessionClosed { reason } => {
                 // An abnormal close carries the provider's dying words (exit
@@ -799,6 +828,7 @@ impl Timeline {
                         id,
                         content: EntryContent::Error {
                             message: reason.clone(),
+                            limit_resets_at: None,
                         },
                         ts,
                         turn,
@@ -2583,7 +2613,28 @@ mod tests {
         );
         assert!(matches!(
             &timeline.entries[1].content,
-            EntryContent::Error { message } if message == "boom"
+            EntryContent::Error { message, .. } if message == "boom"
+        ));
+    }
+
+    #[test]
+    fn usage_limit_reset_is_folded_into_the_latest_error() {
+        let mut timeline = Timeline::default();
+        timeline.apply_at(
+            None,
+            &AgentEvent::Error {
+                message: "boom".into(),
+                fatal: false,
+            },
+        );
+        timeline.apply_at(None, &AgentEvent::UsageLimitReached { resets_at: 42 });
+
+        assert!(matches!(
+            &timeline.entries[0].content,
+            EntryContent::Error {
+                message,
+                limit_resets_at: Some(42),
+            } if message == "boom"
         ));
     }
 
@@ -2622,7 +2673,7 @@ mod tests {
         assert!(timeline.pending_approvals.is_empty());
         assert!(matches!(
             &timeline.entries[0].content,
-            EntryContent::Error { message } if message == "boom"
+            EntryContent::Error { message, .. } if message == "boom"
         ));
         // A silent close (reason: None) leaves no entry…
         let entries_after_silent_close = timeline.entries.len();
@@ -2636,7 +2687,7 @@ mod tests {
         assert_eq!(timeline.entries.len(), entries_after_silent_close + 1);
         assert!(matches!(
             &timeline.entries.last().unwrap().content,
-            EntryContent::Error { message } if message.contains("stderr:\nboom")
+            EntryContent::Error { message, .. } if message.contains("stderr:\nboom")
         ));
     }
 

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -630,6 +630,7 @@ pub enum SettingsPatch {
     ProviderUpdateChecksDisabled(bool),
     InactiveFrameThrottleDisabled(bool),
     AbortOnModelFallback(bool),
+    ResumeOnLimitReset(bool),
     FallbackReviewAdvisor(bool),
     AutoArchiveDisabled(bool),
     AutoArchiveMaxIdleDays(u32),
@@ -732,6 +733,8 @@ pub struct Settings {
     pub inactive_frame_throttle_disabled: bool,
     #[serde(default = "default_true")]
     pub abort_on_model_fallback: bool,
+    #[serde(default = "default_true")]
+    pub resume_on_limit_reset: bool,
     #[serde(default)]
     pub fallback_review_advisor: bool,
     /// Whether automatic archiving is DISABLED. Stored inverted so the feature
@@ -827,6 +830,7 @@ impl Default for Settings {
             provider_update_checks_disabled: false,
             inactive_frame_throttle_disabled: false,
             abort_on_model_fallback: true,
+            resume_on_limit_reset: true,
             fallback_review_advisor: false,
             auto_archive_disabled: false,
             auto_archive_max_idle_days: default_auto_archive_max_idle_days(),
@@ -870,6 +874,9 @@ impl Settings {
             }
             SettingsPatch::AbortOnModelFallback(value) => {
                 self.abort_on_model_fallback = value;
+            }
+            SettingsPatch::ResumeOnLimitReset(value) => {
+                self.resume_on_limit_reset = value;
             }
             SettingsPatch::FallbackReviewAdvisor(value) => {
                 self.fallback_review_advisor = value;

--- a/crates/protocol/src/tests.rs
+++ b/crates/protocol/src/tests.rs
@@ -241,6 +241,7 @@ fn settings_patches_round_trip() {
         SettingsPatch::ProviderUpdateChecksDisabled(true),
         SettingsPatch::InactiveFrameThrottleDisabled(true),
         SettingsPatch::AbortOnModelFallback(false),
+        SettingsPatch::ResumeOnLimitReset(false),
         SettingsPatch::FallbackReviewAdvisor(true),
         SettingsPatch::AutoArchiveDisabled(true),
         SettingsPatch::AutoArchiveMaxIdleDays(14),

--- a/crates/runtime/src/app/events.rs
+++ b/crates/runtime/src/app/events.rs
@@ -255,6 +255,32 @@ impl AppState {
                     RuntimeEvent::Error(RuntimeError::ProviderMessage(message.clone())),
                 );
             }
+            AgentEvent::UsageLimitReached { resets_at } => {
+                if self.settings.resume_on_limit_reset {
+                    let not_before = UNIX_EPOCH + Duration::from_secs(*resets_at);
+                    let scheduled = self.resident_mut(session_id).is_some_and(|resident| {
+                        if resident
+                            .queue
+                            .iter()
+                            .any(|message| message.not_before == Some(not_before))
+                        {
+                            return false;
+                        }
+                        resident.push_scheduled(
+                            tcode_core::session::RESUME_PROMPT.to_string(),
+                            Vec::new(),
+                            not_before,
+                        );
+                        true
+                    });
+                    if scheduled {
+                        log::info!(
+                            "scheduled usage-limit resume for session {session_id} at {resets_at}"
+                        );
+                        self.reschedule_scheduled_wake(cx);
+                    }
+                }
+            }
             AgentEvent::Warning { message } => {
                 // Provider warnings (config problems, deprecations, failed
                 // mode switches) explain later misbehavior: a log line alone

--- a/crates/runtime/src/app/tests.rs
+++ b/crates/runtime/src/app/tests.rs
@@ -3817,6 +3817,46 @@ fn schedule_status_and_queue_actions_preserve_or_remove_deadlines() {
 }
 
 #[test]
+fn usage_limit_event_schedules_resume_when_enabled_only() {
+    let cx = &mut TestAppContext::default();
+    let test_store = TestStore::new("tcode-usage-limit-resume-test");
+    let state = cx.new_entity(|_| AppState::new((*test_store).clone()));
+    let resets_at = now_secs() + 3_600;
+
+    state.host_update(cx, |state, cx| {
+        let (commands, _) = smol::channel::unbounded();
+        let mut active = live_session(ProviderKind::ClaudeCode, commands);
+        active.meta.id = "resume-enabled".into();
+        state.residents.active = Some(active);
+        state.on_event(
+            "resume-enabled",
+            AgentEvent::UsageLimitReached { resets_at },
+            cx,
+        );
+
+        let queue = &state.residents.active.as_ref().unwrap().queue;
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue[0].text, tcode_core::session::RESUME_PROMPT);
+        assert_eq!(
+            queue[0].not_before,
+            Some(UNIX_EPOCH + Duration::from_secs(resets_at))
+        );
+
+        let (commands, _) = smol::channel::unbounded();
+        let mut active = live_session(ProviderKind::ClaudeCode, commands);
+        active.meta.id = "resume-disabled".into();
+        state.residents.active = Some(active);
+        state.settings.resume_on_limit_reset = false;
+        state.on_event(
+            "resume-disabled",
+            AgentEvent::UsageLimitReached { resets_at },
+            cx,
+        );
+        assert!(state.residents.active.as_ref().unwrap().queue.is_empty());
+    });
+}
+
+#[test]
 fn due_scheduled_message_reenters_the_ordinary_send_path() {
     let cx = &mut TestAppContext::default();
     let test_store = TestStore::new("tcode-scheduled-fire-test");

--- a/crates/services/src/settings.rs
+++ b/crates/services/src/settings.rs
@@ -185,6 +185,7 @@ mod tests {
             provider_update_checks_disabled: true,
             inactive_frame_throttle_disabled: true,
             abort_on_model_fallback: true,
+            resume_on_limit_reset: true,
             fallback_review_advisor: false,
             auto_archive_disabled: false,
             auto_archive_max_idle_days: 7,

--- a/crates/ui/src/chat/components/error_card.rs
+++ b/crates/ui/src/chat/components/error_card.rs
@@ -6,9 +6,21 @@ use crate::{
 };
 use gpui::{
     AnyElement, App, ClickEvent, IntoElement as _, ParentElement as _, SharedString, Styled as _,
-    Window, div, px,
+    Window, div, prelude::FluentBuilder as _, px,
 };
 use gpui_base::{StyledExt as _, h_flex, v_flex};
+
+type ClickHandler = Box<dyn Fn(&ClickEvent, &mut Window, &mut App)>;
+
+pub(crate) enum LimitResume {
+    /// No resume is queued and the reset is still ahead: offer to schedule one.
+    Offer { on_schedule: ClickHandler },
+    /// A resume is queued for the reset: live countdown plus cancel.
+    Scheduled {
+        remaining_secs: u64,
+        on_cancel: ClickHandler,
+    },
+}
 
 /// A provider/app error as a first-class timeline block: a danger-tinted card
 /// carrying the full message, wrapped across as many lines as it needs.
@@ -16,6 +28,7 @@ pub(crate) fn error_card(
     id: &str,
     message: &str,
     copied: bool,
+    resume: Option<LimitResume>,
     on_copy: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
     cx: &App,
 ) -> AnyElement {
@@ -34,6 +47,45 @@ pub(crate) fn error_card(
             crate::tr!("chat.copy")
         })
         .on_click(on_copy);
+    let resume_row = resume.map(|resume| match resume {
+        LimitResume::Offer { on_schedule } => h_flex()
+            .gap_2()
+            .items_center()
+            .child(
+                Button::new(SharedString::from(format!("schedule-limit-resume:{id}")))
+                    .outline()
+                    .xsmall()
+                    .icon(IconName::ArrowUp)
+                    .label(crate::tr!("chat.limit_resume.schedule"))
+                    .on_click(on_schedule),
+            )
+            .into_any_element(),
+        LimitResume::Scheduled {
+            remaining_secs,
+            on_cancel,
+        } => h_flex()
+            .gap_2()
+            .items_center()
+            .child(
+                div()
+                    .text_size(px(12.))
+                    .text_color(cx.theme().danger_foreground)
+                    .child(crate::tr!(
+                        "chat.limit_resume.resumes_in",
+                        countdown = crate::composer::model::format_countdown(remaining_secs)
+                    )),
+            )
+            .child(div().flex_1())
+            .child(
+                Button::new(SharedString::from(format!("cancel-limit-resume:{id}")))
+                    .ghost()
+                    .xsmall()
+                    .icon(IconName::Close)
+                    .label(crate::tr!("chat.limit_resume.cancel"))
+                    .on_click(on_cancel),
+            )
+            .into_any_element(),
+    });
     let content = v_flex()
         .flex_1()
         .min_w_0()
@@ -68,7 +120,8 @@ pub(crate) fn error_card(
                 .text_color(cx.theme().danger_foreground)
                 .whitespace_normal()
                 .child(message.to_string()),
-        );
+        )
+        .when_some(resume_row, |content, row| content.child(row));
     h_flex()
         .w_full()
         .items_stretch()

--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -339,6 +339,8 @@ pub struct ChatView {
     highlighted_turn: Option<usize>,
     /// 1s ticker kept alive while a turn is running (drives live "Working for Ns").
     _tick: Option<Task<()>>,
+    /// 1s ticker kept alive while an error card shows a scheduled resume.
+    _limit_tick: Option<Task<()>>,
     /// Which copy button is currently showing its "Copied!" confirmation (2s):
     /// the copy target's key (`plan`, `user:<id>`, `assistant:<id>`).
     copied: Option<String>,
@@ -406,6 +408,7 @@ impl ChatView {
             session_key: None,
             highlighted_turn: None,
             _tick: None,
+            _limit_tick: None,
             copied: None,
             _copied_task: None,
             commit_dialog: None,
@@ -537,6 +540,42 @@ impl ChatView {
             }));
         } else if !running {
             self._tick = None;
+        }
+
+        let scheduled_limit_resume = {
+            let store = self.workspace_store.read(cx);
+            let deadlines: HashSet<u64> = store
+                .composer_state()
+                .queue
+                .into_iter()
+                .flat_map(|queue| queue.messages)
+                .filter_map(|message| message.fire_at_unix_secs)
+                .collect();
+            store
+                .with_active_timeline(|timeline| {
+                    timeline.entries.iter().any(|entry| {
+                        matches!(
+                            entry.content,
+                            EntryContent::Error {
+                                limit_resets_at: Some(resets_at),
+                                ..
+                            } if deadlines.contains(&resets_at)
+                        )
+                    })
+                })
+                .unwrap_or(false)
+        };
+        if scheduled_limit_resume && self._limit_tick.is_none() {
+            self._limit_tick = Some(cx.spawn(async move |this, cx| {
+                loop {
+                    smol::Timer::after(Duration::from_secs(1)).await;
+                    if this.update(cx, |_, cx| cx.notify()).is_err() {
+                        break;
+                    }
+                }
+            }));
+        } else if !scheduled_limit_resume {
+            self._limit_tick = None;
         }
     }
 
@@ -975,6 +1014,47 @@ impl ChatView {
                 }
                 Segment::Error(entry) => {
                     let message = displayed_error_text(&entry.content);
+                    let resume = match &entry.content {
+                        EntryContent::Error {
+                            limit_resets_at: Some(resets_at),
+                            ..
+                        } => {
+                            let resets_at = *resets_at;
+                            let queued_id = self
+                                .workspace_store
+                                .read(cx)
+                                .composer_state()
+                                .queue
+                                .into_iter()
+                                .flat_map(|queue| queue.messages)
+                                .find(|message| message.fire_at_unix_secs == Some(resets_at))
+                                .map(|message| message.id);
+                            if let Some(id) = queued_id {
+                                Some(components::error_card::LimitResume::Scheduled {
+                                    remaining_secs: resets_at.saturating_sub(now_secs()),
+                                    on_cancel: Box::new(cx.listener(move |this, _, _, cx| {
+                                        this.workspace_store
+                                            .update(cx, |store, _| store.drop_queued(id));
+                                    })),
+                                })
+                            } else if resets_at > now_secs() {
+                                Some(components::error_card::LimitResume::Offer {
+                                    on_schedule: Box::new(cx.listener(move |this, _, _, cx| {
+                                        this.workspace_store.update(cx, |store, _| {
+                                            store.schedule_turn(
+                                                tcode_core::session::RESUME_PROMPT.to_string(),
+                                                vec![],
+                                                resets_at,
+                                            )
+                                        });
+                                    })),
+                                })
+                            } else {
+                                None
+                            }
+                        }
+                        _ => None,
+                    };
                     let copy_key = format!("error:{}", entry.id);
                     let copied = self.copied.as_deref() == Some(copy_key.as_str());
                     let mark = copy_key;
@@ -983,6 +1063,7 @@ impl ChatView {
                         &entry.id,
                         &message,
                         copied,
+                        resume,
                         cx.listener(move |this, _, _, cx| {
                             cx.write_to_clipboard(ClipboardItem::new_string(copy_text.clone()));
                             this.mark_copied(mark.clone(), cx);

--- a/crates/ui/src/chat/model.rs
+++ b/crates/ui/src/chat/model.rs
@@ -41,7 +41,7 @@ pub(crate) struct SegmentedEntries<'a> {
 
 pub(crate) fn displayed_error_text(content: &EntryContent) -> Cow<'_, str> {
     match content {
-        EntryContent::Error { message } => Cow::Borrowed(message),
+        EntryContent::Error { message, .. } => Cow::Borrowed(message),
         EntryContent::ProviderStartError { error } => {
             crate::tr!("errors.provider_start", error = error)
         }
@@ -1084,7 +1084,13 @@ fn hash_entry_shape(content: &EntryContent, hash: &mut DefaultHasher) {
             std::mem::discriminant(status).hash(hash);
             summary.as_ref().map(String::len).hash(hash);
         }
-        EntryContent::Error { message } => message.len().hash(hash),
+        EntryContent::Error {
+            message,
+            limit_resets_at,
+        } => {
+            message.len().hash(hash);
+            limit_resets_at.hash(hash);
+        }
         EntryContent::ProviderStartError { error } => error.len().hash(hash),
         EntryContent::ProviderRelay {
             from_provider,
@@ -1291,6 +1297,7 @@ mod tests {
         let _locale_guard = crate::settings::TestLocaleGuard::acquire();
         let generic = EntryContent::Error {
             message: "generic\0原样".into(),
+            limit_resets_at: None,
         };
         let provider_start = EntryContent::ProviderStartError {
             error: "spawn failed".into(),
@@ -1571,6 +1578,7 @@ mod tests {
                 "error",
                 EntryContent::Error {
                     message: "boom".into(),
+                    limit_resets_at: None,
                 },
             ),
         ];

--- a/crates/ui/src/composer/mod.rs
+++ b/crates/ui/src/composer/mod.rs
@@ -3,7 +3,7 @@
 //! the pending-approval panel (see docs/DESIGN.md "Composer").
 
 mod components;
-mod model;
+pub(crate) mod model;
 
 use components::images::PendingImage;
 #[cfg(target_os = "macos")]

--- a/crates/ui/src/composer/model.rs
+++ b/crates/ui/src/composer/model.rs
@@ -155,7 +155,7 @@ pub(super) fn parse_relative(spec: &str) -> Option<chrono::Duration> {
 
 /// Compact queue-strip countdown: hours retain an hour column, shorter waits
 /// use minutes and seconds.
-pub(super) fn format_countdown(secs: u64) -> String {
+pub(crate) fn format_countdown(secs: u64) -> String {
     let hours = secs / 3_600;
     let minutes = (secs % 3_600) / 60;
     let seconds = secs % 60;

--- a/crates/ui/src/gallery_support.rs
+++ b/crates/ui/src/gallery_support.rs
@@ -118,7 +118,7 @@ pub fn assistant(id: &str, markdown: Entity<MarkdownState>, cwd: &Path, cx: &App
 }
 
 pub fn error_card(id: &str, message: &str, cx: &App) -> AnyElement {
-    error_card::error_card(id, message, false, |_, _, _| {}, cx)
+    error_card::error_card(id, message, false, None, |_, _, _| {}, cx)
 }
 
 pub fn relay_divider(id: &str, cx: &App) -> AnyElement {

--- a/crates/ui/src/settings_page.rs
+++ b/crates/ui/src/settings_page.rs
@@ -800,6 +800,12 @@ impl SettingsPage {
                 this.dispatch_settings(|store| store.set_abort_on_model_fallback(true), cx)
             },
         );
+        let resume_on_limit_reset_reset = self.reset_action(
+            "reset-resume-on-limit-reset",
+            !settings.resume_on_limit_reset,
+            cx,
+            |this, _, cx| this.dispatch_settings(|store| store.set_resume_on_limit_reset(true), cx),
+        );
         let mut conversation = vec![
             self.title_generation_row(cx),
             self.toggle_row(
@@ -837,6 +843,15 @@ impl SettingsPage {
                 abort_on_fallback_reset,
                 cx,
                 WorkspaceStore::set_abort_on_model_fallback,
+            ),
+            self.toggle_row(
+                "resume-on-limit-reset",
+                crate::tr!("settings.resume_on_limit_reset.title"),
+                crate::tr!("settings.resume_on_limit_reset.description"),
+                settings.resume_on_limit_reset,
+                resume_on_limit_reset_reset,
+                cx,
+                WorkspaceStore::set_resume_on_limit_reset,
             ),
         ];
         if settings.abort_on_model_fallback {

--- a/crates/ui/src/store/intents.rs
+++ b/crates/ui/src/store/intents.rs
@@ -74,6 +74,9 @@ impl WorkspaceStore {
     pub fn set_abort_on_model_fallback(&mut self, value: bool) {
         self.patch_settings(SettingsPatch::AbortOnModelFallback(value));
     }
+    pub fn set_resume_on_limit_reset(&mut self, value: bool) {
+        self.patch_settings(SettingsPatch::ResumeOnLimitReset(value));
+    }
     pub fn set_fallback_review_advisor(&mut self, value: bool) {
         self.patch_settings(SettingsPatch::FallbackReviewAdvisor(value));
     }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -223,6 +223,8 @@ platform pays that inset.
   which is exactly how T3 Code ends up showing "Request was abo…" and then
   nothing. A failed provider start additionally leaves the unsent message in the
   queue strip (typed text is never destroyed by a dead process).
+  When a Claude usage window is exhausted, the card adds a resume row: either a
+  live reset countdown with Cancel, or a button to schedule the resume manually.
 - CHANGED FILES card per turn with provider-attributed file changes: Codex uses
   its replacement `turn/diff/updated` net snapshot; providers without that
   capability fold only successfully completed structured file-edit operations

--- a/docs/plans/resume-on-limit-reset.md
+++ b/docs/plans/resume-on-limit-reset.md
@@ -1,0 +1,39 @@
+# Resume after the Claude Code usage-limit reset
+
+When Claude Code rejects a turn because the account's 5-hour window is exhausted,
+the turn fails and the error lands on the timeline as an error card. This feature
+lets the session pick the task back up when the window resets.
+
+## Behaviour
+
+- **Settings → Conversation → "Resume when the usage limit resets"** (default on).
+- Claude Code emits `{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetsAt":<unix secs>,"rateLimitType":"five_hour",…}}`
+  before the failed `result`. The Claude adapter remembers `resetsAt` and, on the
+  failed result, emits `AgentEvent::UsageLimitReached { resets_at }` right after the
+  `AgentEvent::Error`.
+- The timeline folds `resets_at` into the preceding error entry
+  (`EntryContent::Error { message, limit_resets_at }`).
+- Runtime: when the toggle is on, the session schedules a turn with the text
+  `Continue from where you left off.` (Claude Code's own resume prompt) at
+  `resets_at`, via the existing scheduled-queue machinery (`push_scheduled` +
+  `reschedule_scheduled_wake`). Nothing is scheduled when the toggle is off.
+- Error card:
+  - a scheduled resume exists for this `resets_at` → "Resumes in H:MM:SS" countdown + **Cancel** (drops the queued message);
+  - no scheduled resume and `resets_at` is in the future → **Resume when limit resets** button (schedules the turn);
+  - otherwise the plain card.
+  The two states are a toggle: the card reads the composer queue, so cancel/resume
+  flip it without any new state.
+
+## Acceptance
+
+```sh
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test -p agent -p tcode-core -p tcode-runtime -p tcode-protocol -p tcode-ui
+```
+
+Named review questions:
+1. A `rate_limit_event` with `status: "rejected"` followed by a failed `result` yields `Error` then `UsageLimitReached { resets_at }` (adapter unit test).
+2. With the toggle on, `UsageLimitReached` puts exactly one scheduled queue entry at `resets_at` on the session; with it off, none (runtime test).
+3. Replaying a persisted transcript containing the new event sets `limit_resets_at` on the error entry and does not panic.
+4. The toggle is in both locales; the parity test passes.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -63,6 +63,10 @@ chat:
   scroll_end: "Scroll to end"
   copy: "Copy"
   copied: "Copied!"
+  limit_resume:
+    resumes_in: "Resumes in %{countdown}"
+    cancel: "Cancel"
+    schedule: "Resume when limit resets"
   steering: "Steering…"
   steered: "Steered"
   orchestrate_skill: "Orchestrate Skill"
@@ -241,6 +245,9 @@ settings:
   abort_on_model_fallback:
     title: "Abort on model fallback"
     description: "When on, tcode watches Claude Code's stream for safety-classifier fallbacks or flags and stops the turn at the conversation level, handing control back to you. Subagents are unaffected."
+  resume_on_limit_reset:
+    title: "Resume when the usage limit resets"
+    description: "When Claude Code stops a turn because the 5-hour usage window is exhausted, tcode schedules a resume for the moment the window resets. Off: the error card offers a button to schedule it by hand."
   fallback_review_advisor:
     title: "Fallback review advisor"
     description: "Use a separate model to review requests interrupted by Claude Code's fallback guard."

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -63,6 +63,10 @@ chat:
   scroll_end: "滚动到底部"
   copy: "复制"
   copied: "已复制！"
+  limit_resume:
+    resumes_in: "将在 %{countdown} 后继续"
+    cancel: "取消"
+    schedule: "额度恢复后继续"
   steering: "引导中…"
   steered: "已引导"
   orchestrate_skill: "编排技能"
@@ -241,6 +245,9 @@ settings:
   abort_on_model_fallback:
     title: "模型回退时中止"
     description: "开启后，tcode 会监控 Claude Code 的流，在检测到安全分类器回退或标记时从对话层面停止当前轮次，并将控制权交还给你。子代理不受影响。"
+  resume_on_limit_reset:
+    title: "额度重置后继续任务"
+    description: "当 Claude Code 因 5 小时用量窗口耗尽而停止本轮时，tcode 会在窗口重置的时刻自动继续任务。关闭后，错误卡片上会提供一个按钮供手动安排。"
   fallback_review_advisor:
     title: "回退审查顾问"
     description: "使用独立模型审查被 Claude Code 回退防护中断的请求。"


### PR DESCRIPTION
## Summary
- Claude adapter maps `rate_limit_event` (status `rejected`, `resetsAt`) into a new `UsageLimitReached` event emitted after the failed turn's error; the timeline folds the reset time into the error entry.
- New Settings → Conversation toggle **Resume when the usage limit resets** (default on) schedules Claude Code's own resume prompt at the reset via the existing scheduled queue.
- Error card shows a live countdown + Cancel while a resume is queued, or a **Resume when limit resets** button when none is queued (toggle off / cancelled).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p agent -p tcode-core -p tcode-runtime -p tcode-protocol -p tcode-ui` (new adapter, timeline, runtime tests; locale parity)
- [ ] Visual check of the card row when a real limit trips