### PR TITLE
Use Tcode consistently as the product display name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to tcode
+# Contributing to Tcode
 
-Thanks for taking the time. tcode is a small project — bug reports, UI polish and
+Thanks for taking the time. Tcode is a small project — bug reports, UI polish and
 new provider work are all welcome.
 
 By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
@@ -85,7 +85,7 @@ cargo run -p agent --example probe -- claude \
     "What color is this image? Reply with just the color." /tmp/smoke --image /tmp/blue.png
 ```
 
-`TCODE_DATA_DIR` points tcode at a throwaway profile (its own sessions, settings
+`TCODE_DATA_DIR` points Tcode at a throwaway profile (its own sessions, settings
 and installed ACP agents) — useful for demos, screenshots and trying a change
 without touching your real threads.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ speaks ACP.
 > ACP entries that duplicate a native integration are deliberately hidden from
 > the marketplace so each CLI has one clear, highest-fidelity path.
 
-## Use tcode from other devices
+## Use Tcode from other devices
 
 Tcode runs on the machine that holds your projects, starts your agents, and
 keeps your threads. You can open that machine from another desktop, a phone or
@@ -125,7 +125,7 @@ choose it under **Nearby machines**, then connect. In a browser, open the
 printed HTTP link and log in with the password. The browser’s **Settings →
 Other devices** shows codes and QR codes for native clients and controls new
 pairings and device revocation.
-See [Use tcode from other devices](docs/remote.md) for the native-app and
+See [Use Tcode from other devices](docs/remote.md) for the native-app and
 browser steps.
 
 **Security.** LAN connections use plain HTTP and WebSockets. Adding a machine

--- a/crates/agent/src/acp.rs
+++ b/crates/agent/src/acp.rs
@@ -654,7 +654,7 @@ async fn handshake(
                             )
                             .client_info(
                                 acp::Implementation::new("tcode", env!("CARGO_PKG_VERSION"))
-                                    .title("tcode"),
+                                    .title("Tcode"),
                             ),
                     )
                     .block_task()
@@ -692,12 +692,12 @@ async fn handshake(
     let mcp_servers = mcp_servers(&registrations, &caps);
     if !registrations.is_empty() && mcp_servers.is_empty() {
         log::info!(
-            "acp[{}]: no mcpCapabilities.http; tcode MCP servers are not registered",
+            "acp[{}]: no mcpCapabilities.http; Tcode MCP servers are not registered",
             agent.id
         );
         let _ = events
             .send(AgentEvent::Warning { message: format!(
-                "{} does not support HTTP MCP servers; tcode MCP tools are unavailable in this session",
+                "{} does not support HTTP MCP servers; Tcode MCP tools are unavailable in this session",
                 agent.name
             ) })
             .await;

--- a/crates/agent/src/codex.rs
+++ b/crates/agent/src/codex.rs
@@ -120,7 +120,7 @@ async fn initialize(
             "id": 1,
             "method": "initialize",
             "params": {
-                "clientInfo": { "name": "tcode", "title": "tcode", "version": env!("CARGO_PKG_VERSION") },
+                "clientInfo": { "name": "tcode", "title": "Tcode", "version": env!("CARGO_PKG_VERSION") },
                 "capabilities": { "experimentalApi": true }
             }
         }),

--- a/crates/agent/src/opencode.rs
+++ b/crates/agent/src/opencode.rs
@@ -379,7 +379,7 @@ impl SessionActor for OpenCodeActor {
             SessionCommand::Rewind { .. } => {
                 self.events
                     .emit(AgentEvent::Warning {
-                        message: "OpenCode rewind is not exposed by tcode's native adapter".into(),
+                        message: "OpenCode rewind is not exposed by Tcode's native adapter".into(),
                     })
                     .await;
                 Ok(())
@@ -478,7 +478,7 @@ impl OpenCodeActor {
         for request_id in pending {
             let _ = self.server.http.post_json(
                 &format!("/permission/{request_id}/reply"),
-                &json!({"reply":"reject","message":"tcode session closed"}),
+                &json!({"reply":"reject","message":"Tcode session closed"}),
             );
         }
         self.server.stop();
@@ -1709,12 +1709,12 @@ fn opencode_config_content(
         Some(inline) => {
             let config: Value = serde_json::from_str(&inline).map_err(|err| {
                 AgentError::Protocol(format!(
-                    "cannot merge tcode MCP servers into OPENCODE_CONFIG_CONTENT: {err}"
+                    "cannot merge Tcode MCP servers into OPENCODE_CONFIG_CONTENT: {err}"
                 ))
             })?;
             if !config.is_object() {
                 return Err(AgentError::Protocol(
-                    "cannot merge tcode MCP servers into non-object OPENCODE_CONFIG_CONTENT".into(),
+                    "cannot merge Tcode MCP servers into non-object OPENCODE_CONFIG_CONTENT".into(),
                 ));
             }
             config

--- a/crates/agent/src/pi.rs
+++ b/crates/agent/src/pi.rs
@@ -330,7 +330,7 @@ async fn run_actor(
         actor.events
             .emit(AgentEvent::Warning {
                 message: format!(
-                    "pi has no MCP client of its own, so tcode's {} tools are unavailable in this session",
+                    "pi has no MCP client of its own, so Tcode's {} tools are unavailable in this session",
                     unattached.join(", ")
                 ),
             })
@@ -501,7 +501,7 @@ impl SessionActor for PiActor {
             SessionCommand::Rewind { .. } => {
                 self.events
                     .emit(AgentEvent::Warning {
-                        message: "pi rewind is not exposed by tcode's native adapter".into(),
+                        message: "pi rewind is not exposed by Tcode's native adapter".into(),
                     })
                     .await;
                 Ok(())

--- a/crates/android/host/app/src/main/AndroidManifest.xml
+++ b/crates/android/host/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:enableOnBackInvokedCallback="false"
         android:hasCode="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="tcode"
+        android:label="Tcode"
         android:supportsRtl="true"
         android:theme="@style/Theme.Tcode"
         android:usesCleartextTraffic="true">

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -408,10 +408,9 @@ fn main() {
                 });
             }
             #[cfg(target_os = "macos")]
-            cx.set_menus([gpui::Menu::new("tcode").items([gpui::MenuItem::action(
-                tcode_ui::tr!("quit.menu_item"),
-                Quit,
-            )])]);
+            cx.set_menus([gpui::Menu::new(tcode_ui::tr!("app.name")).items([
+                gpui::MenuItem::action(tcode_ui::tr!("quit.menu_item"), Quit),
+            ])]);
             // Process ownership, not the window's current attachment, grants
             // authority to stop the local kernel on application quit.
             let quit_subscription = cx.on_app_quit({
@@ -487,7 +486,7 @@ fn main() {
                 WindowSeam::flush(),
                 ShellOptions {
                     window: window_options,
-                    title: "tcode".into(),
+                    title: tcode_ui::tr!("app.name").into(),
                     fonts: application_fonts,
                     theme_json,
                     activate: true,

--- a/crates/computer-use-mcp/src/backend.rs
+++ b/crates/computer-use-mcp/src/backend.rs
@@ -258,7 +258,7 @@ pub fn list_roots(filters: &RootFilters) -> Result<Vec<RootInfo>, BackendError> 
     if filters.pid == Some(own_pid) {
         return Err(BackendError::new(
             BackendErrorCode::RootNotFound,
-            "the tcode host process cannot observe itself; launch a separate instance to drive it",
+            "the Tcode host process cannot observe itself; launch a separate instance to drive it",
         ));
     }
     #[cfg(target_os = "macos")]

--- a/crates/computer-use-mcp/src/tools.rs
+++ b/crates/computer-use-mcp/src/tools.rs
@@ -194,7 +194,7 @@ impl ComputerUseTools {
     #[tool(
         description = "Find and rank desktop window roots, returning @rN references; call this before observe_ui when the target is not the frontmost window. \
                        This server exposes desktop windows only, so use the tcode_preview tools for web pages. \
-                       On macOS, grant Accessibility for all tools and Screen Recording for screenshots in tcode Settings → Computer Use; Windows needs no permissions, and other platforms are unsupported."
+                       On macOS, grant Accessibility for all tools and Screen Recording for screenshots in Tcode Settings → Computer Use; Windows needs no permissions, and other platforms are unsupported."
     )]
     async fn find_roots(&self, Parameters(params): Parameters<RootFilters>) -> CallToolResult {
         let permissions = permissions();
@@ -231,7 +231,7 @@ impl ComputerUseTools {
                        Use find_roots → observe_ui, query that cached state with search_ui/expand_ui/inspect_ui, then use act_ui/wait_for and observe again; those cached queries do not touch the live UI. \
                        Every @e ref belongs to its producing state_id; observations are immutable and kept in a bounded LRU (default 8), so an evicted or stale state or a ref from another state requires a fresh observe_ui. \
                        This server exposes desktop windows only, so use the tcode_preview tools for web pages. \
-                       On macOS, grant Accessibility for all tools and Screen Recording for screenshots in tcode Settings → Computer Use; Windows needs no permissions, and other platforms are unsupported."
+                       On macOS, grant Accessibility for all tools and Screen Recording for screenshots in Tcode Settings → Computer Use; Windows needs no permissions, and other platforms are unsupported."
     )]
     async fn observe_ui(&self, Parameters(params): Parameters<ObserveUiParams>) -> CallToolResult {
         let permissions = permissions();
@@ -749,12 +749,12 @@ fn permission_gate(
 ) -> Option<CallToolResult> {
     if needs_accessibility && !permissions.accessibility {
         return Some(tool_error(
-            "Accessibility permission is missing; grant it in tcode Settings → Computer Use.",
+            "Accessibility permission is missing; grant it in Tcode Settings → Computer Use.",
         ));
     }
     if needs_screen_recording && !permissions.screen_recording {
         return Some(tool_error(
-            "Screen Recording permission is missing; grant it in tcode Settings → Computer Use.",
+            "Screen Recording permission is missing; grant it in Tcode Settings → Computer Use.",
         ));
     }
     None

--- a/crates/ios/host/Sources/Info.plist
+++ b/crates/ios/host/Sources/Info.plist
@@ -30,9 +30,9 @@
     <key>NSBonjourServices</key>
     <array><string>_tcode._tcp</string></array>
     <key>NSLocalNetworkUsageDescription</key>
-    <string>查找同一网络中的 tcode 执行端以进行配对。</string>
+    <string>查找同一网络中的 Tcode 执行端以进行配对。</string>
     <key>NSCameraUsageDescription</key>
-    <string>Scan a QR code to pair with a tcode host.</string>
+    <string>Scan a QR code to pair with a Tcode host.</string>
     <key>UIApplicationSceneManifest</key>
     <dict>
         <key>UIApplicationSupportsMultipleScenes</key>

--- a/crates/orchestrate-mcp/src/tools.rs
+++ b/crates/orchestrate-mcp/src/tools.rs
@@ -134,7 +134,7 @@ impl OrchestrateTools {
     }
 
     #[tool(
-        description = "Dispatch concrete execution work to an enabled execution-model profile in a new child tcode thread. Use collaborate for peer decision discussions. Dispatch a brief to the thread and return its thread id. profile is the provider-profile id from the fleet table, required when the entry names one. access is one of read_only (review/investigation: read-only actions run without prompts; anything that mutates pauses for user approval), workspace_write (edits auto-approved inside the workspace), or full (default; no approval prompts). worktree optionally isolates the child in tcode/<thread-id> and overrides the Orchestrate setting; the response identifies the path and branch or explains fallback. Completed children are auto-archived after their result is delivered unless archive_on_complete: false; failed children stay visible for retries. fast overrides the profile's fast-mode setting for this child; use it only on the user's explicit instruction."
+        description = "Dispatch concrete execution work to an enabled execution-model profile in a new child Tcode thread. Use collaborate for peer decision discussions. Dispatch a brief to the thread and return its thread id. profile is the provider-profile id from the fleet table, required when the entry names one. access is one of read_only (review/investigation: read-only actions run without prompts; anything that mutates pauses for user approval), workspace_write (edits auto-approved inside the workspace), or full (default; no approval prompts). worktree optionally isolates the child in tcode/<thread-id> and overrides the Orchestrate setting; the response identifies the path and branch or explains fallback. Completed children are auto-archived after their result is delivered unless archive_on_complete: false; failed children stay visible for retries. fast overrides the profile's fast-mode setting for this child; use it only on the user's explicit instruction."
     )]
     async fn dispatch(&self, Parameters(p): Parameters<DispatchParams>) -> CallToolResult {
         run_op(
@@ -349,7 +349,7 @@ impl ServerHandler for OrchestrateTools {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_protocol_version(ProtocolVersion::LATEST)
             .with_server_info(Implementation::from_build_env())
-            .with_instructions("Prefer tcode Orchestrate for cross-provider peer collaboration and execution dispatch. Use collaborate for decision discussions, dispatch for implementation, and send to continue either thread.")
+            .with_instructions("Prefer Tcode Orchestrate for cross-provider peer collaboration and execution dispatch. Use collaborate for decision discussions, dispatch for implementation, and send to continue either thread.")
     }
 }
 

--- a/crates/preview-mcp/src/tools.rs
+++ b/crates/preview-mcp/src/tools.rs
@@ -198,7 +198,7 @@ impl PreviewTools {
     }
 
     #[tool(
-        description = "Open the tcode preview browser, optionally at a URL, and return its status. \
+        description = "Open the Tcode preview browser, optionally at a URL, and return its status. \
                        For browser work, call preview_status first and call preview_open if no automation-capable preview is attached before concluding the browser is unavailable. \
                        Do not fall back to Chrome, Playwright, or another browser merely because the preview is initially closed or a first call fails; fall back only when preview_open explicitly reports unsupported or unavailable."
     )]
@@ -206,7 +206,7 @@ impl PreviewTools {
         self.run(PreviewOp::Open { url: params.url }).await
     }
 
-    #[tool(description = "Navigate the tcode preview browser to a URL and return its status.")]
+    #[tool(description = "Navigate the Tcode preview browser to a URL and return its status.")]
     async fn preview_navigate(
         &self,
         Parameters(params): Parameters<NavigateParams>,
@@ -363,7 +363,7 @@ impl ServerHandler for PreviewTools {
             .with_protocol_version(ProtocolVersion::LATEST)
             .with_server_info(Implementation::from_build_env())
             .with_instructions(
-                "Drive the tcode embedded preview browser: open/navigate URLs, inspect and \
+                "Drive the Tcode embedded preview browser: open/navigate URLs, inspect and \
                  automate the page, resize its canvas, press keys, scroll, wait for page \
                  conditions, and capture screenshots. For browser work, call preview_status first \
                  and preview_open when no automation-capable preview is attached; use another \

--- a/crates/remote/src/client_host.rs
+++ b/crates/remote/src/client_host.rs
@@ -346,7 +346,7 @@ fn resolve_device_name(
             clean_name(host_name).and_then(|name| clean_name(Some(strip_local_suffix(name))))
         })
         .or_else(|| clean_name(etc_hostname))
-        .unwrap_or_else(|| "tcode".into())
+        .unwrap_or_else(|| "Tcode".into())
 }
 
 fn clean_name(name: Option<String>) -> Option<String> {

--- a/crates/remote/src/server.rs
+++ b/crates/remote/src/server.rs
@@ -441,7 +441,7 @@ pub fn set_password(
         .ok()
         .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
         .and_then(|value| value["host_name"].as_str().map(str::to_owned))
-        .unwrap_or_else(|| "tcode".into());
+        .unwrap_or_else(|| "Tcode".into());
     AuthStore::open(data_dir, &name)?.set_password(password, revoke_tokens)
 }
 

--- a/crates/services/src/export.rs
+++ b/crates/services/src/export.rs
@@ -134,7 +134,7 @@ pub(crate) fn read_tcode_export(path: &Path) -> Result<TcodeThreadExport, ReadEx
         .map_err(|error| ReadExportError::Invalid(error.to_string()))?;
     if header.version != EXPORT_VERSION {
         return Err(ReadExportError::Invalid(format!(
-            "unsupported tcode export version {}",
+            "unsupported Tcode export version {}",
             header.version
         )));
     }
@@ -161,7 +161,7 @@ fn parse_event_log(bytes: &[u8]) -> Result<Vec<StoredEvent>, String> {
 pub fn render_markdown(meta: &SessionMeta, timeline: &Timeline) -> String {
     let model = meta.model.as_deref().unwrap_or("provider default");
     let mut output = format!(
-        "# {}\n\n- Format: tcode Markdown export v1\n- Session ID: `{}`\n- Provider/model: {} / {}\n- Workspace: `{}`\n- Created: {} (Unix seconds)\n- Updated: {} (Unix seconds)\n- Attachments: referenced by recorded local path; file bytes are not embedded.\n- Privacy: no automatic redaction; recorded messages and tool summaries may contain sensitive data. Provider secrets and settings are not included.\n\n",
+        "# {}\n\n- Format: Tcode Markdown export v1\n- Session ID: `{}`\n- Provider/model: {} / {}\n- Workspace: `{}`\n- Created: {} (Unix seconds)\n- Updated: {} (Unix seconds)\n- Attachments: referenced by recorded local path; file bytes are not embedded.\n- Privacy: no automatic redaction; recorded messages and tool summaries may contain sensitive data. Provider secrets and settings are not included.\n\n",
         meta.title,
         meta.id,
         meta.provider.display_name(),
@@ -419,7 +419,7 @@ mod tests {
             String::from_utf8(rendered).unwrap(),
             concat!(
                 "# Export fixture\n\n",
-                "- Format: tcode Markdown export v1\n",
+                "- Format: Tcode Markdown export v1\n",
                 "- Session ID: `session-export-1`\n",
                 "- Provider/model: Claude Code / opus\n",
                 "- Workspace: `/work/project`\n",

--- a/crates/ui/examples/phone.rs
+++ b/crates/ui/examples/phone.rs
@@ -43,7 +43,7 @@ fn main() {
                         window_background: WindowBackgroundAppearance::Opaque,
                         ..Default::default()
                     },
-                    title: "tcode phone".into(),
+                    title: "Tcode phone".into(),
                     theme_json: Cow::Owned(tcode_ui::flattened_theme_json()),
                     activate: true,
                     setup: ShellSetup {

--- a/crates/ui/src/material.rs
+++ b/crates/ui/src/material.rs
@@ -211,7 +211,7 @@ pub fn brand_wordmark(cx: &App) -> impl IntoElement {
                 .text_size(px(14.))
                 .font_bold()
                 .text_color(cx.theme().sidebar_foreground)
-                .child("tcode"),
+                .child(crate::tr!("app.name")),
         )
         .child(
             div()

--- a/crates/ui/src/provider_status.rs
+++ b/crates/ui/src/provider_status.rs
@@ -238,7 +238,7 @@ mod tests {
         assert_eq!(s.headline, "Disabled");
         assert_eq!(
             s.detail,
-            "This provider is installed but disabled for new sessions in tcode."
+            "This provider is installed but disabled for new sessions in Tcode."
         );
 
         let missing = ProviderSnapshot {

--- a/crates/ui/src/run.rs
+++ b/crates/ui/src/run.rs
@@ -63,7 +63,7 @@ impl Default for ShellOptions {
     fn default() -> Self {
         Self {
             window: WindowOptions::default(),
-            title: "tcode".into(),
+            title: crate::tr!("app.name").into(),
             fonts: vec![Cow::Borrowed(crate::assets::DM_SANS)],
             theme_json: Cow::Borrowed(THEME_JSON),
             activate: false,

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -1171,7 +1171,7 @@ impl SessionsSidebar {
                 .text_sm()
                 .font_bold()
                 .text_color(cx.theme().sidebar_foreground)
-                .child("tcode"),
+                .child(crate::tr!("app.name")),
         )
         .child(
             div()

--- a/crates/ui/src/store/mod.rs
+++ b/crates/ui/src/store/mod.rs
@@ -1603,7 +1603,7 @@ impl WorkspaceStore {
             .clone()
             .filter(|name| !name.trim().is_empty())
             .or_else(|| self.client_host.as_ref().map(|host| host.device_name()))
-            .unwrap_or_else(|| "tcode".into())
+            .unwrap_or_else(|| crate::tr!("app.name").into_owned())
     }
 
     pub fn set_client_device_name(&mut self, name: Option<String>) {
@@ -1832,7 +1832,7 @@ impl WorkspaceStore {
         match self.session_status_replica.as_ref() {
             Some(status) if status.draft => crate::tr!("chat.new_thread").into_owned(),
             Some(status) => status.title.clone(),
-            None => "tcode".to_string(),
+            None => crate::tr!("app.name").into_owned(),
         }
     }
 

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -53,7 +53,7 @@ fn prepare_canvas(canvas_id: &str) -> Result<(), JsValue> {
                     .and_then(|node| node.dyn_into::<web_sys::HtmlCanvasElement>().ok())
                 {
                     canvas.set_id(&canvas_id);
-                    let _ = canvas.set_attribute("aria-label", "tcode remote client");
+                    let _ = canvas.set_attribute("aria-label", "Tcode remote client");
                 }
             }
         }

--- a/crates/web/static/index.html
+++ b/crates/web/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <link rel="icon" href="data:,">
-  <title>tcode remote client</title>
+  <title>Tcode remote client</title>
   <style>
     :root { color-scheme: light dark; background: #111318; color: #f2f3f5; font: 14px system-ui, sans-serif; }
     html, body { margin: 0; width: 100%; height: 100%; overflow: hidden; }
@@ -30,8 +30,8 @@
 </head>
 <body>
   <canvas id="tcode-canvas"></canvas>
-  <p id="loading" role="status">Loading tcode…</p>
-  <noscript>Enable JavaScript to use tcode.</noscript>
+  <p id="loading" role="status">Loading Tcode…</p>
+  <noscript>Enable JavaScript to use Tcode.</noscript>
   <script type="module">
     import init, { start } from './tcode_web.js';
     import { authorizeBrowser } from './auth.mjs';
@@ -40,8 +40,8 @@
       await init();
       await start('tcode-canvas');
     } catch (error) {
-      console.error('tcode startup failed', error);
-      document.getElementById('loading').textContent = `tcode could not start.\n${error}`;
+      console.error('Tcode startup failed', error);
+      document.getElementById('loading').textContent = `Tcode could not start.\n${error}`;
     }
   </script>
 </body>

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,9 +1,13 @@
-# tcode design spec
+# Tcode design spec
 
-The visual and interaction contract for tcode. Update it deliberately when a
+The visual and interaction contract for Tcode. Update it deliberately when a
 product decision changes; historical design drafts are not additional rules.
 There is one shell, described here; **Compact layout** below covers the narrow
 end of it.
+
+The product display name is **Tcode**. The shared UI uses the existing `app.name`
+locale key for its standalone name. Commands, crate and bundle identifiers,
+URLs, file names and data directories retain lowercase `tcode`.
 
 ## One shell, one layout rule
 
@@ -515,7 +519,7 @@ pointer leaves. It is strictly transient state, never persisted, and command
 palette / dialogs / toasts still layer above it. Its own contents are identical
 in both states.
 
-1. App row: "tcode" bold 14px, channel pill ("DEV"). No collapse button — the
+1. App row: "Tcode" bold 14px, channel pill ("DEV"). No collapse button — the
    toggle lives in the chat header, since a collapsed sidebar has no width to
    host it.
 2. Search row: magnifier + "Search" muted + ⌘K (macOS) / Ctrl+K
@@ -852,14 +856,14 @@ Editable fields are seeded from the host's settings the first time a real
 snapshot exists, not from local defaults, and a field the user has since edited
 is never rewritten by a later snapshot.
 
-Provider profiles expose only applicable options. Pi defaults to no tcode
+Provider profiles expose only applicable options. Pi defaults to no Tcode
 permission extension; its Native approvals toggle enables the gate for
 supervised and auto-accept-edits sessions. Without it those stored modes take
 effect as Full access, while Read only uses pi's native tool filter. Trust
 project extensions adds `--approve` at launch. Pi has no MCP client; explicitly
 enabled orchestration or computer-use registrations produce an unavailable-tools
-warning. Using tcode from other devices is documented in
-[Use tcode from other devices](remote.md), and
+warning. Using Tcode from other devices is documented in
+[Use Tcode from other devices](remote.md), and
 permissions in [computer use](computer-use.md).
 
 Orchestrate uses one provider-neutral workflow, refreshed on each explicit
@@ -879,7 +883,7 @@ GPT-6 Astra and Claude Opus 5. The two Astra rows are separate role-specific
 profiles with different descriptions. Other models may still initiate `/orchestrate`.
 `collaborate` opens a read-only peer discussion, continued through `send`;
 `dispatch` assigns concrete work to execution models. Model selection considers
-the whole cross-provider fleet, preferring tcode Orchestrate to native subagents.
+the whole cross-provider fleet, preferring Tcode Orchestrate to native subagents.
 Each collaboration model can be switched on or off independently. Its switch
 controls whether it can be invited through `collaborate`, never whether it may
 serve as the main decision model. Turning every peer off still permits the main
@@ -1040,7 +1044,7 @@ parent is still visible, with the parent's scroll position and panels intact.
 Archiving a thread the user is not viewing changes nothing.
 
 Only a workspace with no projects at all reaches the empty page: centered
-"Add a project to get started" (15px semibold) over "tcode works inside a
+"Add a project to get started" (15px semibold) over "Tcode works inside a
 project folder. Add one to open its first thread." (13px muted) and an
 **Add project** button. No composer is rendered. The same page, titled "Pick a
 thread to continue" over a list of recent projects, covers the moment before a

--- a/docs/computer-use.md
+++ b/docs/computer-use.md
@@ -1,6 +1,6 @@
 # Computer use
 
-tcode gives MCP-capable providers (Claude Code, Codex, OpenCode, and ACP agents that
+Tcode gives MCP-capable providers (Claude Code, Codex, OpenCode, and ACP agents that
 advertise `mcpCapabilities.http`) a set of desktop computer-use tools, served by the
 in-process `tcode_computer_use` MCP server. pi has no MCP client, so its provider card
 and model-picker rows identify computer use, preview, and orchestrate as unavailable
@@ -51,7 +51,7 @@ enabled. Claude, Codex and OpenCode use their native MCP configuration; ACP
 registration is gated on the agent's HTTP MCP capability. The Settings UI
 consumes the same permission facade.
 
-The server runs inside tcode, so macOS permissions apply to the running app;
+The server runs inside Tcode, so macOS permissions apply to the running app;
 there is no separately installed helper app.
 
 ## Text-sparse image fallback
@@ -139,7 +139,7 @@ The relevant Settings pages are:
   live status, a primary action, and **Recheck**. The primary action starts as
   **Request Access** and fires only the native TCC request. If the permission is still missing,
   the next explicit action becomes **Open System Settings** and deep-links the matching
-  `x-apple.systempreferences` pane. Returning to tcode also triggers a recheck.
+  `x-apple.systempreferences` pane. Returning to Tcode also triggers a recheck.
 
 The persisted computer-use block additionally accepts `allow_foreground_fallback` (default
 `false`) and `show_agent_cursor` (default `true`). Both use serde defaults, so settings files from
@@ -148,9 +148,9 @@ before background delivery continue to load without migration.
 ### Restart continuity
 
 macOS applies some grants (notably Screen Recording) only after the app restarts, and shows its
-own "Quit & Reopen" dialog. tcode therefore preserves Screen Recording flows across a restart:
+own "Quit & Reopen" dialog. Tcode therefore preserves Screen Recording flows across a restart:
 
-1. Before a Screen Recording request, tcode writes a temporary `relaunch.json` marker into the
+1. Before a Screen Recording request, Tcode writes a temporary `relaunch.json` marker into the
    data dir: `{ reopen_settings: "computer_use", active_session: <id> }`. Accessibility does not
    need this marker. Returning without a grant clears it.
 2. Session events and resume cursors are persisted continuously. The marker
@@ -159,7 +159,7 @@ own "Quit & Reopen" dialog. tcode therefore preserves Screen Recording flows acr
    status. After a real grant, the previous active session is reopened, Settings is
    reopened on the recorded page, and permissions are rechecked automatically. A denied or stale
    marker is discarded without changing the launch route.
-4. The Computer Use page also offers an explicit **Relaunch tcode** button (shown when a grant
+4. The Computer Use page also offers an explicit **Relaunch Tcode** button (shown when a grant
    was detected as pending-restart) that writes the same marker and relaunches via
    `open -n <bundle>`.
 

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -1,16 +1,16 @@
-# Use tcode from other devices
+# Use Tcode from other devices
 
-tcode runs on the machine that holds your projects, provider tools and terminal
+Tcode runs on the machine that holds your projects, provider tools and terminal
 processes. You can open that machine from another desktop, a phone, a tablet or
 a browser over your LAN or overlay network. There is no relay service. For a
 shorter introduction, see
-[Use tcode from other devices in the README](../README.md#use-tcode-from-other-devices).
+[Use Tcode from other devices in the README](../README.md#use-tcode-from-other-devices).
 
 ## Concepts
 
 | Term | Meaning |
 | --- | --- |
-| Machine | The computer where tcode runs providers and terminals and stores projects and threads. You can use the desktop app or `tcode-headless` there. |
+| Machine | The computer where Tcode runs providers and terminals and stores projects and threads. You can use the desktop app or `tcode-headless` there. |
 | Device | A desktop, phone, tablet or browser that opens a machine and sends actions to it. |
 | Browser password | Protects the web page served by `tcode-headless`. Set it on first open, or preset it with `TCODE_PASSWORD`. A successful login issues a device token. |
 | Adding a machine | Exchanging a single-use, six-digit connection code for a device token. A code expires after five minutes; five wrong attempts invalidate it. Generating a new code replaces the previous code. |
@@ -42,7 +42,7 @@ machine** therefore remains available, and devices that already opened this
 machine continue working. The desktop app accepts native app connections; it
 does not serve the browser app.
 
-## Run tcode without the desktop app
+## Run Tcode without the desktop app
 
 ### Install and start
 
@@ -61,9 +61,9 @@ does not serve the browser app.
    ```
 
 3. Install and authenticate your agent CLIs under the account that will run
