### PR TITLE
fix(terminal): mobile Backspace, scrollable key bar, keyboard reopen

### DIFF
--- a/crates/android/src/lib.rs
+++ b/crates/android/src/lib.rs
@@ -63,7 +63,9 @@ pub fn android_main(app: android_activity::AndroidApp) {
                 host.clone(),
                 // System bars, display cutout and the IME. Android schedules a
                 // frame whenever they change, so the shell never polls.
-                WindowSeam::new(gpui_android::insets).with_lifecycle(gpui_android::platform()),
+                WindowSeam::new(gpui_android::insets)
+                    .with_lifecycle(gpui_android::platform())
+                    .with_soft_keyboard(gpui_android::show_keyboard),
                 ShellOptions {
                     window: WindowOptions {
                         // The activity owns the geometry; the shell reads it back.

--- a/crates/ios/src/entry.rs
+++ b/crates/ios/src/entry.rs
@@ -29,7 +29,9 @@ pub extern "C" fn tcode_ios_start() {
                     host.clone(),
                     // UIKit's safe area and keyboard frame. The platform
                     // schedules a frame whenever either changes.
-                    WindowSeam::new(gpui_ios::insets).with_lifecycle(gpui_ios::platform()),
+                    WindowSeam::new(gpui_ios::insets)
+                        .with_lifecycle(gpui_ios::platform())
+                        .with_soft_keyboard(|| gpui_ios::set_keyboard_visible(true)),
                     ShellOptions {
                         window: WindowOptions {
                             // UIKit owns the geometry; the shell reads it back.

--- a/crates/platform/gpui-android/src/android/mod.rs
+++ b/crates/platform/gpui-android/src/android/mod.rs
@@ -66,3 +66,5 @@ pub fn insets() -> gpui::WindowInsets {
             .unwrap_or_default()
     })
 }
+
+pub(crate) use host::show_keyboard;

--- a/crates/platform/gpui-android/src/android/window.rs
+++ b/crates/platform/gpui-android/src/android/window.rs
@@ -340,7 +340,7 @@ impl AndroidWindow {
                 self.with_input_handler(PlatformInputHandler::unmark_text);
             }
             host::HostEvent::DeleteBackward => {
-                self.with_input_handler(crate::text_input::delete_backward);
+                self.delete_backward();
             }
             host::HostEvent::Key {
                 key_code,
@@ -358,6 +358,27 @@ impl AndroidWindow {
             host::HostEvent::Back => {
                 self.handle_back();
             }
+        }
+    }
+
+    fn delete_backward(&self) {
+        let mut handled = false;
+        self.with_input_handler(|handler| {
+            handled = crate::text_input::delete_backward(handler);
+        });
+        // Terminal handlers accept committed text but expose no editable buffer.
+        // Release the handler borrow before dispatching to the focused view.
+        if !handled {
+            let keystroke = Keystroke {
+                key: "backspace".into(),
+                key_char: None,
+                modifiers: Modifiers::default(),
+            };
+            self.dispatch_input(PlatformInput::KeyDown(crate::text_input::ime_key_down(
+                keystroke.clone(),
+                false,
+            )));
+            self.dispatch_input(PlatformInput::KeyUp(KeyUpEvent { keystroke }));
         }
     }
 
@@ -491,7 +512,7 @@ impl AndroidWindow {
         let key_code = Keycode::from(key_code as u32);
         if key_code == Keycode::Del && meta_state & (0x2 | 0x1000 | 0x10000) == 0 {
             if down {
-                self.with_input_handler(crate::text_input::delete_backward);
+                self.delete_backward();
             }
             return;
         }

--- a/crates/platform/gpui-android/src/lib.rs
+++ b/crates/platform/gpui-android/src/lib.rs
@@ -43,3 +43,9 @@ static FIRST_FRAME_RENDERED: std::sync::atomic::AtomicBool =
 pub fn first_frame_rendered() -> bool {
     FIRST_FRAME_RENDERED.load(std::sync::atomic::Ordering::Acquire)
 }
+
+/// Reopen the software keyboard after an explicit tap, even when focus is unchanged.
+#[cfg(target_os = "android")]
+pub fn show_keyboard() {
+    android::show_keyboard();
+}

--- a/crates/platform/gpui-android/src/text_input.rs
+++ b/crates/platform/gpui-android/src/text_input.rs
@@ -17,20 +17,34 @@ fn delete_from_composition(text: &str, range: Range<usize>) -> (String, Range<us
     (String::from_utf16_lossy(&units), cursor..cursor)
 }
 
-#[cfg(target_os = "android")]
-pub(crate) fn delete_backward(handler: &mut gpui::PlatformInputHandler) {
-    let Some(selection) = handler.selected_text_range(true) else {
-        return;
-    };
-    let mut range = selection.range;
+// None distinguishes a key-oriented handler from an empty editable field.
+fn backward_delete_range(
+    selection: Option<Range<usize>>,
+    mut text_before: impl FnMut(usize) -> Option<String>,
+) -> Option<Range<usize>> {
+    let range = selection?;
     if range.is_empty() {
-        let Some(text) = handler.text_for_range(0..range.start, &mut None) else {
-            return;
-        };
-        range = previous_grapheme_range(&text, range.start);
+        Some(previous_grapheme_range(
+            &text_before(range.start)?,
+            range.start,
+        ))
+    } else {
+        Some(range)
     }
+}
+
+#[cfg(target_os = "android")]
+pub(crate) fn delete_backward(handler: &mut gpui::PlatformInputHandler) -> bool {
+    let selection = handler
+        .selected_text_range(true)
+        .map(|selection| selection.range);
+    let Some(range) = backward_delete_range(selection, |cursor| {
+        handler.text_for_range(0..cursor, &mut None)
+    }) else {
+        return false;
+    };
     if range.is_empty() {
-        return;
+        return true;
     }
     if let Some(marked) = handler.marked_text_range()
         && marked.start <= range.start
@@ -44,6 +58,7 @@ pub(crate) fn delete_backward(handler: &mut gpui::PlatformInputHandler) {
     } else {
         handler.replace_text_in_range(Some(range), "");
     }
+    true
 }
 
 /// Plain multiline Enter is text; other control keys must still reach bindings.
@@ -65,6 +80,29 @@ pub(crate) fn ime_key_down(mut keystroke: Keystroke, multi_line: bool) -> KeyDow
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn terminal_and_absent_text_fields_fall_back_to_control_keystrokes() {
+        assert_eq!(backward_delete_range(None, |_| None), None);
+        assert_eq!(backward_delete_range(Some(0..0), |_| None), None);
+        // An empty editor consumes deletion; it must not receive a second key.
+        assert_eq!(
+            backward_delete_range(Some(0..0), |_| Some(String::new())),
+            Some(0..0)
+        );
+        for key in ["backspace", "enter", "left", "right", "up", "down"] {
+            let event = ime_key_down(
+                Keystroke {
+                    key: key.into(),
+                    key_char: None,
+                    modifiers: Default::default(),
+                },
+                false,
+            );
+            assert_eq!(event.keystroke.key, key);
+            assert!(!event.prefer_character_input);
+        }
+    }
 
     #[test]
     fn multiline_ime_enter_inserts_newline_while_single_line_runs_action() {

--- a/crates/platform/gpui-ios/src/ios/window.rs
+++ b/crates/platform/gpui-ios/src/ios/window.rs
@@ -413,9 +413,12 @@ impl IosWindow {
         };
         let input = if down {
             PlatformInput::KeyDown(KeyDownEvent {
+                prefer_character_input: keystroke.key_char.is_some()
+                    && !modifiers.control
+                    && !modifiers.alt
+                    && !modifiers.platform,
                 keystroke,
                 is_held: repeat,
-                prefer_character_input: true,
             })
         } else {
             PlatformInput::KeyUp(KeyUpEvent { keystroke })

--- a/crates/ui/src/terminal_drawer.rs
+++ b/crates/ui/src/terminal_drawer.rs
@@ -939,6 +939,7 @@ impl TerminalDrawer {
         cx: &mut Context<Self>,
     ) {
         self.focus_handle.focus(window, cx);
+        crate::window_seam::WindowSeam::request_soft_keyboard(cx);
         let Some((point, side)) = self.grid_point_and_side(terminal_id, event.position) else {
             return;
         };
@@ -2567,6 +2568,47 @@ mod tests {
             ..TerminalFrame::default()
         });
         model
+    }
+
+    #[gpui::test]
+    fn tapping_an_already_focused_terminal_requests_the_keyboard(cx: &mut gpui::TestAppContext) {
+        use crate::window_seam::WindowSeam;
+        use std::cell::Cell;
+        let requests = Rc::new(Cell::new(0));
+        let observed = requests.clone();
+        cx.update(|cx| {
+            crate::theme::init(cx);
+            cx.set_global(
+                WindowSeam::new(Default::default).with_soft_keyboard(move || {
+                    observed.set(observed.get() + 1);
+                }),
+            );
+        });
+        let (outgoing, _commands) = async_channel::unbounded();
+        let (_events, incoming) = async_channel::unbounded();
+        let store =
+            cx.new(|cx| WorkspaceStore::new(tcode_client::HostLink::new(outgoing, incoming), cx));
+        let (drawer, cx) = cx.add_window_view(|window, cx| TerminalDrawer::new(store, window, cx));
+        cx.update(|window, cx| {
+            drawer.update(cx, |drawer, cx| {
+                drawer.focus_handle.focus(window, cx);
+                assert!(drawer.focus_handle.is_focused(window));
+                drawer.terminal_mouse_down(
+                    1,
+                    &MouseDownEvent {
+                        button: MouseButton::Left,
+                        position: point(px(20.), px(20.)),
+                        modifiers: Default::default(),
+                        click_count: 1,
+                        first_mouse: false,
+                    },
+                    window,
+                    cx,
+                );
+                assert!(drawer.focus_handle.is_focused(window));
+            })
+        });
+        assert_eq!(requests.get(), 1);
     }
 
     #[test]

--- a/crates/ui/src/terminal_drawer.rs
+++ b/crates/ui/src/terminal_drawer.rs
@@ -710,13 +710,11 @@ impl TerminalDrawer {
         }
         let mut handled = false;
         self.with_terminal(cx, |terminal| {
-            if let Some(bytes) = mappings::key_bytes(
-                &keystroke.key,
-                term_modifiers(keystroke.modifiers),
+            if let Some(bytes) = terminal_key_bytes(
+                keystroke,
                 terminal.mode(),
                 terminal.keyboard_mode(),
                 terminal.modify_other_keys(),
-                true,
             ) {
                 terminal.write_input(bytes);
                 handled = true;
@@ -2406,6 +2404,22 @@ fn prepare_terminal_paste(text: &str, bracketed_paste: bool) -> String {
     }
 }
 
+fn terminal_key_bytes(
+    keystroke: &gpui::Keystroke,
+    mode: Mode,
+    keyboard_mode: tcode_protocol::terminal::KeyboardModes,
+    modify_other_keys: Option<u8>,
+) -> Option<Vec<u8>> {
+    mappings::key_bytes(
+        &keystroke.key,
+        term_modifiers(keystroke.modifiers),
+        mode,
+        keyboard_mode,
+        modify_other_keys,
+        true,
+    )
+}
+
 fn term_modifiers(modifiers: gpui::Modifiers) -> TermModifiers {
     TermModifiers {
         shift: modifiers.shift,
@@ -2553,6 +2567,23 @@ mod tests {
             ..TerminalFrame::default()
         });
         model
+    }
+
+    #[test]
+    fn backspace_keystroke_emits_delete_to_the_terminal_pipe() {
+        assert_eq!(
+            terminal_key_bytes(
+                &gpui::Keystroke {
+                    key: "backspace".into(),
+                    key_char: None,
+                    modifiers: Default::default()
+                },
+                Mode::empty(),
+                tcode_protocol::terminal::KeyboardModes::NO_MODE,
+                None,
+            ),
+            Some(vec![0x7f])
+        );
     }
 
     #[test]

--- a/crates/ui/src/terminal_key_bar.rs
+++ b/crates/ui/src/terminal_key_bar.rs
@@ -12,7 +12,7 @@ use gpui::{
     ParentElement as _, Render, Role, StatefulInteractiveElement as _, Styled as _, Window, div,
     prelude::FluentBuilder as _, px,
 };
-use gpui_base::{StyledExt as _, h_flex, v_flex};
+use gpui_base::{StyledExt as _, h_flex};
 use tcode_protocol::terminal::{
     KeyboardModes, TerminalMode,
     mappings::{self, Modifiers},
@@ -203,6 +203,7 @@ impl TerminalKeyBar {
         let label = label.into();
         let focus = self.terminal_focus.clone();
         material::accessible_clickable(div(), id, Role::Button, accessibility_label, cx)
+            .debug_selector(move || id.into())
             .flex_none()
             .size(px(material::TOUCH_TARGET))
             .flex()
@@ -230,6 +231,7 @@ impl TerminalKeyBar {
     ) -> impl IntoElement {
         let focus = self.terminal_focus.clone();
         material::accessible_clickable(div(), id, Role::Button, accessibility_label, cx)
+            .debug_selector(move || id.into())
             .aria_selected(selected)
             .flex_none()
             .size(px(material::TOUCH_TARGET))
@@ -318,9 +320,9 @@ impl Render for TerminalKeyBar {
                 TerminalKey::Right,
             ),
         ];
-        let mut fixed = fixed;
+        let mut tail = h_flex().flex_none().pr(px(16.));
         for (id, label, translation, key) in arrows {
-            fixed = fixed.child(self.key_button(
+            tail = tail.child(self.key_button(
                 id,
                 label,
                 crate::tr!(translation).into_owned(),
@@ -345,7 +347,7 @@ impl Render for TerminalKeyBar {
                 TerminalKey::Control('d'),
             ),
         ] {
-            fixed = fixed.child(self.key_button(
+            tail = tail.child(self.key_button(
                 id,
                 label,
                 crate::tr!(translation).into_owned(),
@@ -354,9 +356,8 @@ impl Render for TerminalKeyBar {
             ));
         }
 
-        let mut symbols = h_flex().flex_none();
         for (id, symbol) in SYMBOL_KEYS {
-            symbols = symbols.child(self.key_button(
+            tail = tail.child(self.key_button(
                 id,
                 symbol.to_string(),
                 crate::tr!("terminal.key_symbol", symbol = symbol).into_owned(),
@@ -372,19 +373,23 @@ impl Render for TerminalKeyBar {
             .aria_label(crate::tr!("terminal.key_bar"))
             .flex_none()
             .w_full()
+            .min_w_0()
+            .overflow_hidden()
             .h(px(KEY_BAR_HEIGHT))
             .border_t_1()
             .border_color(cx.theme().border)
             .bg(cx.theme().popover)
             .child(fixed)
             .child(
-                v_flex()
-                    .id("terminal-key-symbol-scroll")
+                h_flex()
+                    .id("terminal-key-scroll")
+                    .debug_selector(|| "terminal-key-scroll".into())
                     .flex_1()
                     .min_w_0()
                     .h_full()
+                    .overflow_y_hidden()
                     .touch_overflow_x_scroll()
-                    .child(symbols),
+                    .child(tail),
             )
     }
 }
@@ -506,6 +511,74 @@ mod tests {
             ),
             vec![0x1b]
         );
+    }
+
+    struct NarrowBarProbe {
+        width: f32,
+        bar: Entity<TerminalKeyBar>,
+    }
+
+    impl Render for NarrowBarProbe {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            crate::touch_scroll::root(div().w(px(self.width)).child(self.bar.clone()))
+        }
+    }
+
+    #[gpui::test]
+    fn phone_bar_scrolls_without_losing_pinned_keys_or_vertical_motion(cx: &mut TestAppContext) {
+        use gpui::{PlatformInput, TouchEvent, TouchId, TouchPhase, point};
+        cx.update(crate::theme::init);
+        for width in [360., 393.] {
+            let (_, cx) = cx.add_window_view(|_, cx| NarrowBarProbe {
+                width,
+                bar: cx.new(|cx| TerminalKeyBar::new(cx.focus_handle())),
+            });
+            cx.update(|window, cx| {
+                let _ = window.draw(cx);
+            });
+            let viewport = cx.debug_bounds("terminal-key-scroll").unwrap();
+            let pinned = cx.debug_bounds("terminal-key-escape").unwrap();
+            let first = cx.debug_bounds("terminal-key-left").unwrap();
+            let last = cx.debug_bounds("terminal-key-underscore").unwrap();
+            assert_eq!(
+                cx.debug_bounds("terminal-key-bar").unwrap().size.width,
+                px(width)
+            );
+            assert_eq!(pinned.size.width, px(44.));
+            assert_eq!(pinned.size.height, px(44.));
+            assert!(
+                last.right() > viewport.right(),
+                "content must exceed the viewport"
+            );
+            assert!(viewport.right() <= px(width));
+            let send = |phase, x, y, cx: &mut VisualTestContext| {
+                cx.update(|window, cx| {
+                    window.dispatch_event(
+                        PlatformInput::Touch(TouchEvent {
+                            id: TouchId(1),
+                            phase,
+                            position: point(px(x), px(y)),
+                            predicted_position: None,
+                            force: None,
+                        }),
+                        cx,
+                    );
+                    let _ = window.draw(cx);
+                });
+            };
+            send(TouchPhase::Started, width - 20., 20., cx);
+            send(TouchPhase::Moved, 190., 20., cx);
+            send(TouchPhase::Cancelled, 190., 20., cx);
+            let moved = cx.debug_bounds("terminal-key-left").unwrap();
+            assert!(moved.left() < first.left(), "horizontal swipe must scroll");
+            assert_eq!(moved.top(), first.top());
+            assert_eq!(cx.debug_bounds("terminal-key-escape").unwrap(), pinned);
+            send(TouchPhase::Started, 190., 20., cx);
+            send(TouchPhase::Moved, width + 300., 20., cx);
+            send(TouchPhase::Cancelled, width + 300., 20., cx);
+            assert_eq!(cx.debug_bounds("terminal-key-left").unwrap(), first);
+
+        }
     }
 
     struct KeyBarProbe {

--- a/crates/ui/src/terminal_key_bar.rs
+++ b/crates/ui/src/terminal_key_bar.rs
@@ -215,6 +215,7 @@ impl TerminalKeyBar {
             .hover(|style| style.bg(cx.theme().accent))
             .on_click(cx.listener(move |_, _, window, cx| {
                 focus.focus(window, cx);
+                crate::window_seam::WindowSeam::request_soft_keyboard(cx);
                 cx.emit(TerminalKeyBarEvent(key));
             }))
             .child(label)
@@ -257,6 +258,7 @@ impl TerminalKeyBar {
                     this.encoder.modifiers.alt = !this.encoder.modifiers.alt;
                 }
                 focus.focus(window, cx);
+                crate::window_seam::WindowSeam::request_soft_keyboard(cx);
                 cx.notify();
             }))
             .child(label)
@@ -528,6 +530,14 @@ mod tests {
     fn phone_bar_scrolls_without_losing_pinned_keys_or_vertical_motion(cx: &mut TestAppContext) {
         use gpui::{PlatformInput, TouchEvent, TouchId, TouchPhase, point};
         cx.update(crate::theme::init);
+        let requests = std::rc::Rc::new(std::cell::Cell::new(0));
+        let observed = requests.clone();
+        cx.update(|cx| {
+            cx.set_global(
+                crate::window_seam::WindowSeam::new(Default::default)
+                    .with_soft_keyboard(move || observed.set(observed.get() + 1)),
+            )
+        });
         for width in [360., 393.] {
             let (_, cx) = cx.add_window_view(|_, cx| NarrowBarProbe {
                 width,
@@ -577,7 +587,9 @@ mod tests {
             send(TouchPhase::Moved, width + 300., 20., cx);
             send(TouchPhase::Cancelled, width + 300., 20., cx);
             assert_eq!(cx.debug_bounds("terminal-key-left").unwrap(), first);
-
+            let before = requests.get();
+            cx.simulate_click(pinned.center(), gpui::Modifiers::default());
+            assert_eq!(requests.get(), before + 1, "key-bar taps reopen the IME");
         }
     }
 

--- a/crates/ui/src/touch_scroll.rs
+++ b/crates/ui/src/touch_scroll.rs
@@ -208,8 +208,17 @@ fn install(window: &mut Window) {
         if phase.capture()
             && let Some(mut capture) = registry(window, cx).take_scroll(event)
         {
+            let delta = event.delta.pixel_delta(window.line_height());
+            if let Handle::Scroll(handle) = &capture.target.handle {
+                let max = handle.max_offset();
+                // A horizontal strip must leave vertical gestures to the view
+                // underneath instead of swallowing them at its zero Y limit.
+                if max.x > px(0.) && max.y == px(0.) && delta.y.abs() > delta.x.abs() {
+                    return;
+                }
+            }
             let frame = registry(window, cx).frame;
-            capture.apply(event.delta.pixel_delta(window.line_height()), frame, cx);
+            capture.apply(delta, frame, cx);
             registry(window, cx).finish_scroll(capture, event.touch_phase);
             window.refresh();
             cx.stop_propagation();

--- a/crates/ui/src/window_seam.rs
+++ b/crates/ui/src/window_seam.rs
@@ -23,6 +23,7 @@ pub const COMPACT_BREAKPOINT: f32 = 900.;
 pub struct WindowSeam {
     insets: Rc<dyn Fn() -> WindowInsets>,
     lifecycle: Option<Rc<dyn gpui::Platform>>,
+    show_keyboard: Option<Rc<dyn Fn()>>,
 }
 
 impl Global for WindowSeam {}
@@ -34,6 +35,22 @@ impl WindowSeam {
         Self {
             insets: Rc::new(insets),
             lifecycle: None,
+            show_keyboard: None,
+        }
+    }
+
+    /// Explicit user taps can reopen an IME without changing GPUI focus.
+    pub fn with_soft_keyboard(mut self, show: impl Fn() + 'static) -> Self {
+        self.show_keyboard = Some(Rc::new(show));
+        self
+    }
+
+    pub(crate) fn request_soft_keyboard(cx: &App) {
+        if let Some(show) = cx
+            .try_global::<Self>()
+            .and_then(|seam| seam.show_keyboard.as_ref())
+        {
+            show();
         }
     }
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -441,9 +441,11 @@ One inset, applied once, at the page:
   On iOS and Android, focusing the grid raises the software keyboard and adds one
   44pt special-key row at the bottom of that rect, directly above the keyboard.
   The row reserves its height before the grid is measured, so it never covers the
-  last terminal row. It contains Esc, Tab, sticky Ctrl and Alt, four arrows, the
-  one-tap `^C` and `^D` combos, then a horizontally scrolling symbol tail ordered
-  by how often a shell line needs the character: `- / | ~ : . _`. Sticky
+  last terminal row. Esc, Tab, sticky Ctrl and Alt stay pinned at the leading
+  edge. Four arrows, the one-tap `^C` and `^D` combos, and symbols `- / | ~ : . _`
+  share a horizontally scrolling strip with touch momentum, clipped to the row.
+  Keys retain 44pt targets; trailing padding gives the strip breathing room at
+  its end. The strip has no vertical scroll range. Sticky
   modifiers highlight until the next terminal key or committed character consumes
   them; a combo carries its own Control, encodes through the same key mapping a
   hardware Ctrl+C takes, and consumes any sticky modifier rather than doubling

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -449,7 +449,9 @@ One inset, applied once, at the page:
   modifiers highlight until the next terminal key or committed character consumes
   them; a combo carries its own Control, encodes through the same key mapping a
   hardware Ctrl+C takes, and consumes any sticky modifier rather than doubling
-  it. Desktop and browser terminals never draw the row.
+  it. Tapping the grid or a key explicitly reopens the software keyboard even
+  when the terminal retained focus after keyboard dismissal, on both mobile
+  platforms. Desktop and browser terminals never draw the row.
 
 Prose inside the content (errors, notices, file headers) wraps against the page
 inset rather than running past it. Code and diff lines do not wrap: they scroll


### PR DESCRIPTION
Three mobile terminal bugs reported from a Xiaomi 15 on the release APK.

- **Backspace did nothing on Android.** IME deletions were intercepted as editor edits; the terminal exposes no editable buffer, so nothing was dispatched. Deletions on a handler without an editable buffer now dispatch a Backspace keystroke, which the terminal encodes as `0x7f`. iOS hardware control keys no longer prefer character input.
- **Key bar overflowed the screen.** Esc/Tab/Ctrl/Alt stay pinned; arrows, ^C/^D and symbols live in a touch-registered horizontal strip with momentum and 44 pt targets; vertical gestures pass through.
- **Keyboard could not be reopened after dismissal.** Focus never changes when the IME is hidden, so taps on a focused grid or the key bar now explicitly request the soft keyboard through `WindowSeam`.

Verified on the Android emulator against a local headless: `cat` capture after typing `abc`, Delete ×2, Enter was exactly `a\n`; keyboard reopened from grid and key bar taps; strip scrolled at 360 and 393 pt. Tests added at the gpui-android input layer, terminal view encoding, key bar layout/gesture, and keyboard-request paths.