### PR TITLE
fix(codex): accept a steer only when the turn consumes it

### DIFF
--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -538,6 +538,7 @@ async fn actor_loop(
     );
     let claude_dir = config.claude_dir.clone();
     let mut tailers = HashMap::new();
+    let (tail_tx, tail_rx) = smol::channel::unbounded::<SubagentModelNotice>();
 
     // Set when the child died on its own (stdout EOF): only then do its exit
     // status and stderr tail belong in the close reason.
@@ -545,12 +546,26 @@ async fn actor_loop(
     let closed_reason: Option<String> = loop {
         // Race a UI command against the next stdout line. `or` biases toward the
         // command channel, which is fine: both channels make independent progress.
-        let sel = smol::future::or(async { Sel::Cmd(cmd_rx.recv().await.ok()) }, async {
-            Sel::Line(line_rx.recv().await.ok())
-        })
+        let sel = smol::future::or(
+            async { Sel::Cmd(cmd_rx.recv().await.ok()) },
+            smol::future::or(async { Sel::Line(line_rx.recv().await.ok()) }, async {
+                Sel::Tail(tail_rx.recv().await.ok())
+            }),
+        )
         .await;
 
         match sel {
+            Sel::Tail(notice) => {
+                // The sender side is owned by this loop, so it can't close.
+                let Some(notice) = notice else { continue };
+                for ev in mapper.note_subagent_model(&notice.parent_id, notice.model, notice.effort)
+                {
+                    if event_tx.send(ev).await.is_err() {
+                        let _ = child.kill();
+                        return;
+                    }
+                }
+            }
             Sel::Cmd(Some(command)) => {
                 if let ControlFlow::Break(reason) =
                     handle_command(command, &mut mapper, &mut stdin, &event_tx, &mut child).await
@@ -588,6 +603,7 @@ async fn actor_loop(
                     &mut tailers,
                     claude_dir.as_deref(),
                     &event_tx,
+                    &tail_tx,
                 )
                 .await;
             }
@@ -633,6 +649,15 @@ async fn actor_loop(
 enum Sel {
     Cmd(Option<SessionCommand>),
     Line(Option<String>),
+    Tail(Option<SubagentModelNotice>),
+}
+
+/// Model/effort observed in a tailed subagent transcript, handed back to the
+/// actor so the parent Subagent item is updated with its live status.
+pub(crate) struct SubagentModelNotice {
+    pub(crate) parent_id: String,
+    pub(crate) model: Option<String>,
+    pub(crate) effort: Option<String>,
 }
 
 enum TailControl {
@@ -645,6 +670,7 @@ async fn process_tail_requests(
     tailers: &mut HashMap<String, smol::channel::Sender<TailControl>>,
     claude_dir: Option<&Path>,
     event_tx: &smol::channel::Sender<AgentEvent>,
+    tail_tx: &smol::channel::Sender<SubagentModelNotice>,
 ) {
     for request in requests {
         match request {
@@ -660,8 +686,9 @@ async fn process_tail_requests(
                 tailers.insert(parent_id.clone(), control_tx);
                 let claude_dir = claude_dir.map(Path::to_path_buf);
                 let events = event_tx.clone();
+                let notices = tail_tx.clone();
                 smol::spawn(run_subagent_tail(
-                    parent_id, task_id, session_id, claude_dir, control_rx, events,
+                    parent_id, task_id, session_id, claude_dir, control_rx, events, notices,
                 ))
                 .detach();
             }
@@ -686,6 +713,7 @@ async fn run_subagent_tail(
     claude_dir: Option<PathBuf>,
     controls: smol::channel::Receiver<TailControl>,
     events: smol::channel::Sender<AgentEvent>,
+    notices: smol::channel::Sender<SubagentModelNotice>,
 ) {
     let mut path = None;
     let mut reader = None;
@@ -723,6 +751,15 @@ async fn run_subagent_tail(
                         if events.send(event).await.is_err() {
                             return;
                         }
+                    }
+                    if let Some((model, effort)) = reader.take_model() {
+                        let _ = notices
+                            .send(SubagentModelNotice {
+                                parent_id: parent_id.clone(),
+                                model,
+                                effort,
+                            })
+                            .await;
                     }
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
@@ -1054,7 +1091,10 @@ enum ToolItem {
     Subagent {
         agent_type: String,
         description: String,
+        status: ItemStatus,
         summary: Option<String>,
+        model: Option<String>,
+        effort: Option<String>,
     },
 }
 
@@ -1451,11 +1491,17 @@ impl Mapper {
             .and_then(Value::as_str)
             .filter(|id| !id.is_empty())
         {
-            return self
-                .child_mappers
-                .entry(parent_id.to_owned())
-                .or_insert_with(|| crate::subagent_tail::TranscriptMapper::new(parent_id))
-                .map_value(&msg);
+            let mut events = match crate::subagent_tail::model_and_effort(&msg) {
+                Some((model, effort)) => self.note_subagent_model(parent_id, model, effort),
+                None => Vec::new(),
+            };
+            events.extend(
+                self.child_mappers
+                    .entry(parent_id.to_owned())
+                    .or_insert_with(|| crate::subagent_tail::TranscriptMapper::new(parent_id))
+                    .map_value(&msg),
+            );
+            return events;
         }
         match msg.get("type").and_then(Value::as_str) {
             Some("system") => self.on_system(&msg),
@@ -1739,7 +1785,10 @@ impl Mapper {
         let Some(ToolItem::Subagent {
             agent_type,
             description,
+            status: saved_status,
             summary: saved_summary,
+            model,
+            effort,
         }) = self.tool_items.get_mut(tool_use_id)
         else {
             return Vec::new();
@@ -1747,6 +1796,7 @@ impl Mapper {
         if summary.is_some() {
             *saved_summary = summary;
         }
+        *saved_status = status;
         vec![AgentEvent::ItemUpdated(ThreadItem {
             id: tool_use_id.to_owned(),
             parent_item_id: None,
@@ -1755,8 +1805,38 @@ impl Mapper {
                 description: description.clone(),
                 status,
                 summary: saved_summary.clone(),
+                model: model.clone(),
+                effort: effort.clone(),
             },
         })]
+    }
+
+    /// Record the model/effort a child transcript reports for its spawn item
+    /// and re-emit the item when either changed.
+    pub(crate) fn note_subagent_model(
+        &mut self,
+        tool_use_id: &str,
+        model: Option<String>,
+        effort: Option<String>,
+    ) -> Vec<AgentEvent> {
+        let Some(ToolItem::Subagent {
+            status,
+            model: saved_model,
+            effort: saved_effort,
+            ..
+        }) = self.tool_items.get_mut(tool_use_id)
+        else {
+            return Vec::new();
+        };
+        let model = model.or_else(|| saved_model.clone());
+        let effort = effort.or_else(|| saved_effort.clone());
+        if model == *saved_model && effort == *saved_effort {
+            return Vec::new();
+        }
+        *saved_model = model;
+        *saved_effort = effort;
+        let status = *status;
+        self.update_subagent(tool_use_id, status, None)
     }
 
     fn on_stream_event(&mut self, msg: &Value) -> Vec<AgentEvent> {
@@ -1999,17 +2079,30 @@ impl Mapper {
                 .unwrap_or("subagent")
                 .to_owned();
             let description = subagent_description(&input);
+            // The Agent tool only carries a model alias when the caller picked
+            // one; the resolved model and effort arrive with the child's first
+            // assistant message.
+            let model = input
+                .get("model")
+                .and_then(Value::as_str)
+                .filter(|model| !model.is_empty())
+                .map(str::to_owned);
             (
                 ToolItem::Subagent {
                     agent_type: agent_type.clone(),
                     description: description.clone(),
+                    status: ItemStatus::InProgress,
                     summary: None,
+                    model: model.clone(),
+                    effort: None,
                 },
                 ItemContent::Subagent {
                     agent_type,
                     description,
                     status: ItemStatus::InProgress,
                     summary: None,
+                    model,
+                    effort: None,
                 },
             )
         } else if name == "Bash" {
@@ -2169,12 +2262,17 @@ impl Mapper {
                     agent_type,
                     description,
                     summary,
+                    model,
+                    effort,
+                    ..
                 } => ItemContent::Subagent {
                     agent_type,
                     description,
                     status,
                     summary: summary
                         .or_else(|| (!output.trim().is_empty()).then(|| one_line_summary(&output))),
+                    model,
+                    effort,
                 },
             };
             let event = if matches!(
@@ -4962,12 +5060,25 @@ mod tests {
                 _ => None,
             })
             .collect();
-        assert_eq!(spawn_events.len(), 5);
+        assert_eq!(spawn_events.len(), 6);
         assert!(matches!(
             &spawn_events[0].content,
-            ItemContent::Subagent { agent_type, description, status: ItemStatus::InProgress, summary: None }
+            ItemContent::Subagent { agent_type, description, status: ItemStatus::InProgress, summary: None, model: None, effort: None }
                 if agent_type == "general-purpose" && description == "Ping test"
         ));
+        // The child's first assistant message reveals the model and effort the
+        // subagent actually ran with; the spawn item re-emits with them.
+        assert!(matches!(
+            &spawn_events[2].content,
+            ItemContent::Subagent { status: ItemStatus::InProgress, model: Some(model), effort: Some(effort), .. }
+                if model == "claude-sonnet-5" && effort == "high"
+        ));
+        assert!(matches!(
+            &spawn_events.last().unwrap().content,
+            ItemContent::Subagent { model: Some(model), effort: Some(effort), .. }
+                if model == "claude-sonnet-5" && effort == "high"
+        ));
+
         assert!(spawn_events.iter().any(|item| matches!(
             &item.content,
             ItemContent::Subagent { status: ItemStatus::Completed, summary: Some(summary), .. }
@@ -4992,11 +5103,16 @@ mod tests {
                 _ => None,
             })
             .collect();
-        assert_eq!(children.len(), 1);
+        assert_eq!(children.len(), 2);
         assert!(matches!(
             &children[0].content,
             ItemContent::UserMessage { text, .. } if text.contains("Reply with pong")
         ));
+        assert!(matches!(
+            &children[1].content,
+            ItemContent::AssistantMessage { text } if text == "pong"
+        ));
+
         assert!(events.iter().all(|event| match event {
             AgentEvent::ItemStarted(item)
             | AgentEvent::ItemUpdated(item)

--- a/crates/agent/src/codex.rs
+++ b/crates/agent/src/codex.rs
@@ -426,6 +426,8 @@ struct CodexSubagent {
     agent_type: String,
     description: String,
     child_item_id: String,
+    model: Option<String>,
+    effort: Option<String>,
 }
 
 async fn run_actor(
@@ -1555,6 +1557,8 @@ impl Actor {
                             description: subagent.description.clone(),
                             status,
                             summary: summary.clone(),
+                            model: subagent.model.clone(),
+                            effort: subagent.effort.clone(),
                         };
                         if method == "item/completed" {
                             self.events
@@ -1566,6 +1570,8 @@ impl Actor {
                                         description: "child thread".into(),
                                         status,
                                         summary,
+                                        model: subagent.model.clone(),
+                                        effort: subagent.effort.clone(),
                                     },
                                 }))
                                 .await;
@@ -1712,12 +1718,17 @@ impl Actor {
             .or_else(|| activity.get("agentPath"))
             .and_then(Value::as_str)
             .unwrap_or("subagent");
-        let (agent_type, description) = self
+        let spawn_input = self
             .items
             .get(&parent_id)
             .or_else(|| self.items.get(activity_id))
             .and_then(|item| match &item.content {
-                ItemContent::ToolCall { input, .. } => Some((
+                ItemContent::ToolCall { input, .. } => Some(input),
+                _ => None,
+            });
+        let (agent_type, description) = spawn_input
+            .map(|input| {
+                (
                     input
                         .get("agent_type")
                         .or_else(|| input.get("subagent_type"))
@@ -1730,8 +1741,7 @@ impl Actor {
                         .and_then(Value::as_str)
                         .unwrap_or(path)
                         .to_owned(),
-                )),
-                _ => None,
+                )
             })
             .unwrap_or_else(|| {
                 (
@@ -1739,6 +1749,17 @@ impl Actor {
                     path.to_owned(),
                 )
             });
+        // spawn_agent only carries overrides; a child without them inherits the
+        // parent thread's model and effort.
+        let override_str = |key: &str| {
+            spawn_input
+                .and_then(|input| input.get(key))
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty())
+                .map(str::to_owned)
+        };
+        let model = override_str("model").or_else(|| self.model.clone());
+        let effort = override_str("reasoning_effort").or_else(|| self.effort.clone());
         let child_item_id = format!("{parent_id}:{thread_id}");
         let subagent = self
             .subagents
@@ -1747,6 +1768,8 @@ impl Actor {
                 agent_type,
                 description,
                 child_item_id,
+                model,
+                effort,
             })
             .clone();
         let status = match kind {
@@ -1762,6 +1785,8 @@ impl Actor {
                 description: subagent.description.clone(),
                 status,
                 summary: None,
+                model: subagent.model.clone(),
+                effort: subagent.effort.clone(),
             },
         };
         self.items.insert(parent_id.clone(), parent.clone());
@@ -1785,6 +1810,8 @@ impl Actor {
                 },
                 status,
                 summary: None,
+                model: subagent.model,
+                effort: subagent.effort,
             },
         };
         let event = match kind {
@@ -3349,7 +3376,7 @@ mod tests {
                     parent_item_id: None,
                     content: ItemContent::ToolCall {
                         name: "spawnAgent".into(),
-                        input: json!({"prompt":"Inspect protocol"}),
+                        input: json!({"prompt":"Inspect protocol", "reasoning_effort":"high"}),
                         output: None,
                         status: ItemStatus::Completed,
                     },
@@ -3363,17 +3390,22 @@ mod tests {
                 "kind": "started"
             }});
             actor.handle_notification("item/started", &started).await;
+            // Effort comes from the spawn override; the model is inherited from
+            // the parent thread because spawn_agent did not override it.
             assert!(matches!(
                 events.recv().await.unwrap(),
                 AgentEvent::ItemUpdated(ThreadItem {
                     id,
                     content: ItemContent::Subagent {
                         status: ItemStatus::InProgress,
+                        model: Some(model),
+                        effort: Some(effort),
                         ..
                     },
                     ..
-                }) if id == "call_spawn"
+                }) if id == "call_spawn" && model == "gpt-5-codex" && effort == "high"
             ));
+
             assert!(matches!(
                 events.recv().await.unwrap(),
                 AgentEvent::ItemStarted(ThreadItem {

--- a/crates/agent/src/codex.rs
+++ b/crates/agent/src/codex.rs
@@ -358,7 +358,7 @@ fn codex_service_tier(selections: &[OptionSelection]) -> Option<String> {
 enum PendingRequest {
     TurnStart,
     Interrupt,
-    Steer(String),
+    Steer { request_id: String, text: String },
 }
 
 struct PendingElicitation {
@@ -419,6 +419,11 @@ struct Actor {
     seen_subagent_activities: HashSet<String>,
     usage_by_turn: HashMap<String, TokenUsage>,
     active_turn: Option<String>,
+    /// Steers the server acknowledged but has not yet consumed, as
+    /// `(request_id, text)`. `turn/steer` only enqueues the input; the turn
+    /// loop drains it before its next model request and echoes it back as a
+    /// `userMessage` item, which is the real acceptance signal.
+    pending_steers: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone)]
@@ -485,6 +490,7 @@ async fn run_actor(
         seen_subagent_activities: HashSet::new(),
         usage_by_turn: HashMap::new(),
         active_turn: None,
+        pending_steers: Vec::new(),
     };
 
     let started = AgentEvent::SessionStarted {
@@ -697,7 +703,7 @@ impl SessionActor for Actor {
                         "expectedTurnId": turn_id,
                         "input": user_input(&text, &attachments),
                     }),
-                    PendingRequest::Steer(request_id),
+                    PendingRequest::Steer { request_id, text },
                 )
             }
             SessionCommand::Rewind {
@@ -1253,15 +1259,32 @@ impl Actor {
                             self.active_turn.get_or_insert_with(|| turn_id.to_owned());
                         }
                     }
-                    Some(PendingRequest::Steer(request_id)) => {
-                        self.events
-                            .emit(AgentEvent::SteerAccepted { request_id })
-                            .await;
+                    Some(PendingRequest::Steer { request_id, text }) => {
+                        self.pending_steers.push((request_id, text));
                     }
                     _ => {}
                 }
             }
         }
+    }
+
+    /// Codex echoes user input as a `userMessage` item only once the turn loop
+    /// has drained it into the model context. Match the echo's text against
+    /// the acknowledged steers (oldest first) rather than assuming FIFO, since
+    /// the turn's own prompt echo can land after a fast steer was sent.
+    async fn accept_echoed_steer(&mut self, item: &Value) {
+        let echoed = user_message_text(item);
+        let Some(position) = self
+            .pending_steers
+            .iter()
+            .position(|(_, text)| *text == echoed)
+        else {
+            return;
+        };
+        let (request_id, _) = self.pending_steers.remove(position);
+        self.events
+            .emit(AgentEvent::SteerAccepted { request_id })
+            .await;
     }
 
     /// A `turn/start` the runtime already accepted was rejected by the server
@@ -1519,6 +1542,12 @@ impl Actor {
                     .and_then(|item| item.get("type"))
                     .and_then(Value::as_str)
                 {
+                    Some("userMessage") => {
+                        if let Some(item) = item_value {
+                            self.accept_echoed_steer(item).await;
+                        }
+                        return;
+                    }
                     Some("plan") => {
                         if method == "item/completed"
                             && let Some(item) = item_value
@@ -1873,11 +1902,23 @@ fn user_input(text: &str, attachments: &[Attachment]) -> Value {
     Value::Array(input)
 }
 
+/// The text parts of a `userMessage` item's `content: UserInput[]`, joined in
+/// order; mirrors what [`user_input`] sent so a steer echo compares equal.
+fn user_message_text(item: &Value) -> String {
+    item.get("content")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|part| part.get("type").and_then(Value::as_str) == Some("text"))
+        .filter_map(|part| part.get("text").and_then(Value::as_str))
+        .collect()
+}
+
 fn pending_name(request: Option<&PendingRequest>) -> &'static str {
     match request {
         Some(PendingRequest::TurnStart) => "turn/start",
         Some(PendingRequest::Interrupt) => "turn/interrupt",
-        Some(PendingRequest::Steer(_)) => "turn/steer",
+        Some(PendingRequest::Steer { .. }) => "turn/steer",
         None => "unknown",
     }
 }
@@ -2533,6 +2574,7 @@ mod tests {
                 subagents: HashMap::new(),
                 subagent_parent_by_thread: HashMap::new(),
                 seen_subagent_activities: HashSet::new(),
+                pending_steers: Vec::new(),
                 usage_by_turn: HashMap::new(),
                 active_turn: None,
             },
@@ -2748,7 +2790,7 @@ mod tests {
     }
 
     #[test]
-    fn steer_acceptance_waits_for_successful_correlated_rpc_response() {
+    fn steer_acceptance_waits_for_the_consumed_user_message_echo() {
         smol::block_on(async {
             let (mut actor, events) = test_actor();
             actor.active_turn = Some("turn-1".into());
@@ -2760,10 +2802,6 @@ mod tests {
                 })
                 .await
                 .unwrap();
-            assert!(
-                events.try_recv().is_err(),
-                "request write is not acceptance"
-            );
             let ChildOutput::Line(request) = actor.lines.recv().await.unwrap() else {
                 panic!("expected echoed request")
             };
@@ -2772,10 +2810,35 @@ mod tests {
             actor
                 .handle_line(&json!({"id": id, "result": {"turnId": "turn-1"}}).to_string())
                 .await;
+            assert!(
+                events.try_recv().is_err(),
+                "the turn/steer reply only means the input was enqueued"
+            );
+
+            // The turn's own prompt echo arriving late must not be mistaken
+            // for the steer.
+            actor
+                .handle_line(&json!({"method":"item/started","params":{"threadId":"thread-1","item":{
+                    "type":"userMessage","id":"u0","content":[{"type":"text","text":"original prompt"}]
+                }}}).to_string())
+                .await;
+            assert!(events.try_recv().is_err());
+
+            for method in ["item/started", "item/completed"] {
+                actor
+                    .handle_line(&json!({"method":method,"params":{"threadId":"thread-1","item":{
+                        "type":"userMessage","id":"u1","content":[{"type":"text","text":"redirect"}]
+                    }}}).to_string())
+                    .await;
+            }
             assert!(matches!(
                 events.recv().await.unwrap(),
                 AgentEvent::SteerAccepted { ref request_id } if request_id == "steer-ok"
             ));
+            assert!(
+                events.try_recv().is_err(),
+                "one echo lifecycle accepts once"
+            );
 
             actor
                 .handle_command(SessionCommand::Steer {
@@ -2800,9 +2863,14 @@ mod tests {
                 events.recv().await.unwrap(),
                 AgentEvent::Error { .. }
             ));
+            actor
+                .handle_line(&json!({"method":"item/completed","params":{"threadId":"thread-1","item":{
+                    "type":"userMessage","id":"u2","content":[{"type":"text","text":"do not accept"}]
+                }}}).to_string())
+                .await;
             assert!(
                 events.try_recv().is_err(),
-                "RPC errors must not accept a steer"
+                "RPC errors must not accept a steer, even if matching text is echoed"
             );
 
             let _ = actor.child.kill();

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1257,7 +1257,14 @@ pub enum ItemContent {
         status: ItemStatus,
         /// Final one-line summary when finished.
         summary: Option<String>,
+        /// Model the provider ran the subagent on, once known.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
+        /// Reasoning effort the subagent ran with, once known.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        effort: Option<String>,
     },
+
     WebSearch {
         query: String,
     },

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1042,10 +1042,12 @@ pub enum AgentEvent {
     },
     /// Emitted only after the provider has consumed the correlated steer into
     /// its model context (or provided the strongest available consumption
-    /// signal when its protocol has no explicit acknowledgement). Claude uses
-    /// its next `status: requesting` checkpoint; a steer written microseconds
-    /// before that status can still miss the request, but this is the best
-    /// available signal without CLI protocol support.
+    /// signal when its protocol has no explicit acknowledgement). Codex echoes
+    /// the drained input as a `userMessage` item before its next model request;
+    /// the `turn/steer` reply alone only means the input was enqueued. Claude
+    /// uses its next `status: requesting` checkpoint; a steer written
+    /// microseconds before that status can still miss the request, but this is
+    /// the best available signal without CLI protocol support.
     SteerAccepted {
         request_id: String,
     },

--- a/crates/agent/src/subagent_tail.rs
+++ b/crates/agent/src/subagent_tail.rs
@@ -15,6 +15,8 @@ pub(crate) struct TranscriptMapper {
     parent_id: String,
     tools: HashMap<String, (String, Value)>,
     next_user_id: u64,
+    /// Latest model/effort seen on an assistant record, until taken.
+    model: Option<(Option<String>, Option<String>)>,
 }
 
 impl TranscriptMapper {
@@ -23,12 +25,16 @@ impl TranscriptMapper {
             parent_id: parent_id.into(),
             tools: HashMap::new(),
             next_user_id: 0,
+            model: None,
         }
     }
 
     pub(crate) fn map_value(&mut self, value: &Value) -> Vec<AgentEvent> {
         if should_skip(value) {
             return Vec::new();
+        }
+        if let Some(seen) = model_and_effort(value) {
+            self.model = Some(seen);
         }
         match value.get("type").and_then(Value::as_str) {
             Some("assistant") => self.map_assistant(value),
@@ -186,6 +192,11 @@ impl TailReader {
         }
     }
 
+    /// Model/effort observed since the last call, if any record carried them.
+    pub(crate) fn take_model(&mut self) -> Option<(Option<String>, Option<String>)> {
+        self.mapper.model.take()
+    }
+
     pub(crate) fn read_appended(&mut self) -> std::io::Result<Vec<AgentEvent>> {
         let mut file = File::open(&self.path)?;
         if file.metadata()?.len() < self.offset {
@@ -273,6 +284,23 @@ fn find_named_dir(root: &Path, name: &str, depth: usize) -> Option<PathBuf> {
         }
     }
     None
+}
+
+/// `(model, effort)` from an assistant record: `message.model` and the
+/// top-level `effort` that Claude writes to transcripts.
+pub(crate) fn model_and_effort(value: &Value) -> Option<(Option<String>, Option<String>)> {
+    if value.get("type").and_then(Value::as_str) != Some("assistant") {
+        return None;
+    }
+    let text = |value: Option<&Value>| {
+        value
+            .and_then(Value::as_str)
+            .filter(|text| !text.is_empty())
+            .map(str::to_owned)
+    };
+    let model = text(value.pointer("/message/model"));
+    let effort = text(value.get("effort"));
+    (model.is_some() || effort.is_some()).then_some((model, effort))
 }
 
 fn should_skip(value: &Value) -> bool {

--- a/crates/agent/tests/fixtures/claude/subagent_trace.jsonl
+++ b/crates/agent/tests/fixtures/claude/subagent_trace.jsonl
@@ -1,6 +1,7 @@
 {"type":"assistant","message":{"id":"msg-spawn","content":[{"type":"tool_use","id":"toolu_spawn_1","name":"Agent","input":{"description":"Ping test","prompt":"Reply with pong after checking the task.","subagent_type":"general-purpose","run_in_background":false}}]}}
 {"type":"system","subtype":"task_started","task_id":"task-synthetic-1","tool_use_id":"toolu_spawn_1","description":"Ping test","subagent_type":"general-purpose","task_type":"local_agent","prompt":"Reply with pong after checking the task.","session_id":"session-synthetic-1"}
 {"type":"user","parent_tool_use_id":"toolu_spawn_1","message":{"role":"user","content":"Reply with pong after checking the task."}}
+{"type":"assistant","parent_tool_use_id":"toolu_spawn_1","effort":"high","message":{"id":"msg-child-1","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"pong"}]}}
 {"type":"system","subtype":"task_updated","task_id":"task-synthetic-1","patch":{"status":"completed","end_time":1783944057211,"ignored":"value"}}
 {"type":"system","subtype":"task_notification","task_id":"task-synthetic-1","tool_use_id":"toolu_spawn_1","status":"completed","output_file":"/tmp/tcode-synthetic/tasks/task-synthetic-1.output","summary":"pong","usage":{"total_tokens":12,"tool_uses":0,"duration_ms":34}}
 {"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_spawn_1","content":"pong","is_error":false}]}}

--- a/crates/core/src/relay.rs
+++ b/crates/core/src/relay.rs
@@ -212,8 +212,10 @@ fn render_turn(number: usize, entries: &[&TimelineEntry], timeline: &Timeline) -
                 description,
                 status,
                 summary,
+                ..
             }) => {
                 let outcome = status_outcome(*status, summary.as_deref().unwrap_or(""));
+
                 activity(&mut body, agent_type, &one_line(description), &outcome);
             }
             EntryContent::Error { message, .. }

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -1365,6 +1365,8 @@ fn merge_content(existing: EntryContent, incoming: EntryContent) -> EntryContent
         (
             EntryContent::Item(ItemContent::Subagent {
                 summary: old_summary,
+                model: old_model,
+                effort: old_effort,
                 ..
             }),
             EntryContent::Item(ItemContent::Subagent {
@@ -1372,12 +1374,16 @@ fn merge_content(existing: EntryContent, incoming: EntryContent) -> EntryContent
                 description,
                 status,
                 summary,
+                model,
+                effort,
             }),
         ) => EntryContent::Item(ItemContent::Subagent {
             agent_type,
             description,
             status,
             summary: summary.or(old_summary),
+            model: model.or(old_model),
+            effort: effort.or(old_effort),
         }),
         (_, incoming) => incoming,
     }
@@ -2683,6 +2689,8 @@ mod tests {
                 description: "Ping test".into(),
                 status: ItemStatus::InProgress,
                 summary: None,
+                model: Some("opus".into()),
+                effort: None,
             },
         };
         let child = ThreadItem {
@@ -2700,6 +2708,8 @@ mod tests {
                 description: "Ping test".into(),
                 status: ItemStatus::Completed,
                 summary: Some("pong".into()),
+                model: None,
+                effort: Some("high".into()),
             },
             ..spawn.clone()
         };
@@ -2712,8 +2722,13 @@ mod tests {
         assert_eq!(timeline.entries[0].id, "spawn");
         assert!(matches!(
             &timeline.entries[0].content,
-            EntryContent::Item(ItemContent::Subagent { status: ItemStatus::Completed, summary: Some(summary), .. })
-                if summary == "pong"
+            EntryContent::Item(ItemContent::Subagent {
+                status: ItemStatus::Completed,
+                summary: Some(summary),
+                model: Some(model),
+                effort: Some(effort),
+                ..
+            }) if summary == "pong" && model == "opus" && effort == "high"
         ));
     }
 
@@ -2863,6 +2878,8 @@ mod tests {
                 description: "look around".into(),
                 status,
                 summary: None,
+                model: None,
+                effort: None,
             },
         }
     }

--- a/crates/runtime/src/app/tests.rs
+++ b/crates/runtime/src/app/tests.rs
@@ -48,6 +48,8 @@ fn provider_native_subagent_events_create_and_feed_read_only_mirror_session() {
                     description: "Inspect event routing\nand report".into(),
                     status: ItemStatus::InProgress,
                     summary: None,
+                    model: None,
+                    effort: None,
                 },
             }),
             cx,
@@ -95,6 +97,8 @@ fn provider_native_subagent_events_create_and_feed_read_only_mirror_session() {
                     description: "Inspect event routing\nand report".into(),
                     status: ItemStatus::Completed,
                     summary: Some("routing verified".into()),
+                    model: None,
+                    effort: None,
                 },
             }),
             cx,
@@ -293,6 +297,8 @@ fn native_mirror_parent_item(status: ItemStatus) -> AgentEvent {
             description: "Inspect routing".into(),
             status,
             summary: None,
+            model: None,
+            effort: None,
         },
     };
     if status == ItemStatus::InProgress {

--- a/crates/ui/examples/gallery.rs
+++ b/crates/ui/examples/gallery.rs
@@ -381,6 +381,8 @@ fn subagent_entry(id: &str, status: ItemStatus, summary: Option<&str>) -> Timeli
             description: "Review the extracted component fixtures".into(),
             status,
             summary: summary.map(str::to_string),
+            model: None,
+            effort: None,
         },
     )
 }

--- a/crates/ui/src/chat/components/subagent.rs
+++ b/crates/ui/src/chat/components/subagent.rs
@@ -18,6 +18,15 @@ use super::super::model::one_line;
 
 pub(crate) type ClickHandler = Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>;
 
+/// `model · effort` label for the row chip; `None` when neither is known.
+fn model_chip(model: &Option<String>, effort: &Option<String>) -> Option<String> {
+    let parts: Vec<&str> = [model, effort]
+        .into_iter()
+        .filter_map(|part| part.as_deref())
+        .collect();
+    (!parts.is_empty()).then(|| parts.join(" · "))
+}
+
 pub(crate) fn subagent_row(
     entry: &TimelineEntry,
     on_open: Option<ClickHandler>,
@@ -28,6 +37,8 @@ pub(crate) fn subagent_row(
         description,
         status,
         summary,
+        model,
+        effort,
     }) = &entry.content
     else {
         log::error!(
@@ -108,6 +119,19 @@ pub(crate) fn subagent_row(
         .text_size(px(13.))
         .child(lifecycle)
         .child(div().flex_none().font_medium().child(agent_type.clone()))
+        .when_some(model_chip(model, effort), |row, chip| {
+            row.child(
+                div()
+                    .flex_none()
+                    .px_2()
+                    .rounded(crate::material::radius_chip())
+                    .bg(cx.theme().muted.opacity(0.4))
+                    .text_color(muted)
+                    .font_family(cx.theme().mono_font_family.clone())
+                    .text_size(px(11.5))
+                    .child(chip),
+            )
+        })
         .child(
             div()
                 .min_w_0()

--- a/crates/ui/src/chat/model.rs
+++ b/crates/ui/src/chat/model.rs
@@ -1080,12 +1080,17 @@ fn hash_entry_shape(content: &EntryContent, hash: &mut DefaultHasher) {
             description,
             status,
             summary,
+            model,
+            effort,
         }) => {
             agent_type.len().hash(hash);
             description.len().hash(hash);
             std::mem::discriminant(status).hash(hash);
             summary.as_ref().map(String::len).hash(hash);
+            model.as_ref().map(String::len).hash(hash);
+            effort.as_ref().map(String::len).hash(hash);
         }
+
         EntryContent::Error {
             message,
             limit_resets_at,
@@ -1512,9 +1517,12 @@ mod tests {
                 description: "Inspect the protocol".into(),
                 status: ItemStatus::InProgress,
                 summary: None,
+                model: None,
+                effort: None,
             }),
         )];
         let running = index_turns(&turns, &entries, None, &HashSet::new());
+
         let mut completed_entries = entries;
         if let EntryContent::Item(ItemContent::Subagent {
             status, summary, ..


### PR DESCRIPTION
## Behaviour

Codex steers showed **Steered** the moment \`turn/steer\` was sent. That reply only confirms the app-server enqueued the input; the running turn consumes it later, before its next model request. Until then the message is still **Steering…** in reality.

Codex core (\`session/turn.rs\` → \`record_pending_input\` → \`record_user_prompt_and_emit_turn_item\`) echoes the drained input back as a \`userMessage\` item, so that echo is the real consumption signal. The Codex client now:

- keeps a successfully acknowledged steer as pending \`(request_id, text)\` instead of emitting \`SteerAccepted\` on the RPC reply;
- emits \`SteerAccepted\` when a parent-thread \`userMessage\` item echo's text matches a pending steer (oldest match first, so a late echo of the turn's own prompt is not mistaken for the steer);
- still refuses acceptance on an RPC error, even if matching text is later echoed.

The \`SteerAccepted\` contract doc in \`agent/src/lib.rs\` now describes the Codex signal alongside Claude's.

## Tests

\`steer_acceptance_waits_for_the_consumed_user_message_echo\` replaces the RPC-reply test and protects: no acceptance on the \`turn/steer\` reply, no acceptance on a non-matching \`userMessage\` echo, exactly one acceptance across the started/completed echo pair, and no acceptance after an RPC error.

## Checks run

- \`cargo fmt --all --check\` ✅
- \`cargo clippy --workspace --all-targets --locked -- -D warnings\` ✅
- \`cargo test --workspace --locked\` ✅
- Live probe against codex-cli 0.153.4: \`cargo run -p agent --example probe -- codex "Run sleep 30, then reply DONE" /tmp/smoke --steer "Stop and reply PONG"\` → \`SteerAccepted\` observed before \`TurnCompleted\`, marker PONG present, TurnStarted=1 TurnCompleted=1.
- Not run locally: Windows/Linux, iOS/Android/Web and \`cargo machete\` (CI).