-   tcode. Ensure that account's `PATH` includes them and that it can access your
+   Tcode. Ensure that account's `PATH` includes them and that it can access your
    project directories.
-4. Start tcode with a persistent data directory:
+4. Start Tcode with a persistent data directory:
 
    ```sh
    "$HOME/.local/bin/tcode-headless" serve \
@@ -88,7 +88,7 @@ does not serve the browser app.
    "$HOME/.local/bin/tcode-headless" pair --listen 127.0.0.1:47420
    ```
 
-   `pair` contacts the running tcode process over loopback. Its `--listen`
+   `pair` contacts the running Tcode process over loopback. Its `--listen`
    selects the port and IPv4/IPv6 family; it does not contact the supplied
    address. Keep the listener reachable on loopback, as with the default
    wildcard bind. A listener bound only to a specific LAN address cannot answer
@@ -100,7 +100,7 @@ does not serve the browser app.
    already authorized devices. Use **Remove** to revoke their access.
 7. Open this machine from another device using the instructions below. To
    prepare projects with the local desktop UI, stop `tcode-headless` first and
-   open the desktop app with the same data directory. Do not run two local tcode
+   open the desktop app with the same data directory. Do not run two local Tcode
    processes against the same directory.
 
 On Unix, Ctrl-C requests shutdown and a store flush. The CLI reference is:
