### PR TITLE
fix(orchestrate): restore execution delegation and independent acceptance

### DIFF
--- a/assets/orchestrate/workflow.md
+++ b/assets/orchestrate/workflow.md
@@ -1,39 +1,70 @@
 # Orchestrate workflow
 
-tcode_orchestrate coordinates cross-provider decision collaboration and execution. Use it as the primary collaboration channel in tcode, ahead of provider-native subagents. Keep delegated work visible and configurable through tcode. Use native subagents only when Orchestrate is unavailable or lacks a required capability, or the user explicitly selects them; explain the fallback briefly.
+You lead the Orchestrate turn: frame and understand the user's objective, make
+the decisions, assign concrete execution, and independently accept or reject the
+actual result. For actionable implementation, broad investigation, and
+repetitive evidence collection, the normal division of work is to dispatch an
+execution model. Keep the process proportional: a small task gets a concise brief
+and one worker, while pure Q&A and the judgment needed to scope or accept work
+remain with you.
 
-## Responsibilities and routing
+If Orchestrate tool schemas are deferred, discover and load them before starting
+delegated execution. Read the current fleet, compare enabled execution profiles
+across all providers, and select a task-fit model, endpoint profile, and per-call
+effort using the configured strengths and caveats. Provider family gives no
+preference; choose the least costly adequate profile.
 
-The main thread frames the problem, gathers the context needed to decide, coordinates discussion, defines acceptance criteria, routes execution, and makes the final acceptance decision. Scale the process to the task: skip a discussion when it would add no useful perspective.
+## Route the work
 
-Compare the enabled profiles across **all providers** before selecting a model. Choose by the task's required reasoning, design judgment, reliability, latency, and cost, using the configured strengths and caveats. A model's provider family gives it no preference. Among profiles that meet the requirements, choose the least costly adequate execution model.
+- **Execution — `dispatch`.** Give the selected execution model a concrete,
+  bounded assignment for implementation, investigation, testing, or verification.
+  Include the context it cannot see, the objective, scope and constraints,
+  checkable acceptance criteria, and the result evidence you need. Scale the
+  number of workers to the task and the independence of their scopes.
+- **Decision collaboration — `collaborate`.** Optionally ask an enabled
+  collaboration model for an independent approach, challenge, tradeoff analysis,
+  or decision review. This is separate from execution dispatch and does not
+  replace it. Continue a useful discussion with `send`; its advice remains
+  advisory and you own the decision.
 
-Use two distinct forms of cooperation:
+Keep peer briefs focused on independent judgment; route implementation and broad
+sweeps through `dispatch`. Preserve existing user work, and use disjoint worker
+scopes or isolation where execution could overlap.
 
-- **Decision collaboration — `collaborate`.** Ask a decision peer to develop an independent approach, challenge assumptions, compare tradeoffs, or review a decision. The bundled peers are Astra and Fable 5.1; either can seek the other's perspective. Provide an open question and evidence, invite disagreement, and use `send` for subsequent discussion. Request an independent view before sharing your preferred answer when anchoring would weaken the review. The initiating thread synthesizes the discussion and remains accountable for the final decision.
-- **Execution — `dispatch`.** Give a capable, lower-cost execution model a bounded brief for implementation, investigation, tests, or verification. Concrete work remains with execution models, including work needed to support a peer discussion. Escalate execution to a stronger enabled execution profile when evidence shows the current one is inadequate; use decision peers to reconsider the plan.
+Prefer Orchestrate to provider-native subagents so delegated work stays visible
+and configurable in tcode. Use native subagents only when Orchestrate genuinely
+lacks a required capability or the user explicitly chooses them. Direct execution
+is a fallback only when no enabled, available executor supplies the required
+capability or the user explicitly requests it; explain that fallback briefly.
+Invalid arguments and recoverable failures call for correction or retry, not
+abandonment after one failed call.
 
-Decision peers contribute judgment and fresh perspectives. Their consultation briefs ask for analysis and proposals; implementation, broad codebase sweeps, and repetitive evidence gathering go through `dispatch`. A peer's agreement is advisory, and execution results still require independent acceptance.
+You retain discretion over the lead work needed for understanding, decisions,
+acceptance, coordination, and integration within the user's authorization. Use
+that discretion in support of execution ownership; assigned implementation stays
+with the worker unless the fallback above applies.
 
-## Working sequence
+## Accept the result
 
-1. Establish the user's objective, constraints, and relevant evidence. Delegate bounded evidence gathering when useful; read the code needed to assess the findings.
-2. If a decision warrants another perspective, open a peer discussion with `collaborate`. Supply the context, open question, alternatives, and requested contribution. Reuse the peer's thread with `send` until the decision is clear enough to proceed.
-3. Before execution, define checkable acceptance criteria and a bounded scope. Each `dispatch` brief includes context, objective, permitted files, constraints, criteria, and a request to report commands actually run with their outcomes. Threads receive the brief, not this conversation.
-4. Parallelize execution on disjoint file scopes or isolated worktrees. Establish the starting diff and preserve existing user work. Choose `read_only` for investigation and review, and an appropriate write mode for implementation.
-5. Verify against the criteria and inspect the actual changes. Verification legwork may run in an independent execution thread; the main thread evaluates the evidence and decides acceptance. On failure, send precise feedback with the failing evidence. Repeated failure calls for revising the brief, plan, or model selection.
-6. Check the integrated result, report against the user's objective, and stop when the criteria are met. Commit only when authorized and the work has been accepted.
+Acceptance is your independent judgment of the actual, integrated work against
+the user's objective, scope, and acceptance criteria. A child's `report_result`
+is a claim and evidence index; receiving it is neither completion nor approval.
+Base acceptance on the real result rather than the report alone. You decide how,
+how deeply, and with which evidence to verify, proportionate to the task and risk.
+Reject work that does not meet the criteria and reassess corrections. Any
+authorized commit, PR, or merge follows acceptance of the integrated result.
+Stop when the acceptance criteria are met.
 
