### PR TITLE
Fix macOS action cursor updates and session-scoped cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,6 +1452,7 @@ dependencies = [
  "tcode-core",
  "tcode-services",
  "tokio",
+ "tokio-util",
  "uiautomation",
  "windows 0.62.2",
 ]
@@ -8828,6 +8829,7 @@ dependencies = [
  "base64 0.23.1",
  "computer-use-mcp",
  "log",
+ "mcp-host",
  "orchestrate-mcp",
  "preview-mcp",
  "serde",
@@ -9231,6 +9233,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/computer-use-mcp/Cargo.toml
+++ b/crates/computer-use-mcp/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { version = "1", features = [
     "time",
     "sync",
 ] }
+tokio-util = { version = "0.7", features = ["rt"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = "1"
@@ -43,3 +44,7 @@ windows = { version = "=0.62.2", features = [
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",
 ] }
+
+[[test]]
+name = "macos_overlay"
+harness = false

--- a/crates/computer-use-mcp/src/backend.rs
+++ b/crates/computer-use-mcp/src/backend.rs
@@ -247,8 +247,38 @@ impl std::error::Error for BackendError {}
 
 #[cfg(target_os = "macos")]
 pub use macos::{observe, perform_action};
+
+pub(crate) fn set_feedback_enabled(enabled: bool) {
+    #[cfg(target_os = "macos")]
+    macos::set_feedback_enabled(enabled);
+    #[cfg(not(target_os = "macos"))]
+    let _ = enabled;
+}
+
+pub(crate) fn clear_feedback(owner: Option<u64>, action: Option<u64>) {
+    #[cfg(target_os = "macos")]
+    macos::clear_feedback(owner, action);
+    #[cfg(not(target_os = "macos"))]
+    let _ = (owner, action);
+}
 #[cfg(target_os = "windows")]
 pub use windows::{observe, perform_action};
+
+pub(crate) fn perform_action_with_feedback(
+    root: &RootInfo,
+    request: &ActionRequest,
+    feedback: &crate::feedback::FeedbackRun,
+) -> Result<ActionResult, BackendError> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::perform_action_with_feedback(root, request, Some(feedback))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = feedback;
+        perform_action(root, request)
+    }
+}
 
 /// Enumerate desktop roots. The host process is never a root: in-process
 /// accessibility queries run the host's own accessibility callbacks on the

--- a/crates/computer-use-mcp/src/backend/macos/mod.rs
+++ b/crates/computer-use-mcp/src/backend/macos/mod.rs
@@ -126,7 +126,15 @@ pub fn perform_action(
     root: &RootInfo,
     request: &ActionRequest,
 ) -> Result<ActionResult, BackendError> {
-    reflect_overlay(root, request);
+    perform_action_with_feedback(root, request, None)
+}
+
+pub(crate) fn perform_action_with_feedback(
+    root: &RootInfo,
+    request: &ActionRequest,
+    feedback: Option<&crate::feedback::FeedbackRun>,
+) -> Result<ActionResult, BackendError> {
+    reflect_overlay(root, request, feedback);
     match request.kind {
         ActionKind::Press => {
             let target = target(root, request)?;
@@ -428,24 +436,37 @@ fn keyboard_result_with_optional_foreground(
     }
 }
 
-fn reflect_overlay(root: &RootInfo, request: &ActionRequest) {
-    let enabled = crate::config::get().show_agent_cursor;
-    overlay::set_enabled(enabled);
-    if !enabled {
+fn reflect_overlay(
+    root: &RootInfo,
+    request: &ActionRequest,
+    feedback: Option<&crate::feedback::FeedbackRun>,
+) {
+    let Some(publication) = overlay::begin_action(feedback.map(|run| run.ticket())) else {
         return;
-    }
+    };
     use overlay::OverlayActionKind as K;
     match request.kind {
         ActionKind::Drag => {
             if let Some(path) = request.path.as_ref()
                 && let (Some(first), Some(last)) = (path.first(), path.last())
             {
-                overlay::show_drag(root.pid, (first[0], first[1]), (last[0], last[1]));
+                overlay::show_drag(
+                    publication,
+                    root.pid,
+                    root.window_id,
+                    (first[0], first[1]),
+                    (last[0], last[1]),
+                );
             }
         }
         ActionKind::TypeText | ActionKind::SetText | ActionKind::Keypress => {
-            if let Ok(point) = action_point(root, request) {
-                overlay::show_action(root.pid, K::Keyboard, point);
+            // Untargeted typing/key chords are valid backend actions. Their
+            // feedback belongs to the current root, not the previous pointer.
+            let point = action_point(root, request)
+                .ok()
+                .or_else(|| root.frame.has_area().then(|| root.frame.center()));
+            if let Some(point) = point {
+                overlay::show_action(publication, root.pid, root.window_id, K::Keyboard, point);
             }
         }
         other => {
@@ -455,7 +476,7 @@ fn reflect_overlay(root: &RootInfo, request: &ActionRequest) {
                 _ => K::Click,
             };
             if let Ok(point) = action_point(root, request) {
-                overlay::show_action(root.pid, kind, point);
+                overlay::show_action(publication, root.pid, root.window_id, kind, point);
             }
         }
     }
@@ -538,3 +559,5 @@ fn window_bounds(dictionary: CFDictionaryRef) -> Option<crate::outline::Frame> {
         h: number("Height")?,
     })
 }
+
+pub(crate) use overlay::{clear as clear_feedback, set_enabled as set_feedback_enabled};

--- a/crates/computer-use-mcp/src/backend/macos/overlay/cursor.rs
+++ b/crates/computer-use-mcp/src/backend/macos/overlay/cursor.rs
@@ -109,11 +109,12 @@ impl CursorUi {
         self.set_kind(kind);
         let appkit_point = ax_screen_to_appkit(ax_point, display);
         if self.visible {
-            animate_window_origin(self.window, window_origin(appkit_point));
+            animate_window_origin(self.window, window_origin(appkit_point), ANIMATION_DURATION);
         } else {
             // A hidden panel has no on-screen position to slide from: land on
-            // the point, then reveal.
-            let _ = send_void_point(self.window, c"setFrameOrigin:", window_origin(appkit_point));
+            // the point, then reveal. A zero-duration frame animation also
+            // supersedes any animation still running when the panel was hidden.
+            animate_window_origin(self.window, window_origin(appkit_point), 0.0);
         }
         self.set_visible(visible);
     }
@@ -130,9 +131,9 @@ impl CursorUi {
         self.set_kind(OverlayActionKind::Drag);
         let from = ax_screen_to_appkit(from_ax, from_display);
         let to = ax_screen_to_appkit(to_ax, to_display);
-        let _ = send_void_point(self.window, c"setFrameOrigin:", window_origin(from));
+        animate_window_origin(self.window, window_origin(from), 0.0);
         self.set_visible(visible);
-        animate_window_origin(self.window, window_origin(to));
+        animate_window_origin(self.window, window_origin(to), ANIMATION_DURATION);
     }
 
     /// Must only be called from the process main queue.
@@ -197,7 +198,7 @@ fn cursor_path() -> Option<Id> {
     send_id(path, c"CGPath")
 }
 
-fn animate_window_origin(window: Id, origin: CGPoint) {
+fn animate_window_origin(window: Id, origin: CGPoint, duration: f64) {
     let Some(context_class) = class(c"NSAnimationContext") else {
         let _ = send_void_point(window, c"setFrameOrigin:", origin);
         return;
@@ -208,7 +209,7 @@ fn animate_window_origin(window: Id, origin: CGPoint) {
     }
 
     let animated = send_id(context_class, c"currentContext").is_some_and(|context| {
-        let duration_set = send_void_f64(context, c"setDuration:", ANIMATION_DURATION);
+        let duration_set = send_void_f64(context, c"setDuration:", duration);
         if let Some(timing) = timing_function() {
             let _ = send_void_id(context, c"setTimingFunction:", timing);
         }
@@ -309,7 +310,7 @@ pub(super) fn verify_native() -> u32 {
         visible
             && (frame.origin.x - initial.origin.x - 100.0).abs() < 1.0
             && (frame.origin.y - initial.origin.y + 300.0).abs() < 1.0,
-        "an older animation must not restore its endpoint after hide and new feedback"
+        "an older animation must not restore its endpoint after hide and new feedback: {frame:?}, initial {initial:?}, visible {visible}"
     );
     assert!(super::ffi::window_exists(number));
     let _ = send_void(cursor.window, c"close");

--- a/crates/computer-use-mcp/src/backend/macos/overlay/cursor.rs
+++ b/crates/computer-use-mcp/src/backend/macos/overlay/cursor.rs
@@ -6,7 +6,8 @@ use super::OverlayActionKind;
 use super::ffi::{
     Id, class, send_id, send_id_color, send_id_cstr, send_id_id, send_id_rect, send_id_window_init,
     send_void, send_void_bool, send_void_f32, send_void_f64, send_void_id, send_void_isize,
-    send_void_point, send_void_rect, send_void_size, send_void_usize, status_window_level,
+    send_void_point, send_void_rect, send_void_rect_bool, send_void_size, send_void_usize,
+    status_window_level,
 };
 use super::geometry::{DisplayGeometry, ax_screen_to_appkit};
 
@@ -211,8 +212,16 @@ fn animate_window_origin(window: Id, origin: CGPoint) {
         if let Some(timing) = timing_function() {
             let _ = send_void_id(context, c"setTimingFunction:", timing);
         }
-        let moved = send_id(window, c"animator")
-            .is_some_and(|animator| send_void_point(animator, c"setFrameOrigin:", origin));
+        // NSWindow animates its full frame. Its animator accepts setFrameOrigin:
+        // but leaves an already-visible panel at the old point on macOS.
+        let moved = send_id(window, c"animator").is_some_and(|animator| {
+            send_void_rect_bool(
+                animator,
+                c"setFrame:display:",
+                rect(origin.x, origin.y, CURSOR_SIZE, CURSOR_SIZE),
+                true,
+            )
+        });
         duration_set && moved
     });
     let _ = send_void(context_class, c"endGrouping");
@@ -248,4 +257,54 @@ fn window_origin(point: (f64, f64)) -> CGPoint {
 
 fn rect(x: f64, y: f64, width: f64, height: f64) -> CGRect {
     CGRect::new(&CGPoint::new(x, y), &CGSize::new(width, height))
+}
+
+// Called by the main-thread, opt-in test harness. Normal libtest workers cannot
+// construct AppKit windows, so this regression has a dedicated native runner.
+#[cfg(all(test, target_arch = "aarch64"))]
+#[allow(dead_code)] // Also compiled by ordinary libtest, which cannot run AppKit.
+pub(super) fn verify_native() -> u32 {
+    use std::time::{Duration, Instant};
+    fn pump() {
+        let end = Instant::now() + Duration::from_millis(400);
+        while Instant::now() < end {
+            // SAFETY: this runner owns the process main thread and its run loop.
+            unsafe {
+                core_foundation::runloop::CFRunLoopRunInMode(
+                    core_foundation::runloop::kCFRunLoopDefaultMode,
+                    0.01,
+                    0,
+                );
+            }
+        }
+    }
+    let display = super::ffi::display_frame_for_ax_point((100.0, 100.0)).expect("desktop display");
+    let mut cursor = CursorUi::new().expect("native cursor panel");
+    cursor.show(OverlayActionKind::Click, (100.0, 100.0), display, true);
+    pump();
+    cursor.show(OverlayActionKind::Move, (300.0, 200.0), display, true);
+    pump();
+    let (frame, visible, passthrough, number) = super::ffi::native_panel_state(cursor.window);
+    let expected = window_origin(ax_screen_to_appkit((300.0, 200.0), display));
+    assert!(
+        (frame.origin.x - expected.x).abs() < 1.0 && (frame.origin.y - expected.y).abs() < 1.0,
+        "latest move must reach its endpoint: {frame:?}, expected {expected:?}"
+    );
+    assert!(visible && passthrough);
+    cursor.show_drag((300.0, 200.0), (500.0, 300.0), display, display, true);
+    pump();
+    let (frame, _, _, _) = super::ffi::native_panel_state(cursor.window);
+    let expected = window_origin(ax_screen_to_appkit((500.0, 300.0), display));
+    assert!(
+        (frame.origin.x - expected.x).abs() < 1.0 && (frame.origin.y - expected.y).abs() < 1.0,
+        "drag must reach its final endpoint, not remain at its start"
+    );
+    assert!(super::ffi::window_exists(number));
+    let _ = send_void(cursor.window, c"close");
+    pump();
+    assert!(
+        !super::ffi::window_exists(number),
+        "closed but retained native window must retire target feedback"
+    );
+    number
 }

--- a/crates/computer-use-mcp/src/backend/macos/overlay/cursor.rs
+++ b/crates/computer-use-mcp/src/backend/macos/overlay/cursor.rs
@@ -282,10 +282,11 @@ pub(super) fn verify_native() -> u32 {
     let mut cursor = CursorUi::new().expect("native cursor panel");
     cursor.show(OverlayActionKind::Click, (100.0, 100.0), display, true);
     pump();
+    let initial = super::ffi::native_panel_state(cursor.window).0;
     cursor.show(OverlayActionKind::Move, (300.0, 200.0), display, true);
     pump();
     let (frame, visible, passthrough, number) = super::ffi::native_panel_state(cursor.window);
-    let expected = window_origin(ax_screen_to_appkit((300.0, 200.0), display));
+    let expected = CGPoint::new(initial.origin.x + 200.0, initial.origin.y - 100.0);
     assert!(
         (frame.origin.x - expected.x).abs() < 1.0 && (frame.origin.y - expected.y).abs() < 1.0,
         "latest move must reach its endpoint: {frame:?}, expected {expected:?}"
@@ -294,10 +295,21 @@ pub(super) fn verify_native() -> u32 {
     cursor.show_drag((300.0, 200.0), (500.0, 300.0), display, display, true);
     pump();
     let (frame, _, _, _) = super::ffi::native_panel_state(cursor.window);
-    let expected = window_origin(ax_screen_to_appkit((500.0, 300.0), display));
+    let expected = CGPoint::new(initial.origin.x + 400.0, initial.origin.y - 200.0);
     assert!(
         (frame.origin.x - expected.x).abs() < 1.0 && (frame.origin.y - expected.y).abs() < 1.0,
         "drag must reach its final endpoint, not remain at its start"
+    );
+    cursor.show(OverlayActionKind::Move, (700.0, 100.0), display, true);
+    cursor.hide();
+    cursor.show(OverlayActionKind::Click, (200.0, 400.0), display, true);
+    pump();
+    let (frame, visible, _, _) = super::ffi::native_panel_state(cursor.window);
+    assert!(
+        visible
+            && (frame.origin.x - initial.origin.x - 100.0).abs() < 1.0
+            && (frame.origin.y - initial.origin.y + 300.0).abs() < 1.0,
+        "an older animation must not restore its endpoint after hide and new feedback"
     );
     assert!(super::ffi::window_exists(number));
     let _ = send_void(cursor.window, c"close");

--- a/crates/computer-use-mcp/src/backend/macos/overlay/ffi.rs
+++ b/crates/computer-use-mcp/src/backend/macos/overlay/ffi.rs
@@ -372,3 +372,49 @@ pub(super) fn status_window_level() -> isize {
     // SAFETY: STATUS_WINDOW_LEVEL_KEY is a documented CGWindowLevelKey value.
     unsafe { CGWindowLevelForKey(STATUS_WINDOW_LEVEL_KEY) as isize }
 }
+
+pub(super) fn window_exists(window_id: u32) -> bool {
+    use core_foundation::base::TCFType;
+    use core_foundation::boolean::CFBoolean;
+    use core_foundation::dictionary::{CFDictionaryGetValue, CFDictionaryRef};
+    use core_graphics::window::{
+        copy_window_info, kCGWindowIsOnscreen, kCGWindowListOptionIncludingWindow,
+    };
+
+    let Some(windows) = copy_window_info(kCGWindowListOptionIncludingWindow, window_id) else {
+        return false;
+    };
+    windows.iter().any(|window| {
+        // SAFETY: CGWindowListCopyWindowInfo returns an array of dictionaries;
+        // the borrowed Boolean remains owned by that array throughout the query.
+        unsafe {
+            let dictionary = *window as CFDictionaryRef;
+            let value = CFDictionaryGetValue(dictionary, kCGWindowIsOnscreen.cast());
+            !value.is_null()
+                && core_foundation::base::CFGetTypeID(value) == CFBoolean::type_id()
+                && bool::from(CFBoolean::wrap_under_get_rule(value.cast()))
+        }
+    })
+}
+
+pub(super) fn send_void_rect_bool(receiver: Id, name: &CStr, value: CGRect, display: bool) -> bool {
+    let Some(selector) = selector(name) else {
+        return false;
+    };
+    if !can_send(receiver, selector) {
+        return false;
+    }
+    invoke!((), receiver, selector, CGRect => value, i8 => i8::from(display));
+    true
+}
+
+// These getters inspect the actual AppKit panel in the opt-in native regression.
+// CGRect's objc_msgSend return ABI here is specific to the arm64 runner.
+#[cfg(all(test, target_arch = "aarch64"))]
+pub(super) fn native_panel_state(window: Id) -> (CGRect, bool, bool, u32) {
+    let frame = invoke!(CGRect, window, selector(c"frame").unwrap());
+    let visible = invoke!(i8, window, selector(c"isVisible").unwrap()) != 0;
+    let passthrough = invoke!(i8, window, selector(c"ignoresMouseEvents").unwrap()) != 0;
+    let number = invoke!(isize, window, selector(c"windowNumber").unwrap()) as u32;
+    (frame, visible, passthrough, number)
+}

--- a/crates/computer-use-mcp/src/backend/macos/overlay/mod.rs
+++ b/crates/computer-use-mcp/src/backend/macos/overlay/mod.rs
@@ -4,14 +4,94 @@ mod geometry;
 
 use std::cell::RefCell;
 use std::ffi::c_void;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use cursor::CursorUi;
 
 use self::ffi::{class, dispatch_main, send_id, send_void};
 use self::geometry::is_finite_point;
 
-static ENABLED: AtomicBool = AtomicBool::new(false);
+static SUBMISSIONS: Mutex<Submissions> = Mutex::new(Submissions {
+    enabled: false,
+    revision: 0,
+    owner: None,
+});
+
+// The producer and main queue share this ordering boundary. Invalidation cannot
+// race a producer into enqueueing an obsolete action after the clear callback.
+struct Submissions {
+    enabled: bool,
+    revision: u64,
+    owner: Option<(u64, u64)>,
+}
+
+impl Submissions {
+    fn reserve(
+        &mut self,
+        feedback: Option<crate::feedback::FeedbackTicket>,
+        now: Instant,
+    ) -> Publication {
+        self.revision += 1;
+        self.owner = feedback
+            .as_ref()
+            .map(|ticket| (ticket.owner, ticket.action));
+        Publication {
+            revision: self.revision,
+            expires_at: now + ACTION_LIFETIME,
+            feedback,
+        }
+    }
+
+    fn accepts(&self, queued: &QueuedCommand, now: Instant) -> bool {
+        queued.publication.revision == self.revision
+            && (matches!(queued.command, UiCommand::Clear)
+                || (self.enabled && queued.publication.is_current(now)))
+    }
+
+    fn clear(
+        &mut self,
+        owner: Option<u64>,
+        action: Option<u64>,
+        now: Instant,
+    ) -> Option<QueuedCommand> {
+        if let Some(owner) = owner
+            && !self.owner.is_some_and(|current| {
+                current.0 == owner && action.is_none_or(|action| current.1 == action)
+            })
+        {
+            return None;
+        }
+        Some(QueuedCommand {
+            command: UiCommand::Clear,
+            publication: self.reserve(None, now),
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct Publication {
+    revision: u64,
+    expires_at: Instant,
+    feedback: Option<crate::feedback::FeedbackTicket>,
+}
+
+impl Publication {
+    fn is_current(&self, now: Instant) -> bool {
+        now < self.expires_at
+            && self
+                .feedback
+                .as_ref()
+                .is_none_or(|ticket| ticket.is_current())
+    }
+}
+
+struct QueuedCommand {
+    command: UiCommand,
+    publication: Publication,
+}
+
+const ACTION_LIFETIME: Duration = Duration::from_secs(1);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum OverlayActionKind {
@@ -23,42 +103,84 @@ pub(crate) enum OverlayActionKind {
 }
 
 pub(crate) fn set_enabled(on: bool) {
-    let was_enabled = ENABLED.swap(on, Ordering::AcqRel);
-    if was_enabled && !on {
-        clear();
+    let mut submissions = SUBMISSIONS.lock().unwrap();
+    let was_enabled = submissions.enabled;
+    submissions.enabled = on;
+    if was_enabled
+        && !on
+        && let Some(command) = submissions.clear(None, None, Instant::now())
+    {
+        enqueue(command);
     }
 }
 
-pub(crate) fn show_action(pid: u32, kind: OverlayActionKind, ax_screen_point: (f64, f64)) {
-    if !ENABLED.load(Ordering::Acquire) || !is_finite_point(ax_screen_point) {
-        return;
-    }
-    enqueue(UiCommand::ShowAction {
-        pid,
-        kind,
-        point: ax_screen_point,
-    });
+// Reserve before AX point lookup: an older, slow lookup cannot overwrite a
+// newer action or a disable/cancel that arrived while the lookup was blocked.
+pub(crate) fn begin_action(
+    feedback: Option<crate::feedback::FeedbackTicket>,
+) -> Option<Publication> {
+    let mut submissions = SUBMISSIONS.lock().unwrap();
+    (submissions.enabled && feedback.as_ref().is_none_or(|ticket| ticket.is_current()))
+        .then(|| submissions.reserve(feedback, Instant::now()))
 }
 
-pub(crate) fn show_drag(pid: u32, from: (f64, f64), to: (f64, f64)) {
-    if !ENABLED.load(Ordering::Acquire) || !is_finite_point(from) || !is_finite_point(to) {
-        return;
+pub(crate) fn show_action(
+    publication: Publication,
+    pid: u32,
+    window_id: u32,
+    kind: OverlayActionKind,
+    point: (f64, f64),
+) {
+    if is_finite_point(point) {
+        enqueue(QueuedCommand {
+            publication,
+            command: UiCommand::ShowAction {
+                pid,
+                window_id,
+                kind,
+                point,
+            },
+        });
     }
-    enqueue(UiCommand::ShowDrag { pid, from, to });
 }
 
-pub(crate) fn clear() {
-    enqueue(UiCommand::Clear);
+pub(crate) fn show_drag(
+    publication: Publication,
+    pid: u32,
+    window_id: u32,
+    from: (f64, f64),
+    to: (f64, f64),
+) {
+    if is_finite_point(from) && is_finite_point(to) {
+        enqueue(QueuedCommand {
+            publication,
+            command: UiCommand::ShowDrag {
+                pid,
+                window_id,
+                from,
+                to,
+            },
+        });
+    }
+}
+
+pub(crate) fn clear(owner: Option<u64>, action: Option<u64>) {
+    let mut submissions = SUBMISSIONS.lock().unwrap();
+    if let Some(command) = submissions.clear(owner, action, Instant::now()) {
+        enqueue(command);
+    }
 }
 
 enum UiCommand {
     ShowAction {
         pid: u32,
+        window_id: u32,
         kind: OverlayActionKind,
         point: (f64, f64),
     },
     ShowDrag {
         pid: u32,
+        window_id: u32,
         from: (f64, f64),
         to: (f64, f64),
     },
@@ -67,13 +189,24 @@ enum UiCommand {
 
 struct OverlayState {
     cursor: Option<CursorUi>,
-    target_pid: Option<u32>,
+    target: Option<Target>,
     poll_armed: bool,
 }
 
+#[derive(Clone, Debug)]
+struct Target {
+    pid: u32,
+    window_id: u32,
+    publication: Publication,
+}
+
 impl OverlayState {
-    fn show_action(&mut self, pid: u32, kind: OverlayActionKind, point: (f64, f64)) {
-        self.set_target(pid);
+    fn show_action(&mut self, target: Target, kind: OverlayActionKind, point: (f64, f64)) {
+        if !ffi::window_exists(target.window_id) {
+            self.clear();
+            return;
+        }
+        self.set_target(target.clone());
         let Some(display) = ffi::display_frame_for_ax_point(point) else {
             return;
         };
@@ -81,12 +214,16 @@ impl OverlayState {
             self.cursor = CursorUi::new();
         }
         if let Some(cursor) = self.cursor.as_mut() {
-            cursor.show(kind, point, display, is_target_frontmost(pid));
+            cursor.show(kind, point, display, is_target_frontmost(target.pid));
         }
     }
 
-    fn show_drag(&mut self, pid: u32, from: (f64, f64), to: (f64, f64)) {
-        self.set_target(pid);
+    fn show_drag(&mut self, target: Target, from: (f64, f64), to: (f64, f64)) {
+        if !ffi::window_exists(target.window_id) {
+            self.clear();
+            return;
+        }
+        self.set_target(target.clone());
         let Some(from_display) = ffi::display_frame_for_ax_point(from) else {
             return;
         };
@@ -95,12 +232,18 @@ impl OverlayState {
             self.cursor = CursorUi::new();
         }
         if let Some(cursor) = self.cursor.as_mut() {
-            cursor.show_drag(from, to, from_display, to_display, is_target_frontmost(pid));
+            cursor.show_drag(
+                from,
+                to,
+                from_display,
+                to_display,
+                is_target_frontmost(target.pid),
+            );
         }
     }
 
-    fn set_target(&mut self, pid: u32) {
-        self.target_pid = Some(pid);
+    fn set_target(&mut self, target: Target) {
+        self.target = Some(target);
         if !self.poll_armed
             && ffi::dispatch_main_after(FOREGROUND_POLL_INTERVAL_NS, poll_foreground)
         {
@@ -108,12 +251,11 @@ impl OverlayState {
         }
     }
 
-    fn refresh_visibility(&mut self) {
-        let Some(pid) = self.target_pid else {
+    fn refresh_visibility(&mut self, now: Instant, is_frontmost: bool, target_exists: bool) {
+        let Some(target) = self.target.as_ref() else {
             return;
         };
-        let is_frontmost = is_target_frontmost(pid);
-        if !is_frontmost && !target_process_exists(pid) {
+        if !target.publication.is_current(now) || !target_exists {
             self.clear();
             return;
         }
@@ -126,7 +268,7 @@ impl OverlayState {
         if let Some(cursor) = self.cursor.as_mut() {
             cursor.hide();
         }
-        self.target_pid = None;
+        self.target = None;
     }
 }
 
@@ -156,31 +298,31 @@ thread_local! {
     static MAIN_STATE: RefCell<OverlayState> = const {
         RefCell::new(OverlayState {
             cursor: None,
-            target_pid: None,
+            target: None,
             poll_armed: false,
         })
     };
 }
 
-fn enqueue(command: UiCommand) {
+fn enqueue(command: QueuedCommand) {
     let context = Box::into_raw(Box::new(command)).cast::<c_void>();
     if !dispatch_main(context, run_command) {
         // SAFETY: context came from Box::into_raw above and dispatch rejected it,
         // so no callback can own or free it.
-        drop(unsafe { Box::from_raw(context.cast::<UiCommand>()) });
+        drop(unsafe { Box::from_raw(context.cast::<QueuedCommand>()) });
     }
 }
 
-// SAFETY: libdispatch calls this only with the Box<UiCommand> created by enqueue.
+// SAFETY: libdispatch calls this only with the Box<QueuedCommand> created by enqueue.
 unsafe extern "C" fn run_command(context: *mut c_void) {
     if context.is_null() {
         return;
     }
-    // SAFETY: enqueue passes exactly one Box<UiCommand> to a callback that
+    // SAFETY: enqueue passes exactly one Box<QueuedCommand> to a callback that
     // libdispatch invokes exactly once.
-    let command = unsafe { Box::from_raw(context.cast::<UiCommand>()) };
-    let should_run = matches!(*command, UiCommand::Clear) || ENABLED.load(Ordering::Acquire);
-    if !should_run {
+    let command = unsafe { Box::from_raw(context.cast::<QueuedCommand>()) };
+    let submissions = SUBMISSIONS.lock().unwrap();
+    if !submissions.accepts(&command, Instant::now()) {
         return;
     }
 
@@ -192,9 +334,35 @@ unsafe extern "C" fn run_command(context: *mut c_void) {
         let Ok(mut state) = state.try_borrow_mut() else {
             return;
         };
-        match *command {
-            UiCommand::ShowAction { pid, kind, point } => state.show_action(pid, kind, point),
-            UiCommand::ShowDrag { pid, from, to } => state.show_drag(pid, from, to),
+        match command.command {
+            UiCommand::ShowAction {
+                pid,
+                window_id,
+                kind,
+                point,
+            } => state.show_action(
+                Target {
+                    pid,
+                    window_id,
+                    publication: command.publication.clone(),
+                },
+                kind,
+                point,
+            ),
+            UiCommand::ShowDrag {
+                pid,
+                window_id,
+                from,
+                to,
+            } => state.show_drag(
+                Target {
+                    pid,
+                    window_id,
+                    publication: command.publication.clone(),
+                },
+                from,
+                to,
+            ),
             UiCommand::Clear => state.clear(),
         }
     });
@@ -211,9 +379,15 @@ unsafe extern "C" fn poll_foreground(_context: *mut c_void) {
             return;
         };
         state.poll_armed = false;
-        if ENABLED.load(Ordering::Acquire) && state.target_pid.is_some() {
-            state.refresh_visibility();
-            if state.target_pid.is_some()
+        if SUBMISSIONS.lock().unwrap().enabled
+            && let Some(target) = state.target.clone()
+        {
+            state.refresh_visibility(
+                Instant::now(),
+                is_target_frontmost(target.pid),
+                target_process_exists(target.pid) && ffi::window_exists(target.window_id),
+            );
+            if state.target.is_some()
                 && ffi::dispatch_main_after(FOREGROUND_POLL_INTERVAL_NS, poll_foreground)
             {
                 state.poll_armed = true;
@@ -225,4 +399,183 @@ unsafe extern "C" fn poll_foreground(_context: *mut c_void) {
     if let Some(pool) = pool {
         let _ = send_void(pool, c"drain");
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn action(publication: Publication) -> QueuedCommand {
+        QueuedCommand {
+            publication,
+            command: UiCommand::ShowAction {
+                pid: 42,
+                window_id: 7,
+                kind: OverlayActionKind::Click,
+                point: (10.0, 20.0),
+            },
+        }
+    }
+    fn submissions() -> Submissions {
+        Submissions {
+            enabled: true,
+            revision: 0,
+            owner: None,
+        }
+    }
+    fn target(publication: Publication) -> Target {
+        Target {
+            pid: 42,
+            window_id: 7,
+            publication,
+        }
+    }
+
+    #[test]
+    fn inactive_action_retires_target_before_foreground_refresh() {
+        let now = Instant::now();
+        let mut state = OverlayState {
+            cursor: None,
+            target: None,
+            poll_armed: true,
+        };
+        state.set_target(target(submissions().reserve(None, now)));
+        state.refresh_visibility(now, true, true);
+        assert!(state.target.is_some());
+        state.refresh_visibility(now + Duration::from_secs(2), false, true);
+        assert!(
+            state.target.is_none(),
+            "idle feedback must not reappear on foreground refresh"
+        );
+        state.refresh_visibility(now + Duration::from_secs(3), true, true);
+        assert!(state.target.is_none());
+    }
+
+    #[test]
+    fn newer_action_renews_lifetime_but_closed_window_retires_it() {
+        let now = Instant::now();
+        let mut state = OverlayState {
+            cursor: None,
+            target: None,
+            poll_armed: true,
+        };
+        let mut submissions = submissions();
+        state.set_target(target(submissions.reserve(None, now)));
+        state.set_target(target(
+            submissions.reserve(None, now + Duration::from_millis(500)),
+        ));
+        state.refresh_visibility(now + ACTION_LIFETIME, false, true);
+        assert!(
+            state.target.is_some(),
+            "backgrounding does not retire a live action"
+        );
+        state.refresh_visibility(now + ACTION_LIFETIME, true, false);
+        assert!(
+            state.target.is_none(),
+            "closed window retires feedback while its app stays open"
+        );
+    }
+
+    #[test]
+    fn delayed_callbacks_cannot_restore_cleared_superseded_or_expired_feedback() {
+        let now = Instant::now();
+        let mut submissions = submissions();
+        let first = action(submissions.reserve(None, now));
+        assert!(submissions.accepts(&first, now));
+        let clear = submissions.clear(None, None, now).unwrap();
+        assert!(!submissions.accepts(&first, now));
+        assert!(submissions.accepts(&clear, now));
+        let newer = action(submissions.reserve(None, now));
+        assert!(
+            !submissions.accepts(&clear, now),
+            "late clear cannot erase newer feedback"
+        );
+        assert!(submissions.accepts(&newer, now));
+        assert!(
+            !submissions.accepts(&newer, now + ACTION_LIFETIME),
+            "queue delay consumes lifetime"
+        );
+        submissions.enabled = false;
+        let _disable = submissions.clear(None, None, now);
+        submissions.enabled = true;
+        assert!(
+            !submissions.accepts(&newer, now),
+            "re-enable cannot revive pre-disable work"
+        );
+    }
+
+    #[test]
+    fn cancelling_one_session_does_not_clear_another_sessions_newer_feedback() {
+        let now = Instant::now();
+        let mut submissions = submissions();
+        let first = crate::feedback::FeedbackSession::new();
+        let second = crate::feedback::FeedbackSession::new();
+        let old_run = first.begin(None);
+        let current_run = second.begin(None);
+        let old = action(submissions.reserve(Some(old_run.ticket()), now));
+        let current = action(submissions.reserve(Some(current_run.ticket()), now));
+        first.cancel();
+        assert!(!submissions.accepts(&old, now));
+        assert!(
+            submissions
+                .clear(Some(old_run.ticket().owner), None, now)
+                .is_none()
+        );
+        assert!(submissions.accepts(&current, now));
+        second.cancel();
+        assert!(
+            !submissions.accepts(&current, now),
+            "even an undelivered cancel callback invalidates the marker"
+        );
+        let restarted = second.begin(None);
+        let current = action(submissions.reserve(Some(restarted.ticket()), now));
+        assert!(
+            submissions
+                .clear(
+                    Some(current_run.ticket().owner),
+                    Some(current_run.ticket().action),
+                    now
+                )
+                .is_none(),
+            "a dropped older request cannot clear its successor"
+        );
+        assert!(submissions.accepts(&current, now));
+        drop(second);
+        assert!(
+            !submissions.accepts(&current, now),
+            "actual service teardown invalidates queued publication"
+        );
+    }
+}
+
+#[cfg(all(test, target_arch = "aarch64"))]
+#[allow(dead_code)] // Entry point for the opt-in main-thread integration runner.
+pub(crate) fn verify_native() {
+    let _ = class(c"NSApplication").and_then(|app| send_id(app, c"sharedApplication"));
+    let foreground = super::ax::frontmost_application_pid();
+    let closed_window = cursor::verify_native();
+    let mut state = OverlayState {
+        cursor: None,
+        target: None,
+        poll_armed: true,
+    };
+    let target = Target {
+        pid: std::process::id(),
+        window_id: closed_window,
+        publication: Publication {
+            revision: 1,
+            expires_at: Instant::now() + ACTION_LIFETIME,
+            feedback: None,
+        },
+    };
+    state.show_action(target, OverlayActionKind::Move, (300.0, 200.0));
+    assert!(
+        state.target.is_none() && state.cursor.is_none(),
+        "a queued action reaching a closed native target must not recreate a marker"
+    );
+    assert_eq!(
+        super::ax::frontmost_application_pid(),
+        foreground,
+        "overlay must not activate an app"
+    );
 }

--- a/crates/computer-use-mcp/src/backend/macos/overlay/mod.rs
+++ b/crates/computer-use-mcp/src/backend/macos/overlay/mod.rs
@@ -401,6 +401,38 @@ unsafe extern "C" fn poll_foreground(_context: *mut c_void) {
     }
 }
 
+#[cfg(all(test, target_arch = "aarch64"))]
+#[allow(dead_code)] // Entry point for the opt-in main-thread integration runner.
+pub(crate) fn verify_native() {
+    let _ = class(c"NSApplication").and_then(|app| send_id(app, c"sharedApplication"));
+    let foreground = super::ax::frontmost_application_pid();
+    let closed_window = cursor::verify_native();
+    let mut state = OverlayState {
+        cursor: None,
+        target: None,
+        poll_armed: true,
+    };
+    let target = Target {
+        pid: std::process::id(),
+        window_id: closed_window,
+        publication: Publication {
+            revision: 1,
+            expires_at: Instant::now() + ACTION_LIFETIME,
+            feedback: None,
+        },
+    };
+    state.show_action(target, OverlayActionKind::Move, (300.0, 200.0));
+    assert!(
+        state.target.is_none() && state.cursor.is_none(),
+        "a queued action reaching a closed native target must not recreate a marker"
+    );
+    assert_eq!(
+        super::ax::frontmost_application_pid(),
+        foreground,
+        "overlay must not activate an app"
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -546,36 +578,4 @@ mod tests {
             "actual service teardown invalidates queued publication"
         );
     }
-}
-
-#[cfg(all(test, target_arch = "aarch64"))]
-#[allow(dead_code)] // Entry point for the opt-in main-thread integration runner.
-pub(crate) fn verify_native() {
-    let _ = class(c"NSApplication").and_then(|app| send_id(app, c"sharedApplication"));
-    let foreground = super::ax::frontmost_application_pid();
-    let closed_window = cursor::verify_native();
-    let mut state = OverlayState {
-        cursor: None,
-        target: None,
-        poll_armed: true,
-    };
-    let target = Target {
-        pid: std::process::id(),
-        window_id: closed_window,
-        publication: Publication {
-            revision: 1,
-            expires_at: Instant::now() + ACTION_LIFETIME,
-            feedback: None,
-        },
-    };
-    state.show_action(target, OverlayActionKind::Move, (300.0, 200.0));
-    assert!(
-        state.target.is_none() && state.cursor.is_none(),
-        "a queued action reaching a closed native target must not recreate a marker"
-    );
-    assert_eq!(
-        super::ax::frontmost_application_pid(),
-        foreground,
-        "overlay must not activate an app"
-    );
 }

--- a/crates/computer-use-mcp/src/config.rs
+++ b/crates/computer-use-mcp/src/config.rs
@@ -15,7 +15,9 @@ static CONFIG: RwLock<ComputerUseSettings> = RwLock::new(ComputerUseSettings {
 });
 
 pub fn set(config: ComputerUseSettings) {
-    *CONFIG.write().unwrap() = config;
+    let mut current = CONFIG.write().unwrap();
+    crate::backend::set_feedback_enabled(config.enabled && config.show_agent_cursor);
+    *current = config;
 }
 
 pub fn get() -> ComputerUseSettings {

--- a/crates/computer-use-mcp/src/feedback.rs
+++ b/crates/computer-use-mcp/src/feedback.rs
@@ -1,0 +1,111 @@
+//! Feedback ownership follows authenticated MCP sessions, not registration metadata.
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Weak};
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug)]
+pub(crate) struct FeedbackSession {
+    state: Arc<FeedbackState>,
+}
+
+#[derive(Debug)]
+struct FeedbackState {
+    id: u64,
+    generation: AtomicU64,
+    closed: AtomicBool,
+}
+
+impl FeedbackSession {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: Arc::new(FeedbackState {
+                id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+                generation: AtomicU64::new(0),
+                closed: AtomicBool::new(false),
+            }),
+        })
+    }
+
+    pub(crate) fn begin(
+        self: &Arc<Self>,
+        cancellation: Option<tokio_util::sync::CancellationToken>,
+    ) -> FeedbackRun {
+        FeedbackRun {
+            ticket: FeedbackTicket {
+                owner: self.state.id,
+                action: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+                generation: self.state.generation.load(Ordering::Acquire),
+                session: Arc::downgrade(&self.state),
+                cancellation,
+            },
+            completed: false,
+        }
+    }
+
+    pub(crate) fn stop(&self) {
+        self.state.closed.store(true, Ordering::Release);
+        self.cancel();
+    }
+
+    pub(crate) fn cancel(&self) {
+        self.state.generation.fetch_add(1, Ordering::AcqRel);
+        crate::backend::clear_feedback(Some(self.state.id), None);
+    }
+}
+
+impl Drop for FeedbackSession {
+    fn drop(&mut self) {
+        crate::backend::clear_feedback(Some(self.state.id), None);
+    }
+}
+
+pub(crate) struct FeedbackRun {
+    ticket: FeedbackTicket,
+    completed: bool,
+}
+
+impl FeedbackRun {
+    #[cfg(any(target_os = "macos", test))]
+    pub(crate) fn ticket(&self) -> FeedbackTicket {
+        self.ticket.clone()
+    }
+    pub(crate) fn is_current(&self) -> bool {
+        self.ticket.is_current()
+    }
+    /// Successful actions retain only their bounded visual tail. Cancellation,
+    /// failure and a dropped request clear their own current marker immediately.
+    pub(crate) fn complete(&mut self) {
+        self.completed = true;
+    }
+}
+
+impl Drop for FeedbackRun {
+    fn drop(&mut self) {
+        if !self.completed {
+            crate::backend::clear_feedback(Some(self.ticket.owner), Some(self.ticket.action));
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct FeedbackTicket {
+    pub(crate) owner: u64,
+    pub(crate) action: u64,
+    generation: u64,
+    session: Weak<FeedbackState>,
+    cancellation: Option<tokio_util::sync::CancellationToken>,
+}
+
+impl FeedbackTicket {
+    pub(crate) fn is_current(&self) -> bool {
+        !self
+            .cancellation
+            .as_ref()
+            .is_some_and(|token| token.is_cancelled())
+            && self.session.upgrade().is_some_and(|session| {
+                !session.closed.load(Ordering::Acquire)
+                    && session.generation.load(Ordering::Acquire) == self.generation
+            })
+    }
+}

--- a/crates/computer-use-mcp/src/lib.rs
+++ b/crates/computer-use-mcp/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod backend;
 pub mod config;
+mod feedback;
 pub mod outline;
 pub mod permissions;
 pub mod state;
@@ -20,8 +21,8 @@ pub use backend::frontmost_pid;
 pub struct ComputerUseMcpServer {
     /// Streamable-HTTP endpoint, e.g. `http://127.0.0.1:53211/computer-use`.
     pub url: String,
-    /// Bearer token presented by every registered provider session.
-    pub token: String,
+    /// Per-session tokens and feedback cancellation controls.
+    pub tokens: TokenRegistry,
 }
 
 /// Diagnostic entry for `tcode --cu-smoke`: exercises the platform backend
@@ -74,10 +75,130 @@ pub fn smoke() -> String {
 /// Register the authenticated computer-use route on the shared MCP host.
 pub fn start(host: &mut mcp_host::Host) -> ComputerUseMcpServer {
     let url = host.url("/computer-use");
-    let tokens = mcp_host::TokenRegistry::<tools::Service>::new(|_| tools::service());
-    let token = tokens.register("computer-use");
-    host.mount(mcp_host::route("/computer-use", &tokens));
+    let sessions = std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+    let feedback = sessions.clone();
+    let services = mcp_host::TokenRegistry::new(move |scope| {
+        let mut sessions = feedback.lock().unwrap();
+        let session = sessions
+            .get(&scope)
+            .and_then(std::sync::Weak::upgrade)
+            .unwrap_or_else(feedback::FeedbackSession::new);
+        sessions.insert(scope, std::sync::Arc::downgrade(&session));
+        tools::service(session)
+    });
+    let tokens = TokenRegistry { services, sessions };
+    host.mount(mcp_host::route("/computer-use", &tokens.services));
 
     log::info!("computer-use-mcp: serving at {url}");
-    ComputerUseMcpServer { url, token }
+    ComputerUseMcpServer { url, tokens }
+}
+
+/// Uses the shared authenticated registry; weak feedback controls do not keep a
+/// mounted service alive after its actual route and handlers have been dropped.
+#[derive(Clone)]
+pub struct TokenRegistry {
+    services: mcp_host::TokenRegistry<tools::Service>,
+    sessions: std::sync::Arc<
+        std::sync::Mutex<
+            std::collections::HashMap<String, std::sync::Weak<feedback::FeedbackSession>>,
+        >,
+    >,
+}
+
+impl TokenRegistry {
+    pub fn register(&self, session_id: &str) -> String {
+        self.services.register(session_id)
+    }
+    pub fn cancel(&self, session_id: &str) {
+        if let Some(session) = self
+            .sessions
+            .lock()
+            .unwrap()
+            .get(session_id)
+            .and_then(std::sync::Weak::upgrade)
+        {
+            session.cancel();
+        }
+    }
+    pub fn revoke(&self, session_id: &str, token: &str) {
+        if let Some(session) = self
+            .sessions
+            .lock()
+            .unwrap()
+            .remove(session_id)
+            .and_then(|session| session.upgrade())
+        {
+            session.stop();
+        }
+        self.services.revoke(token);
+    }
+}
+
+#[cfg(test)]
+mod feedback_lifecycle_tests {
+    use super::*;
+
+    #[test]
+    fn mounted_services_own_feedback_and_registrations_cancel_independently() {
+        let mut host = mcp_host::Host::bind().unwrap();
+        let server = start(&mut host);
+        let first = server.tokens.register("first");
+        let second = server.tokens.register("second");
+        assert!(
+            first != second,
+            "sessions need distinct authorization scopes"
+        );
+        let session = |id: &str| {
+            server.tokens.sessions.lock().unwrap()[id]
+                .upgrade()
+                .unwrap()
+        };
+        let first_run = session("first").begin(None);
+        let second_run = session("second").begin(None);
+        server.tokens.cancel("first");
+        assert!(!first_run.is_current());
+        assert!(second_run.is_current());
+        let retained_handler = session("first");
+        let next_turn = retained_handler.begin(None);
+        assert!(next_turn.is_current(), "Stop does not disable future turns");
+        server.tokens.revoke("first", &first);
+        assert!(!next_turn.is_current());
+        assert!(
+            !retained_handler.begin(None).is_current(),
+            "a retained handler cannot restart feedback after revocation"
+        );
+        assert!(second_run.is_current());
+        drop(server);
+        assert!(
+            second_run.is_current(),
+            "registration metadata does not own mounted service lifetime"
+        );
+        drop(host);
+        assert!(
+            !second_run.is_current(),
+            "last mounted service drop invalidates delayed publications"
+        );
+    }
+
+    #[test]
+    fn mcp_cancellation_invalidates_pending_feedback_before_the_handler_resumes() {
+        let session = feedback::FeedbackSession::new();
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let mut success = session.begin(None);
+        let published_success = success.ticket();
+        success.complete();
+        drop(success);
+        assert!(
+            published_success.is_current(),
+            "successful actions retain their bounded tail"
+        );
+        let cancelled = session.begin(Some(cancellation.clone()));
+        let pending = cancelled.ticket();
+        cancellation.cancel();
+        assert!(!pending.is_current());
+        assert!(
+            published_success.is_current(),
+            "request cancellation does not invalidate another request"
+        );
+    }
 }

--- a/crates/computer-use-mcp/src/tools.rs
+++ b/crates/computer-use-mcp/src/tools.rs
@@ -181,13 +181,15 @@ struct WaitForParams {
 #[derive(Clone)]
 pub struct ComputerUseTools {
     tool_router: ToolRouter<Self>,
+    feedback: Arc<crate::feedback::FeedbackSession>,
 }
 
 #[tool_router]
 impl ComputerUseTools {
-    fn new() -> Self {
+    fn new(feedback: Arc<crate::feedback::FeedbackSession>) -> Self {
         Self {
             tool_router: Self::tool_router(),
+            feedback,
         }
     }
 
@@ -368,7 +370,12 @@ impl ComputerUseTools {
                        Results report worked/didnt/unknown per step, stop at the first failure with stopped_at, and use expect as a postcondition rather than treating event delivery as success. \
                        Input is refused when observe-only mode is enabled (allow_input=false) in Settings → Computer Use, and oversized output returns a preview plus a continuation ref for read_text."
     )]
-    async fn act_ui(&self, Parameters(params): Parameters<ActUiParams>) -> CallToolResult {
+    async fn act_ui(
+        &self,
+        context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        Parameters(params): Parameters<ActUiParams>,
+    ) -> CallToolResult {
+        let mut feedback = self.feedback.begin(Some(context.ct.clone()));
         let permissions = permissions();
         if let Some(result) = permission_gate(permissions, true, false) {
             return result;
@@ -400,9 +407,16 @@ impl ComputerUseTools {
         let mut stopped_at = None;
         let mut activation = "none";
         for (index, action) in params.actions.iter().enumerate() {
+            if !feedback.is_current() {
+                return tool_error("computer-use action cancelled");
+            }
             let result = match prepare_action(&previous.tree, action) {
-                Ok(request) => crate::backend::perform_action(&previous.root, &request)
-                    .unwrap_or_else(|error| ActionResult::didnt(error.to_string(), Delivery::None)),
+                Ok(request) => crate::backend::perform_action_with_feedback(
+                    &previous.root,
+                    &request,
+                    &feedback,
+                )
+                .unwrap_or_else(|error| ActionResult::didnt(error.to_string(), Delivery::None)),
                 Err(error) => ActionResult::didnt(error, Delivery::None),
             };
             let didnt = result.outcome == ActionOutcome::Didnt;
@@ -437,13 +451,11 @@ impl ComputerUseTools {
             .expect
             .as_ref()
             .is_some_and(|condition| condition_satisfied(&previous.tree, condition));
-        let (successor, expectation_status, root_changed) = match poll_successor(
-            &previous,
-            params.expect.as_ref(),
-            expectation_preexisting,
-        )
-        .await
-        {
+        let successor_result = tokio::select! {
+            _ = context.ct.cancelled() => return tool_error("computer-use action cancelled"),
+            result = poll_successor(&previous, params.expect.as_ref(), expectation_preexisting) => result,
+        };
+        let (successor, expectation_status, root_changed) = match successor_result {
             Ok(result) => result,
             Err(error) => return backend_error(error),
         };
@@ -486,6 +498,9 @@ impl ComputerUseTools {
         }
         text.push_str("\n\n");
         text.push_str(&successor.harness_annotation);
+        if stopped_at.is_none() && !expectation_failed && feedback.is_current() {
+            feedback.complete();
+        }
         bounded_success(Some(&successor.state_id), text, Vec::new())
     }
 
@@ -644,9 +659,9 @@ impl ServerHandler for ComputerUseTools {
 
 pub type Service = StreamableHttpService<ComputerUseTools, LocalSessionManager>;
 
-pub fn service() -> Service {
+pub(crate) fn service(feedback: Arc<crate::feedback::FeedbackSession>) -> Service {
     StreamableHttpService::new(
-        || Ok(ComputerUseTools::new()),
+        move || Ok(ComputerUseTools::new(feedback.clone())),
         Arc::new(LocalSessionManager::default()),
         StreamableHttpServerConfig::default(),
     )

--- a/crates/computer-use-mcp/tests/macos_overlay.rs
+++ b/crates/computer-use-mcp/tests/macos_overlay.rs
@@ -1,0 +1,36 @@
+//! Opt-in AppKit regression on the process main thread. It imports the production
+//! overlay owner, so reverting its animator call makes this test fail.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+use computer_use_mcp::outline;
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+mod ax {
+    pub(super) use computer_use_mcp::frontmost_pid as frontmost_application_pid;
+}
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[allow(dead_code, unused_imports)] // The runner imports the owner, including unused submission entry points.
+#[path = "../src/backend/macos/overlay/mod.rs"]
+mod overlay;
+
+fn main() {
+    let requested = std::env::args().any(|arg| arg == "--ignored" || arg == "--include-ignored");
+    if !requested || !cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        println!(
+            "test macos_overlay ... ignored (requires macOS arm64 desktop and explicit --ignored; opens a passthrough test panel)"
+        );
+        return;
+    }
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    overlay::verify_native();
+    println!("test macos_overlay ... ok");
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[allow(dead_code)] // Same production feedback owner; only native regression paths run here.
+#[path = "../src/feedback.rs"]
+mod feedback;
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+mod backend {
+    pub(crate) fn clear_feedback(owner: Option<u64>, action: Option<u64>) {
+        super::overlay::clear(owner, action);
+    }
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -25,4 +25,5 @@ term = { path = "../term" }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
+mcp-host = { path = "../mcp-host" }
 tcode-remote = { path = "../remote", default-features = false, features = ["server", "client"] }

--- a/crates/runtime/src/app/events.rs
+++ b/crates/runtime/src/app/events.rs
@@ -420,6 +420,7 @@ impl AppState {
         self.record_event(session_id, &event, cx);
 
         if let AgentEvent::TurnCompleted { status, .. } = &event {
+            self.cancel_computer_use_feedback(session_id);
             self.deliver_child_callback(session_id, *status, cx);
         }
         if let AgentEvent::ApprovalRequested(request) = &event {

--- a/crates/runtime/src/app/lifecycle.rs
+++ b/crates/runtime/src/app/lifecycle.rs
@@ -121,7 +121,7 @@ impl AppState {
         };
         let orchestrate_registration = self.orchestrate_registration_for(&meta);
         let orchestrate_report_registration = self.orchestrate_child_registration_for(&meta);
-        let computer_use_registration = self.mcp.computer_use_registration.clone();
+        let computer_use_registration = self.computer_use_registration_for(&meta);
         let provider_launcher = self.provider_launcher.clone();
         let session_id = meta.id.clone();
         if let Some(cursor) = &meta.resume_cursor {
@@ -338,6 +338,7 @@ impl AppState {
     }
 
     pub(crate) fn shutdown_active(&mut self, target_id: &str, _cx: &mut HostCx) {
+        self.revoke_computer_use_registration(target_id);
         if let Some(session_id) = self
             .resident(target_id)
             .map(|session| session.meta.id.as_str())
@@ -355,6 +356,15 @@ impl AppState {
 
     /// Shut down every provider process before the application exits.
     pub fn shutdown_all(&mut self, cx: &mut HostCx) {
+        for id in self
+            .mcp
+            .computer_use_registrations
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>()
+        {
+            self.revoke_computer_use_registration(&id);
+        }
         for id in self.residents.live.keys().cloned().collect::<Vec<_>>() {
             self.shutdown_active(&id, cx);
         }
@@ -484,6 +494,7 @@ impl AppState {
 
     /// Shut down and forget a parked session (archive/delete paths).
     pub(super) fn drop_background(&mut self, session_id: &str, cx: &mut HostCx) {
+        self.revoke_computer_use_registration(session_id);
         self.clear_approvals(session_id);
         self.pending_native_rewinds.remove(session_id);
         if let Some(parked) = self.residents.evict(session_id)
@@ -507,6 +518,7 @@ impl AppState {
             self.revoke_orchestrate_child_registration(&child_id);
         }
         self.revoke_preview_registration(parent_id);
+        self.revoke_computer_use_registration(parent_id);
         if let Some(registration) = self.mcp.orchestrate_registrations.remove(parent_id)
             && let Some(tokens) = &self.mcp.orchestrate_tokens
         {

--- a/crates/runtime/src/app/orchestrate.rs
+++ b/crates/runtime/src/app/orchestrate.rs
@@ -18,7 +18,9 @@ pub(super) struct McpWiring {
     pub(super) orchestrate_child_registrations: HashMap<String, agent::McpRegistration>,
     pub(super) orchestrate_requests:
         Option<smol::channel::Receiver<orchestrate_mcp::BrokerRequest>>,
-    pub(super) computer_use_registration: Option<agent::McpRegistration>,
+    pub(super) computer_use_url: Option<String>,
+    pub(super) computer_use_tokens: Option<computer_use_mcp::TokenRegistry>,
+    pub(super) computer_use_registrations: HashMap<String, agent::McpRegistration>,
 }
 
 impl AppState {
@@ -99,12 +101,46 @@ impl AppState {
         self.mcp.orchestrate_requests = Some(server.requests);
     }
 
-    pub fn attach_computer_use_mcp(&mut self, url: String, token: String) {
-        self.mcp.computer_use_registration = Some(agent::McpRegistration {
+    pub fn attach_computer_use_mcp(
+        &mut self,
+        url: String,
+        tokens: computer_use_mcp::TokenRegistry,
+    ) {
+        self.mcp.computer_use_url = Some(url);
+        self.mcp.computer_use_tokens = Some(tokens);
+    }
+
+    pub(super) fn computer_use_registration_for(
+        &mut self,
+        meta: &SessionMeta,
+    ) -> Option<agent::McpRegistration> {
+        if let Some(registration) = self.mcp.computer_use_registrations.get(&meta.id) {
+            return Some(registration.clone());
+        }
+        let token = self.mcp.computer_use_tokens.as_ref()?.register(&meta.id);
+        let registration = agent::McpRegistration {
             name: agent::McpRegistration::SERVER_NAME_COMPUTER_USE.into(),
-            url,
+            url: self.mcp.computer_use_url.clone()?,
             bearer_token: token,
-        });
+        };
+        self.mcp
+            .computer_use_registrations
+            .insert(meta.id.clone(), registration.clone());
+        Some(registration)
+    }
+
+    pub(super) fn cancel_computer_use_feedback(&self, session_id: &str) {
+        if let Some(tokens) = &self.mcp.computer_use_tokens {
+            tokens.cancel(session_id);
+        }
+    }
+
+    pub(super) fn revoke_computer_use_registration(&mut self, session_id: &str) {
+        if let Some(registration) = self.mcp.computer_use_registrations.remove(session_id)
+            && let Some(tokens) = &self.mcp.computer_use_tokens
+        {
+            tokens.revoke(session_id, &registration.bearer_token);
+        }
     }
 
     /// Pump orchestrator requests through the runtime on the host executor.

--- a/crates/runtime/src/app/send.rs
+++ b/crates/runtime/src/app/send.rs
@@ -665,7 +665,9 @@ impl AppState {
         };
         commands
             .try_send(SessionCommand::Interrupt)
-            .map_err(provider_command_error)
+            .map_err(provider_command_error)?;
+        self.cancel_computer_use_feedback(target_id);
+        Ok(())
     }
 
     pub fn respond_approval(

--- a/crates/runtime/src/app/tests.rs
+++ b/crates/runtime/src/app/tests.rs
@@ -6780,3 +6780,60 @@ fn history_byte_budget_preserves_contiguous_records_and_reports_shrinking() {
         );
     });
 }
+
+#[test]
+fn computer_use_registrations_survive_stop_but_are_replaced_after_provider_shutdown() {
+    let cx = &mut TestAppContext::default();
+    let store = TestStore::new("tcode-cu-registration-lifecycle");
+    let state = cx.new_entity(TestClientState::new((*store).clone()));
+    let mut host = mcp_host::Host::bind().unwrap();
+    let server = computer_use_mcp::start(&mut host);
+    let (session, commands) = fake_live_session(std::env::temp_dir());
+    state.update(cx, |state, cx| {
+        state
+            .host
+            .attach_computer_use_mcp(server.url, server.tokens);
+        let meta = session.meta.clone();
+        let other = SessionMeta::new(ProviderKind::Codex, std::env::temp_dir(), None);
+        state.install_selected(session);
+        let first = state.host.computer_use_registration_for(&meta).unwrap();
+        let second = state.host.computer_use_registration_for(&other).unwrap();
+        assert!(
+            first.bearer_token != second.bearer_token,
+            "provider sessions must not share one cancellation scope"
+        );
+        state.host.interrupt(&meta.id, cx).unwrap();
+        assert!(matches!(commands.try_recv(), Ok(SessionCommand::Interrupt)));
+        assert!(
+            state
+                .host
+                .computer_use_registration_for(&meta)
+                .unwrap()
+                .bearer_token
+                == first.bearer_token,
+            "Stop permits the same provider to start its next turn"
+        );
+        state.host.shutdown_active(&meta.id, cx);
+        assert!(matches!(commands.try_recv(), Ok(SessionCommand::Shutdown)));
+        assert!(
+            state
+                .host
+                .computer_use_registration_for(&other)
+                .unwrap()
+                .bearer_token
+                == second.bearer_token,
+            "another provider retains its registration"
+        );
+        assert!(
+            state
+                .host
+                .computer_use_registration_for(&meta)
+                .unwrap()
+                .bearer_token
+                != first.bearer_token,
+            "a restarted provider must not inherit revoked credentials"
+        );
+        state.host.shutdown_all(cx);
+        assert!(state.host.mcp.computer_use_registrations.is_empty());
+    });
+}

--- a/crates/runtime/src/pipe.rs
+++ b/crates/runtime/src/pipe.rs
@@ -29,7 +29,7 @@ pub struct HostServices {
     /// entirely on the host executor; a remote transport must expose the same
     /// operations as correlated RPC instead of moving the channel.
     pub orchestrate: Option<orchestrate_mcp::OrchestrateMcpServer>,
-    /// Registration-only startup data (URL and bearer token); this contains no
+    /// Registration-only startup data (URL and token issuer); this contains no
     /// request receiver or live backend handle.
     pub computer_use: Option<computer_use_mcp::ComputerUseMcpServer>,
 }
@@ -128,7 +128,7 @@ pub fn spawn_host(store: SessionStore, mut services: HostServices) -> std::io::R
                 state.attach_orchestrate_mcp(server);
             }
             if let Some(server) = services.computer_use.take() {
-                state.attach_computer_use_mcp(server.url, server.token);
+                state.attach_computer_use_mcp(server.url, server.tokens);
             }
             let mut cx = HostCx::new(mailbox_tx, event_tx);
             state.pump_orchestrate_requests(&mut cx);

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1138,3 +1138,19 @@ Threads marks cached rows **Pending** and provides one **Waiting for connectionâ
 row per uncached pending session, with its first message preview, at both widths.
 A host deletion arriving before the rejected Ack does not navigate away from an
 unresolved send: its inline error and Retry/Discard controls remain on screen.
+
+## macOS Computer Use feedback
+
+The agent cursor is a nonactivating, pointer-passthrough panel, visible only
+while its target application is frontmost. Consecutive actions animate to the
+latest point; a drag ends at its final point. Untargeted typing and key chords
+show keyboard feedback at the current target window's center.
+
+A successful action's marker lasts one second from submission, including queue
+delay, and is removed on the next 200ms visibility tick. Switching applications
+does not restart this lifetime. Stop, turn completion, a cancelled/failed MCP
+request, disabling the cursor or Computer Use, and session/backend teardown
+invalidate pending feedback and clear the current marker on the main queue.
+Cancellation is session-scoped: it cannot clear another session's newer marker.
+Closing or hiding the target window retires its marker even when its process
+stays open. See [Computer use](computer-use.md) for the native verification path.

--- a/docs/computer-use.md
+++ b/docs/computer-use.md
@@ -46,8 +46,8 @@ WebView; this server exposes desktop windows, not CDP browser roots.
 
 [crates/computer-use-mcp](../crates/computer-use-mcp/src/lib.rs) owns the outline,
 immutable state store, tool router, platform backends and permission facade.
-Providers receive its streamable-HTTP MCP registration when computer use is
-enabled. Claude, Codex and OpenCode use their native MCP configuration; ACP
+Providers receive a per-session authenticated streamable-HTTP MCP registration
+when computer use is enabled. Claude, Codex and OpenCode use their native MCP configuration; ACP
 registration is gated on the agent's HTTP MCP capability. The Settings UI
 consumes the same permission facade.
 
@@ -90,6 +90,24 @@ and `keypress` may retry through foreground activation and HID delivery after a
 background failure. Pointer actions do not take that fallback. `show_agent_cursor`
 defaults to `true` and controls a separate macOS action overlay; it is visible
 only while the target app is frontmost and does not move the system cursor.
+The overlay uses an animatable window frame for consecutive moves and the final
+drag endpoint. Typing/key chords without an element or coordinate anchor use the
+current root window's center.
+
+Successful action feedback expires one second after submission (queue delay
+counts); the next 200ms visibility poll removes it. Foreground changes never
+renew that deadline. Runtime Stop and turn completion cancel only the issuing
+session's feedback. MCP request cancellation/failure clears only that request's
+current marker; cancellation tokens are checked by queued publication and the
+visibility poll even while a synchronous native action has not returned.
+An already-posted native input event cannot be recalled by this visual cleanup.
+
+Disabling Computer Use or its cursor invalidates queued publications immediately.
+Closing/hiding a target window clears feedback on the next visibility poll,
+including when the app process remains alive. Revoking a provider registration
+stops its retained handlers from publishing again. Feedback belongs to the actual
+mounted service/handler lifetime, not the URL/token-issuer metadata; dropping one
+server cannot disable another server's newer marker.
 
 Before walking Chromium/Electron windows, the backend best-effort enables their
 accessibility exposure. It also retries activation for processes whose earlier
@@ -173,3 +191,17 @@ state on the target platform. For macOS permission changes, also check denial,
 return from System Settings, grant, restart continuity and revocation. Use an
 isolated test environment when changing permission state would disrupt the
 working desktop; keep evidence in the PR rather than a machine-specific run log.
+
+
+The opt-in macOS arm64 native regression runs AppKit on the process main thread:
+
+```sh
+cargo test -p computer-use-mcp --test macos_overlay --locked -- --ignored
+```
+
+It opens a temporary passthrough panel to check successive movement, drag
+completion, foreground preservation, and the real CoreGraphics query after
+closing a retained window. Ordinary Cargo tests explicitly report this test as
+ignored because it requires a desktop slot. Run it only when the shared GUI is
+available. Automated lifecycle tests separately exercise delayed publication,
+session/request cancellation, disable/re-enable, and mounted-service teardown.


### PR DESCRIPTION
Fixes #359.

On macOS, the first action marker appeared but later moves and drag endpoints stayed at its original position. Calling the AppKit animator with `setFrame:display:` delivers subsequent positions; untargeted keyboard actions now use the target window center for feedback. Hidden-panel reveal and drag-start placement use a zero-duration frame animation to supersede any older animation still running after hide/show.

Feedback expires one second after submission (including callback delay), with retirement checked every 200 ms. Stop, turn completion, request cancellation/failure, disable, session shutdown and mounted-service teardown invalidate feedback. Closed or hidden target windows retire it. Publication revisions reject delayed callbacks; session/request ownership prevents one session's Stop or an older request's cleanup from clearing another session's newer marker. Runtime uses existing per-session MCP registrations, following Preview's pattern. Registration metadata has no Drop cleanup. Foreground gating and mouse passthrough remain in the native owner.

Validation:

- Actual production backend action sequence on macOS 26.6.2 (25G83), arm64, one display: click → move → scroll → key → drag, at 1000px and 600px widths in light and dark themes, using dedicated test apps and an isolated profile. Baseline revision: `cacab223d81d6cc23badc81c1bfbefc827fccb62`. Baseline click `(400,466)` then move `(800,666)` left the native frame at `(396,461)`; fixed move reached `(796,661)`. Input delivery and marker movement were checked separately.
- Reverting only the animator call reproduced the failure: `('move', [{'Height':40,'Width':40,'X':196,'Y':461}], (596,661))`. Restoring the fix passed the full sequence. Background hide, foreground return within lifetime, background action without activation, expiry, disable and re-enable passed.
- Deterministic production-owner regressions cover expiry, superseded/delayed callbacks, cancellation ownership, mounted-service lifetime, MCP cancellation and runtime Stop/shutdown registration wiring. Removing the ownership guard makes the session-race regression fail; restoration passes all 40 computer-use library tests. Runtime registration regression passes.
- Full workspace formatting, Clippy (`--all-targets --locked -- -D warnings`), build and tests; iOS simulator, Web and Android checks with `RUSTFLAGS='-D warnings'`; dependency hygiene pass on final integrated head `07006fb7e`. Commands: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo build --workspace --locked`, `cargo test --workspace --locked`; cross-target commands match the linked CI workflow. Android uses CI NDK 27.1.12297006. Local `cargo machete` treats its subcommand as a directory; direct `cargo-machete .` (0.9.2) passes.

The opt-in native regression passed on pre-integration head `69bd0aade6796125f2d89a2a3d0dc2ad8b9f0848` (production overlay unchanged on final integrated head `07006fb7e5f970fbbdbb585fe37a9405379ef83f`): `cargo test -p computer-use-mcp --test macos_overlay --locked -- --ignored`. On preceding head `dcfb8e92f`, it exposed an actual in-flight animation overwriting the new marker after move → hide → new click; applying the zero-duration animator correction made the same test pass. The test checks actual native move/drag frame deltas, rapid hide/show, passthrough, unchanged foreground, actual CG window visibility before/after native close, and production rejection of late feedback for that closed window. Default workspace tests explicitly report this desktop test ignored. The temporary GUI example was removed. Final integrated source, native evidence and exact-head CI results were independently reviewed and accepted.

No other-platform native behavior or multiple-display verification is claimed. The build emits the existing large `__eh_frame` linker warning and the dependency `block 0.1.6` future-compatibility notice. No new localized UI strings were introduced; DESIGN and the computer-use lifecycle documentation describe the behavior. Evidence screenshots and exact red/green logs are retained locally under `/tmp/tcode-359/` for lead review.


Final integration: rebased onto `cd83cdda9cb01f0a22ef9d8a57f85f219c71725e`, preserving merged #380 usage and #382 sidebar behavior. All three commits are patch-equivalent in `git range-diff`; no conflict resolution or semantic changes were needed. Runtime retains the new `ContextCompacted(_)` event shape and adds only session feedback cancellation at `TurnCompleted`; DESIGN retains both merged sections. Combined-head formatting, full workspace Clippy/build/tests, dependency hygiene and iOS/Web/Android checks all pass. Workspace tests report 1101 passed, zero failed, five ignored, plus the explicitly ignored native runner. [Exact-head CI run 34223690533](https://github.com/Tryanks/tcode/actions/runs/34223690533) passed all six jobs on `07006fb7e5f970fbbdbb585fe37a9405379ef83f`.