@@ -127,7 +127,7 @@ Do not run this command against a data directory used by a running process.
 ### Data directory
 
 The `tcode-headless --data-dir` option takes precedence over `TCODE_DATA_DIR`.
-Without the option, `TCODE_DATA_DIR` selects the store; otherwise tcode uses the
+Without the option, `TCODE_DATA_DIR` selects the store; otherwise Tcode uses the
 platform app-data directory with a `tcode` subdirectory. This includes settings,
 threads and connection records. It does not move project working directories
 into the store.
@@ -152,7 +152,7 @@ setup.
 
 ```ini
 [Unit]
-Description=tcode without the desktop app
+Description=Tcode without the desktop app
 
 [Service]
 Type=simple
@@ -169,7 +169,7 @@ TimeoutStopSec=60
 WantedBy=default.target
 ```
 
-`SIGINT` uses tcode's shutdown-and-flush path. Stop any foreground tcode process
+`SIGINT` uses Tcode's shutdown-and-flush path. Stop any foreground Tcode process
 using the same port or data directory, then load and start the service:
 
 ```sh
@@ -200,7 +200,7 @@ The script optionally uses `wasm-opt` if installed. Build the bundle before the
 option, not a `serve` flag. The resulting executable is
 `target/release/tcode-headless`.
 
-tcode serves the browser app at `/` over HTTP, on the same port as the
+Tcode serves the browser app at `/` over HTTP, on the same port as the
 connection-code exchange and WebSockets. Without `web`, static requests
 return 404 while native apps can still add and connect to the machine. The
 browser runs the same shell as the desktop app; it lays itself out from the
@@ -223,7 +223,7 @@ compact stack.
    Choose another machine under **Your machines** to switch again;
    **This machine** restores the local workspace, and a machine row's
    **⋯ → Disconnect** leaves without removing it. Switching closes only this
-   device's old link, not tcode on either machine. Opening **Machines** by itself
+   device's old link, not Tcode on either machine. Opening **Machines** by itself
    does not change the connection.
 
 You can also add a machine from the desktop executable. Replace the sample
@@ -320,7 +320,7 @@ name, Android from the device model.
 
 Connect the machine and your other devices to the same LAN or overlay, such as
 Tailscale or EasyTier. Allow the listener through the machine's firewall and any
-overlay access rules. tcode provides no relay or public discovery service. Treat
+overlay access rules. Tcode provides no relay or public discovery service. Treat
 nearby-machine search as LAN-only: it does not cross a normal overlay connection.
 Enter the machine's overlay address and port when it does not appear nearby.
 Nearby-machine search advertises identity and address hints; it does not grant
@@ -341,7 +341,7 @@ port as pairing and WebSockets (default `47420`). It requires
 as password. Plain HTTP is forwarded; HTTPS uses opaque CONNECT tunnels with
 certificate validation performed by the client webview, without TLS interception.
 The machine connects directly to destinations; OS routing and global TUNs apply.
-tcode does not read upstream-proxy environment variables or system proxy settings.
+Tcode does not read upstream-proxy environment variables or system proxy settings.
 There is nothing new to configure in hosting settings.
 
 The listener admits at most 256 concurrent connections, including WebSockets.
@@ -359,7 +359,7 @@ macOS attached previews are unavailable: WebKit bypasses its Network proxy
 configuration for destinations on the client’s local interfaces, including
 localhost and its own LAN addresses. Clearing excluded domains, explicit match
 domains, disabling failover, and installing the authenticated configuration before
-creating the WebView do not prevent this bypass. tcode refuses attached WebView
+creating the WebView do not prevent this bypass. Tcode refuses attached WebView
 creation through the existing error surface so navigations, redirects, and
 subresources cannot connect directly. Local macOS previews remain available.
 
@@ -378,7 +378,7 @@ attachment lifetime. The browser client cannot override its browser's proxy.
 
 The LAN transport is plain HTTP and `ws://`. Anyone on the LAN who captures
 traffic can read the device token and the work sent over the connection. Use a
