### PR TITLE
chore: depend on gpui-base git rev directly instead of a patch table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,3 @@ lto = "fat"
 codegen-units = 1
 strip = "symbols"
 panic = "unwind"
-
-[patch.crates-io]
-# gpui-base 0.6.0 on crates.io declares gpui-pre-platform as a dependency it
-# never uses, which does not compile for iOS/Android. Fixed on gpui-kit main
-# (merged 2026-09-05); drop this patch once a gpui-base release includes it.
-gpui-base = { git = "https://github.com/longbridge/gpui-kit", rev = "9d9bd9bfa9b4c3af25475078458b3e3c7abd2981" }

--- a/crates/mobile/Cargo.toml
+++ b/crates/mobile/Cargo.toml
@@ -19,7 +19,7 @@ gpui = { package = "gpui-pre", version = "=0.3.3", default-features = false }
 tcode-ui = { path = "../ui", default-features = false }
 tcode-core = { path = "../core", default-features = false }
 tcode-protocol = { path = "../protocol", default-features = false }
-gpui-base = "0.6.0"
+gpui-base = { git = "https://github.com/longbridge/gpui-kit", rev = "9d9bd9bfa9b4c3af25475078458b3e3c7abd2981" } # 0.6.0 on crates.io pulls an unused gpui-pre-platform that breaks iOS/Android; switch back once 0.6.1 ships
 chrono = "0.4"
 tcode-client = { path = "../client" }
 async-channel = "2"

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -46,7 +46,7 @@ term = { path = "../term", optional = true }
 preview-mcp = { path = "../preview-mcp", optional = true }
 computer-use-mcp = { path = "../computer-use-mcp", optional = true }
 gpui = { package = "gpui-pre", version = "0.3.1" }
-gpui-base = "0.6.0"
+gpui-base = { git = "https://github.com/longbridge/gpui-kit", rev = "9d9bd9bfa9b4c3af25475078458b3e3c7abd2981" } # 0.6.0 on crates.io pulls an unused gpui-pre-platform that breaks iOS/Android; switch back once 0.6.1 ships
 gpui-component-assets = { package = "gpui-kit-assets", version = "0.6.0" }
 gpui-component-macros = "0.6.0"
 image = { version = "0.25.10", default-features = false, features = ["png", "jpeg", "gif", "webp", "bmp", "tiff"] }


### PR DESCRIPTION
Only our own crates (tcode, tcode-ui, tcode-mobile) depend on gpui-base, so the `[patch.crates-io]` entry was pure indirection. The three dependencies now name the git rev directly. Cargo.lock is unchanged.

Local: fmt, clippy `--locked -D warnings`, wasm32 and aarch64-apple-ios-sim checks pass.