### PR TITLE
fix(orchestrate): encourage parallel work and clarify lead integration

### DIFF
--- a/assets/orchestrate/workflow.md
+++ b/assets/orchestrate/workflow.md
@@ -20,7 +20,8 @@ preference; choose the least costly adequate profile.
   bounded assignment for implementation, investigation, testing, or verification.
   Include the context it cannot see, the objective, scope and constraints,
   checkable acceptance criteria, and the result evidence you need. Scale the
-  number of workers to the task and the independence of their scopes.
+  number of workers to the work that can advance concurrently and its dependencies;
+  trivial indivisible tasks do not need multiple workers.
 - **Decision collaboration — `collaborate`.** Optionally ask an enabled
   collaboration model for an independent approach, challenge, tradeoff analysis,
   or decision review. This is separate from execution dispatch and does not
@@ -28,8 +29,10 @@ preference; choose the least costly adequate profile.
   advisory and you own the decision.
 
 Keep peer briefs focused on independent judgment; route implementation and broad
-sweeps through `dispatch`. Preserve existing user work, and use disjoint worker
-scopes or isolation where execution could overlap.
+sweeps through `dispatch`. Proactively dispatch work that can advance concurrently.
+Overlapping file scopes are allowed and are not by themselves a reason to
+serialize work. Choose a shared workspace or isolation to fit the task; isolation
+is not required. Preserve existing user work and task outcomes.
 
 Prefer Orchestrate to provider-native subagents so delegated work stays visible
 and configurable in tcode. Use native subagents only when Orchestrate genuinely
@@ -42,7 +45,10 @@ abandonment after one failed call.
 You retain discretion over the lead work needed for understanding, decisions,
 acceptance, coordination, and integration within the user's authorization. Use
 that discretion in support of execution ownership; assigned implementation stays
-with the worker unless the fallback above applies.
+with the worker unless the fallback above applies. Integrating and reconciling
+parallel deliverables, including textual or semantic conflicts, is itself a valid
+bounded dispatch assignment. You retain decisions about competing intent and
+tradeoffs, and final acceptance of the integrated result.
 
 ## Accept the result
 

--- a/assets/orchestrate/workflow.md
+++ b/assets/orchestrate/workflow.md
@@ -30,9 +30,7 @@ preference; choose the least costly adequate profile.
 
 Keep peer briefs focused on independent judgment; route implementation and broad
 sweeps through `dispatch`. Proactively dispatch work that can advance concurrently.
-Overlapping file scopes are allowed and are not by themselves a reason to
-serialize work. Choose a shared workspace or isolation to fit the task; isolation
-is not required. Preserve existing user work and task outcomes.
+Preserve existing user work and task outcomes.
 
 Prefer Orchestrate to provider-native subagents so delegated work stays visible
 and configurable in tcode. Use native subagents only when Orchestrate genuinely
@@ -45,10 +43,9 @@ abandonment after one failed call.
 You retain discretion over the lead work needed for understanding, decisions,
 acceptance, coordination, and integration within the user's authorization. Use
 that discretion in support of execution ownership; assigned implementation stays
-with the worker unless the fallback above applies. Integrating and reconciling
-parallel deliverables, including textual or semantic conflicts, is itself a valid
-bounded dispatch assignment. You retain decisions about competing intent and
-tradeoffs, and final acceptance of the integrated result.
+with the worker unless the fallback above applies. You integrate parallel
+deliverables and resolve conflicts, retaining final acceptance of the integrated
+result.
 
 ## Accept the result
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -322,12 +322,12 @@ Orchestrate uses one provider-neutral workflow, refreshed on each explicit
 `/orchestrate` message. The main thread frames and decides, routes concrete work
 to execution models across the enabled provider fleet, and independently accepts
 or rejects the actual integrated result. Small tasks reduce coordination overhead,
-not execution ownership. Work that can advance concurrently may overlap files;
-the main thread chooses shared workspaces or isolation and may dispatch integration
-or conflict reconciliation while retaining decisions about intent, tradeoffs, and
-final acceptance. Optional peer discussion remains separate from execution. A
-child report informs the main thread's judgment but is not itself acceptance; the
-main thread retains discretion over proportionate verification.
+not execution ownership. Work that can advance concurrently is routed according
+to task dependencies; the main thread integrates parallel deliverables, resolves
+conflicts, and retains final acceptance of the integrated result. Optional peer
+discussion remains separate from execution. A child report informs the main
+thread's judgment but is not itself acceptance; the main thread retains discretion
+over proportionate verification.
 
 Settings show two model lists: **Collaboration models**, bundled
 with GPT-6 Astra and Claude Fable 5.1, and **Execution models**, bundled with

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -322,9 +322,12 @@ Orchestrate uses one provider-neutral workflow, refreshed on each explicit
 `/orchestrate` message. The main thread frames and decides, routes concrete work
 to execution models across the enabled provider fleet, and independently accepts
 or rejects the actual integrated result. Small tasks reduce coordination overhead,
-not execution ownership. Optional peer discussion remains separate from execution.
-A child report informs the main thread's judgment but is not itself acceptance;
-the main thread retains discretion over proportionate verification.
+not execution ownership. Work that can advance concurrently may overlap files;
+the main thread chooses shared workspaces or isolation and may dispatch integration
+or conflict reconciliation while retaining decisions about intent, tradeoffs, and
+final acceptance. Optional peer discussion remains separate from execution. A
+child report informs the main thread's judgment but is not itself acceptance; the
+main thread retains discretion over proportionate verification.
 
 Settings show two model lists: **Collaboration models**, bundled
 with GPT-6 Astra and Claude Fable 5.1, and **Execution models**, bundled with


### PR DESCRIPTION
Encourage Orchestrate to proactively dispatch work that can advance concurrently, with worker count guided by tasks and dependencies. Remove the existing file-scope restriction from the workflow. The lead integrates parallel deliverables and resolves conflicts.

The lead retains decisions about intent and tradeoffs, along with independent acceptance of the integrated result and discretion over how to perform it. Preserve existing user work and task outcomes. The matching design contract is updated; the implementation remains a focused change to the workflow asset and its documentation.

Validation:
- Based on `main` in an independent worktree; changes are limited to `assets/orchestrate/workflow.md` and `docs/DESIGN.md`.
- Passed `git diff --check`, `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo build --workspace --locked`, and `cargo test --workspace --locked` after the final wording correction.
- Direct `cargo-machete` 0.9.2 found no unused dependencies before the wording correction; Cargo manifests are unchanged. This was the direct binary invocation, not `cargo machete`.
- Existing environment-dependent tests remain ignored. Mobile/Web and other desktop platforms are left to CI. Existing macOS linker and third-party future-incompatibility notices remain non-failing.
- No new tests or live-model probes were added for this wording change. These checks establish repository compatibility, not guaranteed parallel-dispatch or conflict-resolution behavior.