-tunnel or VPN on untrusted networks. tcode never provisions or manages TLS.
+tunnel or VPN on untrusted networks. Tcode never provisions or manages TLS.
 
 Anyone holding a paired device token can browse through the machine, including
 its loopback and private-network services. Treat it as network access to that
@@ -395,7 +395,7 @@ tokens and origins in `hosts.json` in their own data directory.
 Phone records are in the app's private data directory; Android uses its
 `filesDir`. Browser records use `localStorage` as described above.
 
-On Unix, tcode writes `remote.json` and `hosts.json` with mode `0600`. These are filesystem permissions, not file
+On Unix, Tcode writes `remote.json` and `hosts.json` with mode `0600`. These are filesystem permissions, not file
 encryption. Protect this device's data directory and browser profile: possession
 of a device token grants that device's access. There are no per-device project
 permissions or read-only device roles.
@@ -410,22 +410,22 @@ the machine.
 There is no `tcode-headless` remove subcommand. To remove access without the
 desktop UI, stop `tcode-headless`, back up `remote.json`, remove the matching
 entry from its `devices` array, preserve its permissions, and restart. Do not
-edit that file while tcode is running: it holds the device list in memory.
+edit that file while Tcode is running: it holds the device list in memory.
 
 ## Reaching your machine from outside
 
 - **Tailscale / WireGuard:** once your machine and device are on the VPN, there
