### PR TITLE
test: verify CI scope routing for #351 (do not merge)

### DIFF
--- a/crates/headless/src/main.rs
+++ b/crates/headless/src/main.rs
@@ -256,3 +256,5 @@ fn wait_for_interrupt() {
     use std::io::Read as _;
     let _ = std::io::stdin().read(&mut [0_u8]);
 }
+
+// Temporary CI scope probe; this branch is never merged.

--- a/docs/ci-scope-probe.md
+++ b/docs/ci-scope-probe.md
@@ -1,0 +1,1 @@
+Temporary documentation-only CI scope probe. This branch is never merged.


### PR DESCRIPTION
Temporary integration probe for #351. First validate that documentation changes skip all five named required jobs. Then validate a scoped Rust change. This PR will be closed and its branch deleted after evidence is collected; it will never be merged.