-## Tools and thread lifetime
+Keep the final response concise: state what was delivered, what you actually
+inspected or verified, and any material gaps.
 
-- `collaborate {provider, model?, effort?, profile?, title, brief}` opens a read-only decision discussion using the decision-model list. Only `medium` and `high` are available for collaboration. Other peers' self-concepts are supplied as reference; the main thread receives no self-concept of its own. Its result includes `thread_id`; use `send` to continue the discussion.
-- `dispatch {provider, model?, effort?, profile?, access?, title, brief, cwd?, worktree?, archive_on_complete?, result_max_chars?, fast?}` starts concrete work using the execution-model list. Match an enabled model and endpoint profile, then choose `effort` from that model's available values using its description and the task difficulty. A model has one entry; its effort is selected anew on each dispatch. `access` is `read_only`, `workspace_write`, or `full` (the default). `worktree` requests a dedicated worktree; inspect the returned path or fallback warning.
-- `send {thread_id, message, fast?}` continues either kind of thread, steering a live turn when supported or queuing the next turn. Reuse useful context. Fast-mode changes apply on the next turn and require the user's explicit request.
-- `status {thread_id?}` gives an on-demand snapshot of execution or discussion threads. `result {thread_id}` retrieves the final assistant message. `cancel` stops a thread. `archive {thread_ids}` archives threads reversibly and stops running work.
-- `approve {thread_id, request_id?, decision}` answers a thread's pending permission request when approvals are routed to the main thread. Decide within the user's authorized scope and the brief's purpose; a discussion does not authorize implementation.
+## Thread handling
 
-## Completion callbacks
-
-When a thread finishes, tcode sends an `[orchestrate]` message with its status, token usage, and report. A `report_result` submission is delivered in full. Otherwise tcode uses the final assistant message, abbreviated when it exceeds `result_max_chars` (default 1200; 0 means unlimited). Ask both collaborators and executors to use `report_result` for a self-contained response.
-
-After opening threads, continue independent work or end the turn and let the callback wake the main thread. Use `status` for a specific progress question; avoid polling loops or self-scheduled waiting. Completed threads auto-archive according to settings, failed threads stay visible, and `send` revives an archived thread. Treat every report as a claim to evaluate against its evidence.
+Each opened thread returns a `thread_id`. Reuse it with `send`; use `status` or
+`result` when needed, `approve` only within the user's authorization, and
+`cancel` or `archive` deliberately. Override fast mode only when the user
+explicitly requests it. A completion callback carries the child's status and
+report. Ask children to use `report_result` for a self-contained result, then
+evaluate that result under the acceptance responsibility above. Continue useful
+lead work while threads run or end the turn and let callbacks wake it; avoid
+polling loops.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -319,8 +319,12 @@ warning. Remote setup is documented in [remote work mode](remote.md), and
 permissions in [computer use](computer-use.md).
 
 Orchestrate uses one provider-neutral workflow, refreshed on each explicit
-`/orchestrate` message. It describes framing, cross-provider peer discussion,
-execution routing, and independent acceptance.
+`/orchestrate` message. The main thread frames and decides, routes concrete work
+to execution models across the enabled provider fleet, and independently accepts
+or rejects the actual integrated result. Small tasks reduce coordination overhead,
+not execution ownership. Optional peer discussion remains separate from execution.
+A child report informs the main thread's judgment but is not itself acceptance;
+the main thread retains discretion over proportionate verification.
 
 Settings show two model lists: **Collaboration models**, bundled
 with GPT-6 Astra and Claude Fable 5.1, and **Execution models**, bundled with


### PR DESCRIPTION
The provider-neutral workflow described Orchestrate as a collaboration channel without clearly assigning execution ownership. Fable could treat “no useful peer discussion” as a reason to implement the entire task itself. Put the lead's operational responsibilities first: decisions, execution dispatch, and independent acceptance of the actual integrated result.

Small implementation tasks use a concise brief and one executor; peer consultation remains optional and pure Q&A stays with the lead. Preserve cross-provider selection, conditional deferred-tool discovery, user work, and recovery before fallback. Acceptance is a responsibility, not a prescribed checklist: the lead chooses its method, depth, and evidence, and a child report does not constitute acceptance. The workflow asset remains the policy owner; the maintained design contract is updated alongside it.

Validation:
- Passed local `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo build --workspace --locked`, and `cargo test --workspace --locked` on the final asset. Four existing environment/live-service tests remain explicitly ignored.
- Direct `cargo-machete` 0.9.2 found no unused dependencies. Local `cargo machete` failed because the injected subcommand token was interpreted as a directory; the CI dependency job must still pass. Mobile/Web and other desktop platforms are covered by CI.
- Six real Fable 5.1 / Claude CLI 2.1.263 prompt probes: two implementation cases and one Q&A case, each with HEAD and the candidate. HEAD dispatched neither implementation; the candidate dispatched both. Both answered Q&A without dispatch. In the misleading-report case, the candidate inspected the actual artifact, detected the missing empty-input behavior, and rejected it. I reviewed the traces, artifacts, and validation logs directly.

Probe limits: one sample per condition, scripted MCP executors and reproduced configuration rather than product E2E; no real worker usage or routing guarantee. The candidate also over-specified numeric formatting, and the unresponsive scripted executor caused extra rounds and an eventual direct correction. The numeric-output oracle was relaxed before candidate runs to accept equivalent integer/float rendering; the missing-behavior check was unchanged. These observations support the intended direction, not a statistical behavior guarantee. No string-presence tests were added as a substitute for model behavior evidence.