-  is nothing to configure in tcode. Save the machine's VPN address, such as
+  is nothing to configure in Tcode. Save the machine's VPN address, such as
   `http://100.64.0.10:47420`, and allow the listener in the VPN's access rules.
   Discovery usually stays on the LAN, so type the address when needed.
-- **Cloudflare Tunnel / frp:** forward your tunnel's HTTPS endpoint to tcode's
+- **Cloudflare Tunnel / frp:** forward your tunnel's HTTPS endpoint to Tcode's
   local HTTP listener, including WebSocket upgrades. Save the tunnel's HTTPS
   origin, such as `https://tunnel.example.com`. The tunnel manages TLS.
 - **Tailscale HTTPS:** save its HTTPS origin when using its HTTPS forwarding.
   Native clients use standard trusted roots and hostname validation.
 
 Browser password login, native six-digit pairing codes, and device-token
-authorization keep the same behavior through a tunnel or VPN. Protect tunnel access and your stored tokens. tcode does not
+authorization keep the same behavior through a tunnel or VPN. Protect tunnel access and your stored tokens. Tcode does not
 encrypt stored JSON or project files; preview servers and provider connections
 use their own transports.
 
@@ -436,7 +436,7 @@ use their own transports.
 | Browser password is wrong or forgotten | After five wrong attempts, wait five minutes. To reset it, stop the host and use `set-password`; add `--revoke-tokens` if saved devices should lose access. |
 | Native pairing is disabled | Enable **Allow other devices** in the logged-in browser’s **Settings → Other devices**. Web login is independent. |
 | Connection code is wrong or expired | Generate **New code** on the machine, or run `tcode-headless pair`. Codes expire after five minutes, after use, after five wrong attempts, or when replaced. Get a separate code for each device. |
-| Cannot reach the machine | Check that tcode is running, that the address is reachable from this device, and that the TCP port is allowed. Use the overlay address if no nearby machine appears. This device's `127.0.0.1` points to itself. |
+| Cannot reach the machine | Check that Tcode is running, that the address is reachable from this device, and that the TCP port is allowed. Use the overlay address if no nearby machine appears. This device's `127.0.0.1` points to itself. |
 | `tcode-headless pair` cannot reach a running listener | Check its port and IPv4/IPv6 family. The listener must accept loopback connections; `pair` always uses loopback. |
 | Browser shows 404 | Use a `tcode-headless` build with `web`. The desktop app and builds without the bundle do not serve the browser app. |
 | Browser fails before adding the machine | Check the HTTP host or your HTTPS tunnel. Check that JavaScript and site storage are allowed. |

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,5 +1,5 @@
 app:
-  name: "tcode"
+  name: "Tcode"
 chat:
   sending: "Sending…"
   waiting_connection: "Waiting for connection…"
@@ -64,7 +64,7 @@ chat:
   open_zed: "Open in Zed"
   empty_title: "Pick a thread to continue"
   no_projects_title: "Add a project to get started"
-  no_projects_description: "tcode works inside a project folder. Add one to open its first thread."
+  no_projects_description: "Tcode works inside a project folder. Add one to open its first thread."
   start_hub_title: "Start a new thread in"
   palette_hint: "or press %{shortcut} to search"
   scroll_end: "Scroll to end"
@@ -142,7 +142,7 @@ sidebar:
   auto_archived: "Auto-archived %{count} inactive threads — view"
   auto_archive_dialog:
     title: "Threads auto-archived"
-    body: "tcode auto-archived %{count} threads idle for over %{days} days and beyond your %{keep} most recent. Restore them anytime in Settings → Archived Threads, or turn auto-archive off in Settings."
+    body: "Tcode auto-archived %{count} threads idle for over %{days} days and beyond your %{keep} most recent. Restore them anytime in Settings → Archived Threads, or turn auto-archive off in Settings."
     got_it: "Got it"
     open_settings: "Open Settings"
   working: "Working"
@@ -162,7 +162,7 @@ sidebar:
   archive_all_action: "Archive all"
   remove_project: "Remove project"
   remove_project_title: 'Remove project "%{project}"?'
-  remove_project_description: "This removes the project and its %{count} threads from tcode. Files on disk are not touched."
+  remove_project_description: "This removes the project and its %{count} threads from Tcode. Files on disk are not touched."
   remove_project_action: "Remove project"
   reveal_project: "Reveal in Finder"
   ctx_rename: "Rename thread"
@@ -175,7 +175,7 @@ sidebar:
   ctx_mark_unread: "Mark unread"
   ctx_copy_path: "Copy workspace path"
   ctx_copy_id: "Copy thread ID"
-  ctx_export_jsonl: "Export as tcode JSONL"
+  ctx_export_jsonl: "Export as Tcode JSONL"
   ctx_export_markdown: "Export as Markdown"
   ctx_delete: "Delete"
   delete_title: 'Delete thread "%{title}"?'
@@ -187,8 +187,8 @@ sidebar:
   worktree_cleanup_keep: "Keep worktree"
   empty: "No projects yet. Add one to start."
 quit:
-  menu_item: "Quit tcode"
-  title: "Quit tcode?"
+  menu_item: "Quit Tcode"
+  title: "Quit Tcode?"
   description: "%{count} session(s) are still working. Quitting will stop them."
   confirm: "Quit"
 settings:
@@ -238,13 +238,13 @@ settings:
   reset_section: "RESET"
   language:
     title: "Language"
-    description: "Choose the language used across tcode."
+    description: "Choose the language used across Tcode."
     system: "System"
     english: "English"
     chinese: "简体中文"
   theme:
     title: "Theme"
-    description: "Choose how tcode looks across the app."
+    description: "Choose how Tcode looks across the app."
     system: "System default"
     light: "Light"
     dark: "Dark"
@@ -266,16 +266,16 @@ settings:
     description: "Automatically show command output while it runs, then hide the panel when it finishes."
   provider_updates:
     title: "Provider update checks"
