### PR TITLE
fix(computer-use): never expose the host process as a root

### DIFF
--- a/crates/computer-use-mcp/src/backend.rs
+++ b/crates/computer-use-mcp/src/backend.rs
@@ -234,20 +234,26 @@ impl fmt::Display for BackendError {
 
 impl std::error::Error for BackendError {}
 
+/// Enumerate desktop roots. The host process is never a root: in-process
+/// accessibility queries run the host's own accessibility callbacks on the
+/// calling (non-main) thread, which aborts the app.
 pub fn list_roots(filters: &RootFilters) -> Result<Vec<RootInfo>, BackendError> {
+    let own_pid = std::process::id();
+    if filters.pid == Some(own_pid) {
+        return Err(BackendError::new(
+            BackendErrorCode::RootNotFound,
+            "the tcode host process cannot observe itself; launch a separate instance to drive it",
+        ));
+    }
     #[cfg(target_os = "macos")]
-    {
-        macos::MacosBackend.list_roots(filters)
-    }
+    let roots = macos::MacosBackend.list_roots(filters);
     #[cfg(target_os = "windows")]
-    {
-        windows::WindowsBackend.list_roots(filters)
-    }
+    let roots = windows::WindowsBackend.list_roots(filters);
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    {
-        let _ = filters;
-        Err(BackendError::unsupported())
-    }
+    let roots: Result<Vec<RootInfo>, BackendError> = Err(BackendError::unsupported());
+    let mut roots = roots?;
+    roots.retain(|root| root.pid != own_pid);
+    Ok(roots)
 }
 
 pub fn observe(root: &RootInfo, request: ObserveRequest) -> Result<RootObservation, BackendError> {

--- a/crates/computer-use-mcp/src/backend/macos/mod.rs
+++ b/crates/computer-use-mcp/src/backend/macos/mod.rs
@@ -62,7 +62,8 @@ impl MacosBackend {
             let window_id = dictionary_i64(dictionary, unsafe { kCGWindowNumber })
                 .and_then(|id| u32::try_from(id).ok())
                 .unwrap_or_default();
-            if pid == 0 || window_id == 0 {
+            // Skip our own windows before any AX query touches them.
+            if pid == 0 || window_id == 0 || pid == std::process::id() {
                 continue;
             }
             let app_name =


### PR DESCRIPTION
## Summary
- `computer_use` observing tcode's own window crashed the app with SIGABRT: AppKit serves in-process `AXUIElementCopyAttributeValue` on the calling tokio thread, which invokes gpui's accessibility callbacks off the main thread; the resulting panic crosses an `extern "C"` boundary and aborts.
- Exclude the host pid from `list_roots` (the single source of every root ref, including the frontmost fallback and `--cu-smoke`), skip own windows on macOS before any AX query, and return a clear error when `find_roots` is called with the host pid.

## Test plan
- `cargo fmt --all --check`
- `cargo clippy -p computer-use-mcp --all-targets --locked -- -D warnings`
- `cargo test -p computer-use-mcp --locked` (42 passed)