-    description: "Check for newer tcode and provider CLI versions on launch."
+    description: "Check for newer Tcode and provider CLI versions on launch."
   inactive_frame_throttle:
     title: "Background frame throttle"
     description: "Drop to ~2 FPS while the window is unfocused to save energy. Takes effect after restart."
   abort_on_model_fallback:
     title: "Abort on model fallback"
-    description: "When on, tcode watches Claude Code's stream for safety-classifier fallbacks or flags and stops the turn at the conversation level, handing control back to you. Subagents are unaffected."
+    description: "When on, Tcode watches Claude Code's stream for safety-classifier fallbacks or flags and stops the turn at the conversation level, handing control back to you. Subagents are unaffected."
   resume_on_limit_reset:
     title: "Resume when the usage limit resets"
-    description: "When Claude Code stops a turn because the 5-hour usage window is exhausted, tcode schedules a resume for the moment the window resets. Off: the error card offers a button to schedule it by hand."
+    description: "When Claude Code stops a turn because the 5-hour usage window is exhausted, Tcode schedules a resume for the moment the window resets. Off: the error card offers a button to schedule it by hand."
   fallback_review_advisor:
     title: "Fallback review advisor"
     description: "Use a separate model to review requests interrupted by Claude Code's fallback guard."
@@ -335,8 +335,8 @@ permissions:
   recheck: "Recheck"
   unsupported: "Only available on macOS."
   manage_on_host: "Manage these system permissions on %{host}."
-  restart_banner: "Screen Recording grants take effect only after tcode restarts."
-  relaunch: "Relaunch tcode"
+  restart_banner: "Screen Recording grants take effect only after Tcode restarts."
+  relaunch: "Relaunch Tcode"
   accessibility:
     name: "Accessibility"
     why: "Read the on-screen accessibility tree and post keyboard and mouse events."
@@ -358,7 +358,7 @@ orchestrate:
     description: "When a dispatch cwd is a Git repository root, create a dedicated tcode/<thread-id> branch and worktree for the child. A dispatch can override this with worktree."
   all_models:
     title: "Orchestrate workflow"
-    description: "The main thread frames decisions, collaborates with peers, routes concrete work to execution models, and verifies the outcome. Prefer tcode Orchestrate over provider-native subagents and compare profiles across all providers. Every main model may use /orchestrate; bundled decision peers are Astra and Fable 5.1."
+    description: "The main thread frames decisions, collaborates with peers, routes concrete work to execution models, and verifies the outcome. Prefer Tcode Orchestrate over provider-native subagents and compare profiles across all providers. Every main model may use /orchestrate; bundled decision peers are Astra and Fable 5.1."
   decisions:
     title: "Collaboration models"
     description: "Astra and Fable 5.1 provide independent perspectives through collaborate. Astra may gather focused app-UI evidence with Computer Use when enabled; implementation and bulk sweeps remain execution work. Switches only control consultation, not use as the main decision model. Collaboration supports medium and high only."
@@ -403,7 +403,7 @@ providers:
     checking: "Checking provider status"
     checking_detail: "Waiting for the server to report installation and authentication details."
     disabled: "Disabled"
-    disabled_detail: "This provider is installed but disabled for new sessions in tcode."
+    disabled_detail: "This provider is installed but disabled for new sessions in Tcode."
     not_found: "Not found"
     not_found_detail: "CLI not detected on PATH."
     authenticated: "Authenticated"
@@ -437,9 +437,9 @@ providers:
   updating: "Updating"
   update_manual: "or, update manually using"
   copy_command: "Copy command"
-  tcode_update_available: "tcode %{version} available"
-  tcode_update_aria: "tcode update available — view details"
-  tcode_update_title: "tcode update available"
+  tcode_update_available: "Tcode %{version} available"
+  tcode_update_aria: "Tcode update available — view details"
+  tcode_update_title: "Tcode update available"
   tcode_update_message: "Download the latest release from GitHub."
   view_release: "View release"
   # Per-profile settings dialog (opened from a provider row's gear).
@@ -496,7 +496,7 @@ providers:
   pi_trust_project_extensions: "Trust project extensions"
   pi_trust_project_extensions_help: "Launch pi with --approve so extensions, settings, and skills in the project's .pi directory are loaded."
   pi_native_approvals: "Native approvals"
-  pi_native_approvals_help: "Inject a tcode permission extension into pi so supervised modes can confirm commands, edits, and extension tools natively. Off keeps pi sessions injection-free (full access)."
+  pi_native_approvals_help: "Inject a Tcode permission extension into pi so supervised modes can confirm commands, edits, and extension tools natively. Off keeps pi sessions injection-free (full access)."
   models:
     title: "Models"
     count: "%{count} models available."
@@ -549,7 +549,7 @@ palette:
   open_preview: "Open preview"
   check_updates: "Check for provider updates"
   merge_worktree: "Merge active worktree back"
-  export_jsonl: "Export active thread as tcode JSONL"
+  export_jsonl: "Export active thread as Tcode JSONL"
   export_markdown: "Export active thread as Markdown"
   actions: "Actions"
   results: "Command palette results"
@@ -561,7 +561,7 @@ palette:
   close: "Esc Close"
 composer:
   relay_title: "Conversation relay"
-  relay_description: "%{to} cannot natively resume this %{from} conversation. tcode will hand off the accumulated context before sending your message."
+  relay_description: "%{to} cannot natively resume this %{from} conversation. Tcode will hand off the accumulated context before sending your message."
   relay_confirm: "Confirm & send"
   relay_cancel: "Cancel"
   placeholder: "Ask anything, @tag files/folders, $use skills, or / for commands"
@@ -626,7 +626,7 @@ composer:
   cmd_plan_desc: "Switch this thread into plan mode"
   cmd_default_desc: "Switch this thread back to normal build mode"
   cmd_orchestrate_label: "orchestrate"
-  cmd_orchestrate_desc: "Coordinate work through child tcode threads"
+  cmd_orchestrate_desc: "Coordinate work through child Tcode threads"
   group_builtin: "Built-in"
   group_provider: "Provider"
   group_skills: "Skills"
@@ -728,11 +728,11 @@ userinput:
   done: "Done"
 fallback:
   title: "Turn stopped by the safety classifier"
-  reason_cyber: "Claude Code's safety classifier flagged this turn as potentially cyber-related. tcode stopped it instead of letting Claude silently switch models."
-  reason_bio: "Claude Code's safety classifier flagged this turn as potentially biology-related. tcode stopped it instead of letting Claude silently switch models."
-  reason_generic: "Claude Code's safety classifier flagged this turn. tcode stopped it instead of letting Claude silently switch models."
+  reason_cyber: "Claude Code's safety classifier flagged this turn as potentially cyber-related. Tcode stopped it instead of letting Claude silently switch models."
+  reason_bio: "Claude Code's safety classifier flagged this turn as potentially biology-related. Tcode stopped it instead of letting Claude silently switch models."
+  reason_generic: "Claude Code's safety classifier flagged this turn. Tcode stopped it instead of letting Claude silently switch models."
   blocked: "%{model} refused the request."
-  rerouted: "Claude rerouted to %{model}; tcode interrupted the turn."
+  rerouted: "Claude rerouted to %{model}; Tcode interrupted the turn."
   retry_on: "Retry on %{model}"
   edit_retry: "Edit & retry"
   dismiss: "Dismiss"
@@ -841,7 +841,7 @@ notice:
   worktree_merge_git_error: "Could not merge the worktree branch: %{error}"
   dirty_tree: "Working tree has uncommitted changes"
   update_available: "Update Available: %{provider} v%{version}"
-  tcode_update_available: "tcode %{version} available"
+  tcode_update_available: "Tcode %{version} available"
   updating_provider: "Updating %{provider}…"
   update_done: "%{provider} updated"
 attach:
@@ -867,7 +867,7 @@ preview:
   no_backend_hint: "Open the page in your system browser, or copy its URL."
   unsupported_client: "this device has no embedded browser, so the preview tools are unavailable here"
   unavailable: "The preview browser could not start."
-  unavailable_hint: "It needs the system webview component. Everything else in tcode works without it."
+  unavailable_hint: "It needs the system webview component. Everything else in Tcode works without it."
 git:
   action:
     commit: "Commit"
@@ -990,7 +990,7 @@ hosts:
     address_placeholder: "192.168.1.10:47420"
     code_placeholder: "123456"
     scan: "Scan a QR code"
-    bad_invite: "That is not a tcode connection link."
+    bad_invite: "That is not a Tcode connection link."
     filled: "Connection details filled in."
     connect_host: "Connect to %{name}"
     bad_code: "A connection code is six digits."
@@ -1031,7 +1031,7 @@ mobile:
 web_auth:
   setup: "Set a password"
   login: "Log in"
-  description: "Open tcode on this machine with its password."
+  description: "Open Tcode on this machine with its password."
   password: "Password"
   confirm: "Confirm password"
   minimum: "At least 8 characters"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -1,5 +1,5 @@
 app:
-  name: "tcode"
+  name: "Tcode"
 chat:
   sending: "正在发送…"
   waiting_connection: "等待连接…"
@@ -64,7 +64,7 @@ chat:
   open_zed: "在 Zed 中打开"
   empty_title: "选择一个对话以继续"
   no_projects_title: "添加一个项目以开始"
-  no_projects_description: "tcode 在项目文件夹中工作。添加一个项目即可开始第一个对话。"
+  no_projects_description: "Tcode 在项目文件夹中工作。添加一个项目即可开始第一个对话。"
   start_hub_title: "开始新对话"
   palette_hint: "或按 %{shortcut} 搜索"
   scroll_end: "滚动到底部"
@@ -142,7 +142,7 @@ sidebar:
   auto_archived: "已自动归档 %{count} 个不活跃对话 — 查看"
   auto_archive_dialog:
     title: "对话已自动归档"
-    body: "tcode 已自动归档 %{count} 个超过 %{days} 天未活动且排在最近 %{keep} 条之外的对话。你可以在 设置 → 已归档对话 中恢复它们，或在设置中关闭自动归档。"
+    body: "Tcode 已自动归档 %{count} 个超过 %{days} 天未活动且排在最近 %{keep} 条之外的对话。你可以在 设置 → 已归档对话 中恢复它们，或在设置中关闭自动归档。"
     got_it: "知道了"
     open_settings: "打开设置"
   working: "工作中"
@@ -162,7 +162,7 @@ sidebar:
   archive_all_action: "归档全部"
   remove_project: "删除项目"
   remove_project_title: "删除项目“%{project}”？"
-  remove_project_description: "这将从 tcode 中删除此项目及其 %{count} 个对话，但不会改动磁盘上的文件。"
+  remove_project_description: "这将从 Tcode 中删除此项目及其 %{count} 个对话，但不会改动磁盘上的文件。"
   remove_project_action: "删除项目"
   reveal_project: "在访达中显示"
   ctx_rename: "重命名对话"
@@ -175,7 +175,7 @@ sidebar:
   ctx_mark_unread: "标记为未读"
   ctx_copy_path: "复制工作区路径"
   ctx_copy_id: "复制对话 ID"
-  ctx_export_jsonl: "导出为 tcode JSONL"
+  ctx_export_jsonl: "导出为 Tcode JSONL"
   ctx_export_markdown: "导出为 Markdown"
   ctx_delete: "删除"
   delete_title: "删除对话“%{title}”？"
@@ -187,8 +187,8 @@ sidebar:
   worktree_cleanup_keep: "保留工作树"
   empty: "还没有项目，请添加一个项目以开始。"
 quit:
-  menu_item: "退出 tcode"
-  title: "退出 tcode？"
+  menu_item: "退出 Tcode"
+  title: "退出 Tcode？"
   description: "仍有 %{count} 个会话正在工作。退出将停止这些会话。"
   confirm: "退出"
 settings:
@@ -238,13 +238,13 @@ settings:
   reset_section: "重置"
   language:
     title: "语言"
-    description: "选择 tcode 的界面语言。"
+    description: "选择 Tcode 的界面语言。"
     system: "跟随系统"
     english: "English"
     chinese: "简体中文"
   theme:
     title: "主题"
-    description: "选择 tcode 的界面外观。"
+    description: "选择 Tcode 的界面外观。"
     system: "跟随系统"
     light: "浅色"
     dark: "深色"
@@ -266,16 +266,16 @@ settings:
     description: "命令执行时自动展开其面板并实时显示输出，完成后自动收起。"
   provider_updates:
     title: "提供方更新检查"
-    description: "启动时检查 tcode 和提供方 CLI 的新版本。"
+    description: "启动时检查 Tcode 和提供方 CLI 的新版本。"
   inactive_frame_throttle:
     title: "后台帧率限制"
     description: "窗口失焦时将刷新率降至约 2 FPS 以节省能耗。重启后生效。"
   abort_on_model_fallback:
     title: "模型回退时中止"
-    description: "开启后，tcode 会监控 Claude Code 的流，在检测到安全分类器回退或标记时从对话层面停止当前轮次，并将控制权交还给你。子代理不受影响。"
+    description: "开启后，Tcode 会监控 Claude Code 的流，在检测到安全分类器回退或标记时从对话层面停止当前轮次，并将控制权交还给你。子代理不受影响。"
   resume_on_limit_reset:
     title: "额度重置后继续任务"
-    description: "当 Claude Code 因 5 小时用量窗口耗尽而停止本轮时，tcode 会在窗口重置的时刻自动继续任务。关闭后，错误卡片上会提供一个按钮供手动安排。"
+    description: "当 Claude Code 因 5 小时用量窗口耗尽而停止本轮时，Tcode 会在窗口重置的时刻自动继续任务。关闭后，错误卡片上会提供一个按钮供手动安排。"
   fallback_review_advisor:
     title: "回退审查顾问"
     description: "使用独立模型审查被 Claude Code 回退防护中断的请求。"
@@ -335,8 +335,8 @@ permissions:
   recheck: "重新检查"
   unsupported: "仅在 macOS 上可用。"
   manage_on_host: "请在 %{host} 上管理系统权限。"
-  restart_banner: "屏幕录制授权需重新启动 tcode 后才会生效。"
-  relaunch: "重新启动 tcode"
+  restart_banner: "屏幕录制授权需重新启动 Tcode 后才会生效。"
+  relaunch: "重新启动 Tcode"
   accessibility:
     name: "辅助功能"
     why: "读取屏幕上的辅助功能树，并发送键盘和鼠标事件。"
@@ -358,7 +358,7 @@ orchestrate:
     description: "派发目录为 Git 仓库根目录时，为子线程创建专用的 tcode/<thread-id> 分支和工作树。每次派发可通过 worktree 单独覆盖。"
   all_models:
     title: "Orchestrate 工作流程"
-    description: "主线程负责形成决策、与同级模型协作、将具体工作派发给执行模型并验收结果。优先使用 tcode Orchestrate，综合所有提供方的模型特点选择协作方和执行者。所有主模型均可使用 /orchestrate；内置决策模型为 Astra 和 Fable 5.1。"
+    description: "主线程负责形成决策、与同级模型协作、将具体工作派发给执行模型并验收结果。优先使用 Tcode Orchestrate，综合所有提供方的模型特点选择协作方和执行者。所有主模型均可使用 /orchestrate；内置决策模型为 Astra 和 Fable 5.1。"
   decisions:
     title: "协作模型"
     description: "Astra 与 Fable 5.1 通过 collaborate 提供独立视角。启用电脑操作后，Astra 可收集聚焦的应用界面证据；实现与批量检查仍属于执行任务。开关仅控制是否可被邀请协作，不影响作为主决策模型使用；协作仅支持 medium 和 high。"
@@ -401,7 +401,7 @@ providers:
     checking: "正在检查提供方状态"
     checking_detail: "正在等待服务返回安装与认证详情。"
     disabled: "已禁用"
-    disabled_detail: "该提供方已安装，但在 tcode 中已被禁用，不会用于新会话。"
+    disabled_detail: "该提供方已安装，但在 Tcode 中已被禁用，不会用于新会话。"
     not_found: "未找到"
     not_found_detail: "未在 PATH 中检测到该 CLI。"
     authenticated: "已认证"
@@ -433,9 +433,9 @@ providers:
   updating: "更新中"
   update_manual: "或者手动更新："
   copy_command: "复制命令"
-  tcode_update_available: "tcode %{version} 可用"
-  tcode_update_aria: "tcode 有可用更新 — 查看详情"
-  tcode_update_title: "tcode 有可用更新"
+  tcode_update_available: "Tcode %{version} 可用"
+  tcode_update_aria: "Tcode 有可用更新 — 查看详情"
+  tcode_update_title: "Tcode 有可用更新"
   tcode_update_message: "从 GitHub 下载最新版本。"
   view_release: "查看发布版本"
   # 单个配置的设置对话框（点击提供方行的齿轮图标打开）。
@@ -492,7 +492,7 @@ providers:
   pi_trust_project_extensions: "信任项目扩展"
   pi_trust_project_extensions_help: "以 --approve 启动 pi，加载项目 .pi 目录中的扩展、设置与技能。"
   pi_native_approvals: "原生审批"
-  pi_native_approvals_help: "向 pi 注入 tcode 权限扩展，使监督类模式可对命令、编辑与扩展工具进行原生确认。关闭则保持 pi 会话零注入（完全访问）。"
+  pi_native_approvals_help: "向 pi 注入 Tcode 权限扩展，使监督类模式可对命令、编辑与扩展工具进行原生确认。关闭则保持 pi 会话零注入（完全访问）。"
   models:
     title: "模型"
     count: "有 %{count} 个可用模型。"
@@ -543,7 +543,7 @@ palette:
   open_preview: "打开预览"
   check_updates: "检查提供方更新"
   merge_worktree: "将当前工作树合并回主检出目录"
-  export_jsonl: "将当前对话导出为 tcode JSONL"
+  export_jsonl: "将当前对话导出为 Tcode JSONL"
   export_markdown: "将当前对话导出为 Markdown"
   actions: "操作"
   results: "命令面板结果"
@@ -555,7 +555,7 @@ palette:
   close: "Esc 关闭"
 composer:
   relay_title: "会话接力"
-  relay_description: "%{to} 无法原生恢复此 %{from} 会话。tcode 会先移交累积的上下文，再发送你的消息。"
+  relay_description: "%{to} 无法原生恢复此 %{from} 会话。Tcode 会先移交累积的上下文，再发送你的消息。"
   relay_confirm: "确认并发送"
   relay_cancel: "取消"
   placeholder: "提问、@引用文件/文件夹、$使用技能，或输入 / 执行命令"
@@ -620,7 +620,7 @@ composer:
   cmd_plan_desc: "将此会话切换到计划模式"
   cmd_default_desc: "将此会话切换回普通构建模式"
   cmd_orchestrate_label: "orchestrate"
-  cmd_orchestrate_desc: "通过 tcode 子会话协调工作"
+  cmd_orchestrate_desc: "通过 Tcode 子会话协调工作"
   group_builtin: "内置"
   group_provider: "提供方"
   group_skills: "技能"
@@ -722,11 +722,11 @@ userinput:
   done: "完成"
 fallback:
   title: "本轮已被安全分类器中止"
-  reason_cyber: "Claude Code 的安全分类器认为本轮可能涉及网络安全内容。tcode 已将其中止，而不是让 Claude 悄悄切换模型。"
-  reason_bio: "Claude Code 的安全分类器认为本轮可能涉及生物学内容。tcode 已将其中止，而不是让 Claude 悄悄切换模型。"
-  reason_generic: "Claude Code 的安全分类器标记了本轮对话。tcode 已将其中止，而不是让 Claude 悄悄切换模型。"
+  reason_cyber: "Claude Code 的安全分类器认为本轮可能涉及网络安全内容。Tcode 已将其中止，而不是让 Claude 悄悄切换模型。"
+  reason_bio: "Claude Code 的安全分类器认为本轮可能涉及生物学内容。Tcode 已将其中止，而不是让 Claude 悄悄切换模型。"
+  reason_generic: "Claude Code 的安全分类器标记了本轮对话。Tcode 已将其中止，而不是让 Claude 悄悄切换模型。"
   blocked: "%{model} 拒绝了该请求。"
-  rerouted: "Claude 已改用 %{model}，tcode 中断了本轮。"
+  rerouted: "Claude 已改用 %{model}，Tcode 中断了本轮。"
   retry_on: "换用 %{model} 重试"
   edit_retry: "修改后重试"
   dismiss: "关闭"
@@ -835,7 +835,7 @@ notice:
   worktree_merge_git_error: "无法合并工作树分支：%{error}"
   dirty_tree: "工作树中有未提交的更改"
   update_available: "有可用更新：%{provider} v%{version}"
-  tcode_update_available: "tcode %{version} 可用"
+  tcode_update_available: "Tcode %{version} 可用"
   updating_provider: "正在更新 %{provider}…"
   update_done: "%{provider} 已更新"
 attach:
@@ -861,7 +861,7 @@ preview:
   no_backend_hint: "请在系统浏览器中打开该页面，或复制其网址。"
   unsupported_client: "这台设备没有内嵌浏览器，预览工具在这里不可用"
   unavailable: "预览浏览器无法启动。"
-  unavailable_hint: "它需要系统的 webview 组件。tcode 的其他功能不受影响。"
+  unavailable_hint: "它需要系统的 webview 组件。Tcode 的其他功能不受影响。"
 git:
   action:
     commit: "提交"
@@ -984,7 +984,7 @@ hosts:
     address_placeholder: "192.168.1.10:47420"
     code_placeholder: "123456"
     scan: "扫描二维码"
-    bad_invite: "这不是有效的 tcode 连接链接。"
+    bad_invite: "这不是有效的 Tcode 连接链接。"
     filled: "已从连接链接填入。"
     connect_host: "连接到 %{name}"
     bad_code: "连接码必须为六位数字。"
@@ -1025,7 +1025,7 @@ mobile:
 web_auth:
   setup: "设置密码"
   login: "登录"
-  description: "输入密码以使用这台主机上的 tcode。"
+  description: "输入密码以使用这台主机上的 Tcode。"
   password: "密码"
   confirm: "再次输入密码"
   minimum: "至少 8 个字符"


### PR DESCRIPTION
The product name now appears as **Tcode** in the shared shell, native menu/window captions, Android app label, iOS permission prompts, web startup/accessibility text, both locales, provider display titles and warnings, MCP help, Markdown exports, and user documentation. Commands, crate names, protocol/server IDs, URLs, filenames, storage keys and data directories retain `tcode`.

Reuses the existing `app.name` locale key for standalone shared-UI names instead of adding a competing constant or locale key. Existing packaging already uses Tcode for macOS/iOS display names and release notes; those technical packaging references remain unchanged. Headless CLI references remain command names. No new abstraction or text-mirroring test was added. The existing Markdown export fixture and provider-status expectation were updated for the visible wording; JSONL compatibility coverage remains intact.

Validation so far:
- `cargo fmt --all --check` and `git diff --check`: pass.
- `cargo test -p tcode-services --locked export::`: 3 passed.
- `cargo test -p tcode-ui --locked i18n::`: 3 passed, including locale parity.
- `node --test crates/web/static/auth.test.mjs`: 2 passed.
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: final rerun passed after restoring the required app title field with `app.name`.
- `cargo build --workspace --locked`: passed. The debug link emits an existing-size warning about `__eh_frame`; Cargo also reports future incompatibility in dependency `block` 0.1.6.
- `cargo test --workspace --locked`: passed; suite summaries report 1,083 passes and 5 explicit ignores (includes child-process fixture summaries), including all 392 UI tests.
- `cargo-machete` 0.9.2: passed. This installation's `cargo machete` wrapper treats the subcommand as a directory; direct invocation works. GitHub Dependency hygiene also passed.
- `RUSTFLAGS='-D warnings' IPHONEOS_DEPLOYMENT_TARGET=26.0 cargo check -p tcode-ios --target aarch64-apple-ios-sim --locked`: passed.
- `RUSTFLAGS='-D warnings' cargo check -p tcode-web --target wasm32-unknown-unknown --locked`: passed.
- `RUSTFLAGS='-D warnings' CARGO_NDK_PLATFORM=26 cargo ndk -t arm64-v8a check -p tcode-android --locked`: local toolchain unavailable (no Android NDK found). GitHub Mobile and web checks passed on the same commit.
- `python3 .github/scripts/test_ci_scope.py`: passed (13 tests, 9 explicitly skipped).
- Actual macOS GUI verification completed on this commit in the copied review app with `TCODE_DATA_DIR=/tmp/377-evidence/profiles/light`. Fresh isolated startup AX reports window **Tcode**, never `app.name`; sidebar and empty-project description show Tcode. English and Chinese General Settings prose was inspected in both themes at normal and narrow widths, with no branding-related clipping.
- Local GUI evidence: `/tmp/377-evidence/light-wide-startup.png`; `{light,dark}-{wide,narrow}-settings.png`; `zh-{light,dark}-{wide,narrow}-settings.png`; `final-window-ax.txt`. Normal captures are approximately 1152×768 (the default 1200×800 window rendered by the capture tool); narrow captures are 668–669×800. These local paths are for lead inspection, not hosted PR attachments.
- Review app was quit and no `/tmp/377-evidence` process remains. GUI slot released. Native phone launch screens, OS notification dialogs and the browser canvas were not separately driven; native metadata/source checks and passing mobile/Web CI cover those build surfaces.
- All six GitHub checks passed: Plan CI scope, Dependency hygiene, macOS arm64, Linux x64, Windows x64, and Mobile and web checks. Awaiting lead acceptance; not merged.

The repository description is empty and remains unchanged.

Closes #377.
