### PR TITLE
Enable macOS remote loopback Preview through paired port forwards

### DIFF
--- a/crates/remote/Cargo.toml
+++ b/crates/remote/Cargo.toml
@@ -14,7 +14,7 @@ server = [
     "dep:uuid",
     "dep:pbkdf2",
 ]
-client = ["dep:tcode-protocol", "dep:dirs"]
+client = ["dep:tcode-protocol", "dep:dirs", "dep:base64"]
 
 [dependencies]
 tcode-client = { path = "../client" }

--- a/crates/remote/src/lib.rs
+++ b/crates/remote/src/lib.rs
@@ -22,3 +22,6 @@ pub use client_host::NativeClientHost;
 pub use mux::{Connection, HostMux};
 #[cfg(feature = "server")]
 pub use server::{DeviceInfo, PairingCode, RemoteConfig, RemoteServer, StaticBundle, serve};
+
+#[cfg(feature = "client")]
+pub mod preview;

--- a/crates/remote/src/preview.rs
+++ b/crates/remote/src/preview.rs
@@ -82,7 +82,9 @@ impl PreviewRoutes {
             return actual.into();
         };
         let mut url = Url::parse(actual).unwrap();
-        let _ = url.set_port(route.remote.port());
+        // A TCP route can be reused under another scheme, whose default port
+        // need not match the scheme that first allocated it.
+        let _ = url.set_port(route.remote.port_or_known_default());
         url.into()
     }
 
@@ -229,25 +231,46 @@ fn bind_loopback(url: &Url) -> io::Result<Vec<std::net::TcpListener>> {
 }
 
 async fn forward(socket: TcpStream, host: &PairedHost, destination: &str) -> io::Result<()> {
-    let mut remote = future::race(async {
-        let proxy = Url::parse(&host.origin).map_err(io::Error::other)?;
-        let mut remote = TcpStream::connect((proxy.host_str().ok_or_else(|| io::Error::other("Missing paired host"))?.trim_matches(['[', ']']), proxy.port_or_known_default().unwrap())).await.map_err(|_| io::Error::other("Cannot connect to the paired host preview service"))?;
-        let auth = STANDARD.encode(format!("tcode:{}", host.token));
-        remote.write_all(format!("CONNECT {destination} HTTP/1.1\r\nHost: {destination}\r\nProxy-Authorization: Basic {auth}\r\n\r\n").as_bytes()).await?;
-        let mut head = Vec::new();
-        while !head.ends_with(b"\r\n\r\n") && head.len() < 16384 {
-            let mut byte = [0];
-            remote.read_exact(&mut byte).await?;
-            head.push(byte[0]);
-        }
-        if !head.starts_with(b"HTTP/1.1 200 ") || !head.ends_with(b"\r\n\r\n") {
-            return Err(io::Error::other(if head.starts_with(b"HTTP/1.1 407 ") { "Paired host rejected preview authentication; reconnect or pair again" } else { "Paired host could not connect to the remote preview destination" }));
-        }
-        Ok(remote)
-    }, async {
-        smol::Timer::after(Duration::from_secs(12)).await;
-        Err(io::Error::other("Timed out connecting to the remote preview destination"))
-    }).await?;
+    let mut remote = future::race(
+        async {
+            let proxy = Url::parse(&host.origin).map_err(io::Error::other)?;
+            let address = proxy
+                .host_str()
+                .ok_or_else(|| io::Error::other("Missing paired host"))?
+                .trim_matches(['[', ']']);
+            let port = proxy.port_or_known_default().unwrap();
+            let mut remote = TcpStream::connect((address, port)).await.map_err(|_| {
+                io::Error::other("Cannot connect to the paired host preview service")
+            })?;
+            let auth = STANDARD.encode(format!("tcode:{}", host.token));
+            let request = format!(
+                "CONNECT {destination} HTTP/1.1\r\nHost: {destination}\r\nProxy-Authorization: Basic {auth}\r\n\r\n"
+            );
+            remote.write_all(request.as_bytes()).await?;
+            let mut head = Vec::new();
+            while !head.ends_with(b"\r\n\r\n") && head.len() < 16384 {
+                let mut byte = [0];
+                remote.read_exact(&mut byte).await?;
+                head.push(byte[0]);
+            }
+            if !head.starts_with(b"HTTP/1.1 200 ") || !head.ends_with(b"\r\n\r\n") {
+                let message = if head.starts_with(b"HTTP/1.1 407 ") {
+                    "Paired host rejected preview authentication; reconnect or pair again"
+                } else {
+                    "Paired host could not connect to the remote preview destination"
+                };
+                return Err(io::Error::other(message));
+            }
+            Ok(remote)
+        },
+        async {
+            smol::Timer::after(Duration::from_secs(12)).await;
+            Err(io::Error::other(
+                "Timed out connecting to the remote preview destination",
+            ))
+        },
+    )
+    .await?;
     let mut browser = socket.clone();
     let mut outbound = remote.clone();
     // Once CONNECT succeeds, normal browser cancellation and peer shutdown

--- a/crates/remote/src/preview.rs
+++ b/crates/remote/src/preview.rs
@@ -1,0 +1,268 @@
+//! Browser-owned local endpoints for the paired host's existing CONNECT service.
+//! Only the CONNECT handshake is interpreted; browser traffic is copied verbatim.
+use std::{
+    collections::HashMap,
+    io,
+    net::{IpAddr, Shutdown},
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use futures_lite::{
+    future,
+    io::{AsyncReadExt as _, AsyncWriteExt as _},
+};
+use smol::net::{TcpListener, TcpStream};
+use tcode_client::pairing::PairedHost;
+use url::Url;
+
+struct Route {
+    remote: Url,
+    port: u16,
+    _listeners: Vec<smol::Task<()>>,
+}
+
+/// One browser's mapping identity and local socket lifetime. Public/LAN URLs
+/// remain direct on the viewer. This is not a general browser-network proxy.
+pub struct PreviewRoutes {
+    host: PairedHost,
+    routes: HashMap<String, Route>,
+    error: Arc<Mutex<Option<(String, String)>>>,
+    current: Option<String>,
+    changes: async_channel::Receiver<()>,
+    changed: async_channel::Sender<()>,
+}
+
+impl PreviewRoutes {
+    pub fn new(host: PairedHost) -> Self {
+        let (changed, changes) = async_channel::bounded(1);
+        Self {
+            changed,
+            changes,
+            host,
+            routes: HashMap::new(),
+            error: Arc::new(Mutex::new(None)),
+            current: None,
+        }
+    }
+
+    /// Explicit user/tool intent always names a remote endpoint, even when its
+    /// port happens to equal an already allocated viewing port.
+    pub fn navigate(&mut self, intent: &str) -> Result<String, String> {
+        *self.error.lock().unwrap() = None;
+        self.current = Some(intent.into());
+        let result = self.map(intent);
+        if let Err(error) = &result {
+            *self.error.lock().unwrap() = Some((intent.into(), error.clone()));
+        }
+        result
+    }
+
+    /// Native reentry/history can already contain a mapped URL. Only this
+    /// entry point recognizes viewing endpoints before resolving a new target.
+    pub fn navigation(&mut self, actual: &str) -> Result<String, String> {
+        if self.route_for_actual(actual).is_some() {
+            *self.error.lock().unwrap() = None;
+            self.current = Some(self.logical_url(actual));
+            return Ok(actual.into());
+        }
+        if actual == "about:blank" {
+            return Ok(actual.into());
+        }
+        self.navigate(actual)
+    }
+
+    pub fn current_url(&self) -> Option<&str> {
+        self.current.as_deref()
+    }
+
+    pub fn logical_url(&self, actual: &str) -> String {
+        let Some(route) = self.route_for_actual(actual) else {
+            return actual.into();
+        };
+        let mut url = Url::parse(actual).unwrap();
+        let _ = url.set_port(route.remote.port());
+        url.into()
+    }
+
+    /// No allocation: external browsers may use only a live route. Its URL
+    /// stops working when this browser slot is closed.
+    pub fn external_url(&self, logical: &str) -> Option<String> {
+        let mut url = Url::parse(logical).ok()?;
+        if !loopback(&url) {
+            return Some(logical.into());
+        }
+        let route = self.routes.get(&authority(&url)?)?;
+        url.set_port(Some(route.port)).ok()?;
+        Some(url.into())
+    }
+
+    fn route_for_actual(&self, actual: &str) -> Option<&Route> {
+        let url = Url::parse(actual).ok()?;
+        self.routes.values().find(|route| {
+            url.host() == route.remote.host() && url.port_or_known_default() == Some(route.port)
+        })
+    }
+
+    fn map(&mut self, intent: &str) -> Result<String, String> {
+        let mut url = Url::parse(intent).map_err(|_| "Invalid preview URL")?;
+        if !loopback(&url) {
+            return Ok(intent.into());
+        }
+        let proxy = Url::parse(&self.host.origin).map_err(|_| "Invalid paired host origin")?;
+        if proxy.scheme() != "http" {
+            return Err("Remote preview requires a direct HTTP paired host connection".into());
+        }
+        let destination = authority(&url).ok_or("Missing preview port")?;
+        let port = if let Some(route) = self.routes.get(&destination) {
+            route.port
+        } else {
+            let listeners =
+                bind_loopback(&url).map_err(|_| "Could not allocate a local preview listener")?;
+            let port = listeners[0]
+                .local_addr()
+                .map_err(|_| "Could not read preview port")?
+                .port();
+            let mut tasks = Vec::new();
+            for listener in listeners {
+                let listener = TcpListener::try_from(listener)
+                    .map_err(|_| "Could not start preview listener")?;
+                let host = self.host.clone();
+                let destination = destination.clone();
+                let error = self.error.clone();
+                let changed = self.changed.clone();
+                tasks.push(smol::spawn(async move {
+                    let mut connections = Vec::new();
+                    while let Ok((socket, _)) = listener.accept().await {
+                        connections.retain(|task: &smol::Task<()>| !task.is_finished());
+                        let host = host.clone();
+                        let destination = destination.clone();
+                        let error = error.clone();
+                        let changed = changed.clone();
+                        connections.push(smol::spawn(async move {
+                            let keepalive = socket.clone();
+                            if let Err(failure) = forward(socket, &host, &destination).await {
+                                *error.lock().unwrap() = Some((destination, failure.to_string()));
+                                let _ = changed.try_send(());
+                            }
+                            drop(keepalive);
+                        }));
+                    }
+                }));
+            }
+            self.routes.insert(
+                destination,
+                Route {
+                    remote: url.clone(),
+                    port,
+                    _listeners: tasks,
+                },
+            );
+            port
+        };
+        url.set_port(Some(port))
+            .map_err(|_| "Invalid preview port")?;
+        Ok(url.into())
+    }
+
+    pub fn error(&self) -> Option<String> {
+        let error = self.error.lock().unwrap();
+        let (destination, message) = error.as_ref()?;
+        let current = self.current.as_deref()?;
+        (destination == current
+            || Url::parse(current)
+                .ok()
+                .and_then(|url| authority(&url))
+                .as_ref()
+                == Some(destination))
+        .then(|| message.clone())
+    }
+
+    /// The owning UI consumes wakeups; error details remain in this owner.
+    pub fn changes(&self) -> async_channel::Receiver<()> {
+        self.changes.clone()
+    }
+}
+
+fn authority(url: &Url) -> Option<String> {
+    Some(format!(
+        "{}:{}",
+        url.host_str()?,
+        url.port_or_known_default()?
+    ))
+}
+
+fn loopback(url: &Url) -> bool {
+    matches!(url.scheme(), "http" | "https")
+        && url.host_str().is_some_and(|host| {
+            host == "localhost"
+                || host
+                    .trim_matches(['[', ']'])
+                    .parse::<IpAddr>()
+                    .is_ok_and(|ip| ip.is_loopback())
+        })
+}
+
+fn bind_loopback(url: &Url) -> io::Result<Vec<std::net::TcpListener>> {
+    let host = url.host_str().unwrap();
+    if host != "localhost" {
+        return Ok(vec![std::net::TcpListener::bind((
+            host.trim_matches(['[', ']']),
+            0,
+        ))?]);
+    }
+    // WebKit may resolve localhost to either family. Reserve both at one
+    // kernel-selected port; retry only a collision on the second reservation.
+    for _ in 0..8 {
+        let v4 = std::net::TcpListener::bind("127.0.0.1:0")?;
+        match std::net::TcpListener::bind(("::1", v4.local_addr()?.port())) {
+            Ok(v6) => return Ok(vec![v4, v6]),
+            Err(error) if error.kind() == io::ErrorKind::AddrInUse => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AddrInUse,
+        "Could not reserve localhost preview port",
+    ))
+}
+
+async fn forward(socket: TcpStream, host: &PairedHost, destination: &str) -> io::Result<()> {
+    let mut remote = future::race(async {
+        let proxy = Url::parse(&host.origin).map_err(io::Error::other)?;
+        let mut remote = TcpStream::connect((proxy.host_str().ok_or_else(|| io::Error::other("Missing paired host"))?.trim_matches(['[', ']']), proxy.port_or_known_default().unwrap())).await.map_err(|_| io::Error::other("Cannot connect to the paired host preview service"))?;
+        let auth = STANDARD.encode(format!("tcode:{}", host.token));
+        remote.write_all(format!("CONNECT {destination} HTTP/1.1\r\nHost: {destination}\r\nProxy-Authorization: Basic {auth}\r\n\r\n").as_bytes()).await?;
+        let mut head = Vec::new();
+        while !head.ends_with(b"\r\n\r\n") && head.len() < 16384 {
+            let mut byte = [0];
+            remote.read_exact(&mut byte).await?;
+            head.push(byte[0]);
+        }
+        if !head.starts_with(b"HTTP/1.1 200 ") || !head.ends_with(b"\r\n\r\n") {
+            return Err(io::Error::other(if head.starts_with(b"HTTP/1.1 407 ") { "Paired host rejected preview authentication; reconnect or pair again" } else { "Paired host could not connect to the remote preview destination" }));
+        }
+        Ok(remote)
+    }, async {
+        smol::Timer::after(Duration::from_secs(12)).await;
+        Err(io::Error::other("Timed out connecting to the remote preview destination"))
+    }).await?;
+    let mut browser = socket.clone();
+    let mut outbound = remote.clone();
+    // Once CONNECT succeeds, normal browser cancellation and peer shutdown
+    // can return NotConnected/BrokenPipe. WebKit owns page-load errors; a
+    // closed keepalive socket must not overwrite a successfully loaded page.
+    let _ = future::try_zip(
+        async {
+            futures_lite::io::copy(&mut browser, &mut outbound).await?;
+            outbound.shutdown(Shutdown::Write)
+        },
+        async {
+            futures_lite::io::copy(&mut remote, &mut socket.clone()).await?;
+            socket.shutdown(Shutdown::Write)
+        },
+    )
+    .await;
+    Ok(())
+}

--- a/crates/remote/tests/proxy.rs
+++ b/crates/remote/tests/proxy.rs
@@ -139,62 +139,80 @@ fn missing_invalid_and_revoked_credentials_receive_407_for_http_and_connect() {
 
 #[test]
 fn connect_carries_verified_tls_bytes_without_interception() {
-    use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer, ServerName};
-    let machine = Machine::new();
-    // This self-signed localhost identity is trusted only by this test client.
-    let certificate = CertificateDer::from(include_bytes!("fixtures/localhost.der").to_vec());
-    let key = PrivatePkcs8KeyDer::from(include_bytes!("fixtures/localhost-key.der").to_vec());
-    let server_config = rustls::ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(vec![certificate.clone()], key.into())
-        .unwrap();
-    let origin = TcpListener::bind("127.0.0.1:0").unwrap();
-    let port = origin.local_addr().unwrap().port();
-    let origin = std::thread::spawn(move || {
-        let (stream, _) = origin.accept().unwrap();
-        stream
-            .set_read_timeout(Some(Duration::from_secs(10)))
+    for forwarded in [false, true] {
+        use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer, ServerName};
+        let machine = Machine::new();
+        // This self-signed localhost identity is trusted only by this test client.
+        let certificate = CertificateDer::from(include_bytes!("fixtures/localhost.der").to_vec());
+        let key = PrivatePkcs8KeyDer::from(include_bytes!("fixtures/localhost-key.der").to_vec());
+        let server_config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![certificate.clone()], key.into())
             .unwrap();
+        let origin = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = origin.local_addr().unwrap().port();
+        let origin = std::thread::spawn(move || {
+            let (stream, _) = origin.accept().unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(10)))
+                .unwrap();
+            let mut tls = rustls::StreamOwned::new(
+                rustls::ServerConnection::new(Arc::new(server_config)).unwrap(),
+                stream,
+            );
+            assert!(head(&mut tls).starts_with("GET /secure HTTP/1.1"));
+            tls.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nsecure")
+                .unwrap();
+            tls.conn.send_close_notify();
+            tls.flush().unwrap();
+        });
+        let mut routes = paired_preview(&machine);
+        let socket = if forwarded {
+            let intent = format!("https://localhost:{port}/secure");
+            let actual = routes.navigate(&intent).unwrap();
+            assert_eq!(routes.logical_url(&actual), intent);
+            let port = url::Url::parse(&actual).unwrap().port().unwrap();
+            let socket = TcpStream::connect(("127.0.0.1", port)).unwrap();
+            socket
+                .set_read_timeout(Some(Duration::from_secs(10)))
+                .unwrap();
+            socket
+        } else {
+            let mut socket = machine.socket();
+            socket
+                .write_all(
+                    format!(
+                        "CONNECT localhost:{port} HTTP/1.1\r\nHost: localhost:{port}\r\n{}\r\n",
+                        machine.auth
+                    )
+                    .as_bytes(),
+                )
+                .unwrap();
+            assert!(head(&mut socket).starts_with("HTTP/1.1 200 Connection Established"));
+            socket
+        };
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(certificate).unwrap();
+        let config = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
         let mut tls = rustls::StreamOwned::new(
-            rustls::ServerConnection::new(Arc::new(server_config)).unwrap(),
-            stream,
-        );
-        assert!(head(&mut tls).starts_with("GET /secure HTTP/1.1"));
-        tls.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nsecure")
-            .unwrap();
-        tls.conn.send_close_notify();
-        tls.flush().unwrap();
-    });
-    let mut socket = machine.socket();
-    socket
-        .write_all(
-            format!(
-                "CONNECT localhost:{port} HTTP/1.1\r\nHost: localhost:{port}\r\n{}\r\n",
-                machine.auth
+            rustls::ClientConnection::new(
+                Arc::new(config),
+                ServerName::try_from("localhost").unwrap(),
             )
-            .as_bytes(),
-        )
-        .unwrap();
-    assert!(head(&mut socket).starts_with("HTTP/1.1 200 Connection Established"));
-    let mut roots = rustls::RootCertStore::empty();
-    roots.add(certificate).unwrap();
-    let config = rustls::ClientConfig::builder()
-        .with_root_certificates(roots)
-        .with_no_client_auth();
-    let mut tls = rustls::StreamOwned::new(
-        rustls::ClientConnection::new(Arc::new(config), ServerName::try_from("localhost").unwrap())
             .unwrap(),
-        socket,
-    );
-    tls.write_all(b"GET /secure HTTP/1.1\r\nHost: localhost\r\n\r\n")
-        .unwrap();
-    assert!(head(&mut tls).starts_with("HTTP/1.1 200 OK"));
-    let mut body = [0; 6];
-    tls.read_exact(&mut body).unwrap();
-    assert_eq!(&body, b"secure");
-    origin.join().unwrap();
+            socket,
+        );
+        tls.write_all(b"GET /secure HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .unwrap();
+        assert!(head(&mut tls).starts_with("HTTP/1.1 200 OK"));
+        let mut body = [0; 6];
+        tls.read_exact(&mut body).unwrap();
+        assert_eq!(&body, b"secure");
+        origin.join().unwrap();
+    }
 }
-
 #[test]
 fn pipelined_request_and_chunk_trailers_never_reach_origin() {
     let machine = Machine::new();
@@ -283,4 +301,229 @@ fn connect_preserves_half_close_and_host_shutdown_closes_active_tunnels() {
     let (_target, _) = listener.accept().unwrap();
     machine.server.take().unwrap().shutdown();
     assert_eq!(socket.read(&mut [0; 1]).unwrap(), 0);
+}
+
+fn paired_preview(machine: &Machine) -> tcode_remote::preview::PreviewRoutes {
+    let encoded = machine
+        .auth
+        .trim()
+        .strip_prefix("Proxy-Authorization: Basic ")
+        .unwrap();
+    let decoded = String::from_utf8(STANDARD.decode(encoded).unwrap()).unwrap();
+    tcode_remote::preview::PreviewRoutes::new(tcode_remote::client::PairedHost {
+        host_id: "fixture".into(),
+        name: "fixture".into(),
+        origin: format!("http://{}", machine.server.as_ref().unwrap().local_addr()),
+        token: decoded.strip_prefix("tcode:").unwrap().into(),
+        last_connected_unix: None,
+    })
+}
+
+#[test]
+fn browser_forward_routes_bytes_and_navigation_then_disposes_connections() {
+    let machine = Machine::new();
+    // The viewing machine already occupies the remote port. The mapped socket
+    // must be allocated elsewhere, including when a second browser opens it.
+    let destination = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = destination.local_addr().unwrap().port();
+    let intent = format!("http://localhost:{port}/page?source=remote#fragment");
+    let mut routes = paired_preview(&machine);
+    let actual = routes.navigate(&intent).unwrap();
+    assert_ne!(
+        actual, intent,
+        "remote navigation must allocate a viewing endpoint"
+    );
+    let actual_url = url::Url::parse(&actual).unwrap();
+    assert_ne!(actual_url.port().unwrap(), port);
+    assert_eq!(routes.logical_url(&actual), intent);
+    assert_eq!(
+        routes.navigate(&intent).unwrap(),
+        actual,
+        "reload reuses the route"
+    );
+    assert_eq!(
+        routes.navigation(&actual).unwrap(),
+        actual,
+        "native reentry is not mapped twice"
+    );
+    let entered_collision = format!(
+        "http://localhost:{}/another-remote-port",
+        actual_url.port().unwrap()
+    );
+    assert_ne!(
+        routes.navigate(&entered_collision).unwrap(),
+        entered_collision,
+        "explicit remote intent must not be mistaken for native reentry"
+    );
+    let public = "https://example.com/public?viewer=direct";
+    assert_eq!(routes.navigate(public).unwrap(), public);
+    assert_eq!(routes.navigation(&actual).unwrap(), actual);
+    assert_eq!(
+        routes.external_url(&intent).as_deref(),
+        Some(actual.as_str())
+    );
+    let mut second = paired_preview(&machine);
+    assert_ne!(second.navigate(&intent).unwrap(), actual);
+    let mut browser = TcpStream::connect(("127.0.0.1", actual_url.port().unwrap())).unwrap();
+    browser
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    // Opaque HTTP/WS-like bytes, including site authorization and binary bytes:
+    // the CONNECT client must not parse/rewrite/remove any of these.
+    let bytes = b"GET /page?source=remote HTTP/1.1\r\nHost: localhost:12345\r\nAuthorization: Basic site-only\r\nUpgrade: websocket\r\n\r\n\x00\xff\x81payload";
+    browser.write_all(bytes).unwrap();
+    let (mut remote, _) = destination.accept().unwrap();
+    remote
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    let mut received = vec![0; bytes.len()];
+    remote.read_exact(&mut received).unwrap();
+    assert_eq!(received, bytes);
+    browser.shutdown(std::net::Shutdown::Write).unwrap();
+    assert_eq!(remote.read(&mut [0]).unwrap(), 0);
+    remote.write_all(b"remote after EOF").unwrap();
+    let mut reply = [0; 16];
+    browser.read_exact(&mut reply).unwrap();
+    assert_eq!(&reply, b"remote after EOF");
+    drop(routes);
+    assert_eq!(
+        browser.read(&mut [0]).unwrap(),
+        0,
+        "slot close must close accepted tunnels"
+    );
+    assert_eq!(remote.read(&mut [0]).unwrap(), 0);
+}
+
+#[test]
+fn browser_forward_uses_paired_auth_and_preserves_ipv6_destination() {
+    let machine = Machine::new();
+    let destination = TcpListener::bind("[::1]:0").unwrap();
+    let intent = format!(
+        "http://[::1]:{}/ipv6",
+        destination.local_addr().unwrap().port()
+    );
+    let mut routes = paired_preview(&machine);
+    let actual = routes.navigate(&intent).unwrap();
+    let actual_url = url::Url::parse(&actual).unwrap();
+    assert_eq!(actual_url.host_str(), Some("[::1]"));
+    let mut browser = TcpStream::connect(("::1", actual_url.port().unwrap())).unwrap();
+    browser
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    browser.write_all(b"IPv6 remote").unwrap();
+    let (mut remote, _) = destination.accept().unwrap();
+    remote
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    let mut request = [0; 11];
+    remote.read_exact(&mut request).unwrap();
+    assert_eq!(&request, b"IPv6 remote");
+    drop(browser);
+    drop(remote);
+    drop(destination);
+    let mut browser = TcpStream::connect(("::1", actual_url.port().unwrap())).unwrap();
+    browser
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    assert_eq!(browser.read(&mut [0]).unwrap(), 0);
+    assert!(routes.error().unwrap().contains("destination"));
+    routes.navigation(&actual).unwrap();
+    assert_eq!(
+        routes.error(),
+        None,
+        "native reload clears the previous attempt's error"
+    );
+    let server = machine.server.as_ref().unwrap();
+    server.revoke_device(&server.devices()[0].id).unwrap();
+    let mut browser = TcpStream::connect(("::1", actual_url.port().unwrap())).unwrap();
+    browser
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    assert_eq!(browser.read(&mut [0]).unwrap(), 0);
+    assert!(routes.error().unwrap().contains("authentication"));
+}
+
+#[test]
+fn browser_top_level_cross_port_navigation_reaches_the_new_remote_listener() {
+    let machine = Machine::new();
+    let first = TcpListener::bind("127.0.0.1:0").unwrap();
+    let next = TcpListener::bind("[::1]:0").unwrap();
+    let mut routes = paired_preview(&machine);
+    let initial = format!(
+        "http://localhost:{}/start",
+        first.local_addr().unwrap().port()
+    );
+    routes.navigate(&initial).unwrap();
+    // An absolute Location header carries a new remote authority. It enters
+    // the same production navigation owner used by the WK delegate.
+    let redirect = format!(
+        "http://[::1]:{}/arrived?from=redirect",
+        next.local_addr().unwrap().port()
+    );
+    let actual = routes.navigation(&redirect).unwrap();
+    assert_eq!(routes.logical_url(&actual), redirect);
+    assert_eq!(routes.current_url(), Some(redirect.as_str()));
+    let url = url::Url::parse(&actual).unwrap();
+    let mut browser = TcpStream::connect(("::1", url.port().unwrap())).unwrap();
+    browser
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    browser
+        .write_all(b"GET /arrived?from=redirect HTTP/1.1\r\nHost: fixture\r\n\r\n")
+        .unwrap();
+    let (mut remote, _) = next.accept().unwrap();
+    remote
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    assert!(head(&mut remote).starts_with("GET /arrived?from=redirect HTTP/1.1"));
+    remote.write_all(b"second remote port").unwrap();
+    let mut body = [0; 18];
+    browser.read_exact(&mut body).unwrap();
+    assert_eq!(&body, b"second remote port");
+    drop(routes);
+    assert_eq!(browser.read(&mut [0]).unwrap(), 0);
+}
+
+#[test]
+fn browser_keepalive_shutdown_does_not_report_a_failed_navigation() {
+    let machine = Machine::new();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let mut routes = paired_preview(&machine);
+    let actual = routes
+        .navigate(&format!(
+            "http://localhost:{}/",
+            listener.local_addr().unwrap().port()
+        ))
+        .unwrap();
+    let port = url::Url::parse(&actual).unwrap().port().unwrap();
+    let mut browser = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    browser
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    browser
+        .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .unwrap();
+    let (mut remote, _) = listener.accept().unwrap();
+    remote
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    head(&mut remote);
+    remote
+        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+        .unwrap();
+    drop(remote);
+    let mut response = String::new();
+    browser.read_to_string(&mut response).unwrap();
+    assert!(response.ends_with("ok"));
+    drop(browser);
+    // The task can finish after the reader gets EOF. A subsequent round trip
+    // through the same listener lets the executor process that completion.
+    let mut browser = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    browser
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    let (mut remote, _) = listener.accept().unwrap();
+    remote.write_all(b"next").unwrap();
+    browser.read_exact(&mut [0; 4]).unwrap();
+    assert_eq!(routes.error(), None);
 }

--- a/crates/remote/tests/proxy.rs
+++ b/crates/remote/tests/proxy.rs
@@ -322,6 +322,29 @@ fn paired_preview(machine: &Machine) -> tcode_remote::preview::PreviewRoutes {
 #[test]
 fn browser_forward_routes_bytes_and_navigation_then_disposes_connections() {
     let machine = Machine::new();
+    for (first, next) in [
+        (
+            "http://localhost/",
+            "https://localhost:80/page?scheme=https",
+        ),
+        (
+            "https://localhost/",
+            "http://localhost:443/page?scheme=http",
+        ),
+    ] {
+        let mut routes = paired_preview(&machine);
+        let initial = url::Url::parse(&routes.navigate(first).unwrap()).unwrap();
+        let actual = routes.navigate(next).unwrap();
+        assert_eq!(
+            url::Url::parse(&actual).unwrap().port(),
+            initial.port(),
+            "changing scheme retains the same TCP route"
+        );
+        assert_eq!(routes.logical_url(&actual), next);
+        assert_eq!(routes.navigation(&actual).unwrap(), actual);
+        assert_eq!(routes.current_url(), Some(next));
+        assert_eq!(routes.external_url(next).as_deref(), Some(actual.as_str()));
+    }
     // The viewing machine already occupies the remote port. The mapped socket
     // must be allocated elsewhere, including when a second browser opens it.
     let destination = TcpListener::bind("127.0.0.1:0").unwrap();

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -27,6 +27,8 @@ native-dialogs = []
 # Embedded webview preview backend. Available on macOS, Windows and Android; the panel,
 # its URL field, open-externally and copy-URL are always compiled.
 native-preview = [
+    "dep:tcode-remote",
+    "tcode-remote/client",
     "dep:gpui-android",
     "dep:gpui-wry",
     "dep:wry",
@@ -100,7 +102,7 @@ computer-use-mcp = { path = "../computer-use-mcp", optional = true }
 block2 = { version = "0.6.2", optional = true }
 objc2 = { version = "0.6.4", optional = true }
 objc2-app-kit = { version = "0.3.2", features = ["NSGraphicsContext", "NSImage", "NSImageRep", "NSPasteboard", "objc2-core-graphics"], optional = true }
-objc2-foundation = { version = "0.3.2", features = ["NSDictionary", "NSError", "NSString", "NSURLError", "block2"], optional = true }
+objc2-foundation = { version = "0.3.2", features = ["NSDictionary", "NSError", "NSString", "NSURLError", "NSURLRequest", "block2"], optional = true }
 
 # The macOS WKWebView snapshot backend, and the navigation delegate the
 # load-error observer patches.
@@ -116,7 +118,7 @@ optional = true
 
 [target.'cfg(target_os = "macos")'.dependencies.objc2-web-kit]
 version = "0.3.2"
-features = ["WKNavigationDelegate", "WKSnapshotConfiguration", "WKWebView"]
+features = ["WKNavigationDelegate", "WKNavigationAction", "WKFrameInfo", "WKSnapshotConfiguration", "WKWebView"]
 optional = true
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/crates/ui/src/preview_panel.rs
+++ b/crates/ui/src/preview_panel.rs
@@ -300,9 +300,19 @@ impl PreviewPanel {
     /// Hand the current URL to the OS browser. `cx.open_url` is gpui's
     /// cross-platform launcher (`open` / `ShellExecute` / `xdg-open`, and the
     /// browser's own `window.open`).
-    fn open_in_system_browser(&mut self, cx: &mut Context<Self>) {
-        if let Some(url) = self.active_url(cx) {
+    fn open_in_system_browser(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        #[cfg(all(feature = "native-preview", target_os = "macos"))]
+        let url = self.external_preview_url(cx);
+        #[cfg(not(all(feature = "native-preview", target_os = "macos")))]
+        let url = self.active_url(cx);
+        if let Some(url) = url {
             cx.open_url(&url);
+        } else {
+            use crate::overlay::{Notification, OverlayExt as _};
+            window.push_notification(
+                Notification::error(crate::tr!("preview.external_unavailable")),
+                cx,
+            );
         }
     }
 
@@ -456,7 +466,9 @@ impl PreviewPanel {
                             crate::tr!("preview.open_external"),
                             false,
                         )
-                        .on_click(cx.listener(|this, _, _, cx| this.open_in_system_browser(cx))),
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.open_in_system_browser(window, cx)
+                        })),
                     )
             })
             .when(!compact, |chrome| {
@@ -482,7 +494,7 @@ impl PreviewPanel {
         match action {
             PreviewAction::Close => self.release_preview(cx),
             PreviewAction::CopyUrl => self.copy_url(cx),
-            PreviewAction::OpenExternal => self.open_in_system_browser(cx),
+            PreviewAction::OpenExternal => self.open_in_system_browser(_window, cx),
             PreviewAction::ScanPorts => self.rescan_ports(cx),
         }
     }
@@ -769,3 +781,6 @@ mod android_geometry;
     any(target_os = "macos", target_os = "windows")
 ))]
 mod proxy;
+
+#[cfg(all(feature = "native-preview", target_os = "macos"))]
+mod remote;

--- a/crates/ui/src/preview_panel/backend.rs
+++ b/crates/ui/src/preview_panel/backend.rs
@@ -70,6 +70,19 @@ impl PreviewPanel {
         self.backend.lifecycle.clone()
     }
 
+    #[cfg(target_os = "macos")]
+    pub(super) fn external_preview_url(&mut self, cx: &mut Context<Self>) -> Option<String> {
+        let key = self.active_key(cx)?;
+        let logical = self
+            .lifecycle_entity()
+            .read(cx)
+            .remote_url(&key)
+            .or_else(|| self.store.read(cx).preview_url(&key))?;
+        self.lifecycle_entity()
+            .read(cx)
+            .external_url(&key, &logical)
+    }
+
     pub(super) fn observe_backend(&mut self, cx: &mut Context<Self>) {
         let lifecycle = self.lifecycle_entity();
         self._subscriptions
@@ -350,6 +363,16 @@ impl PreviewPanel {
                     .update(cx, |input, cx| input.set_value(url, window, cx));
             }
         }
+        #[cfg(target_os = "macos")]
+        if let Some(key) = active
+            && let Some(url) = self.lifecycle_entity().read(cx).remote_url(key)
+            && self.store.read(cx).preview_url(key).as_ref() != Some(&url)
+        {
+            self.store
+                .update(cx, |store, cx| store.set_preview_url(key, url.clone(), cx));
+            self.url_input
+                .update(cx, |input, cx| input.set_value(url, window, cx));
+        }
         let body: AnyElement = match active {
             Some(id) => match self.ensure_webview(id, window, cx) {
                 Availability::Ready(view) => {
@@ -400,7 +423,6 @@ impl PreviewPanel {
         // `ensure_webview` creates children hidden; make the owning
         // conversation visible only after the current layout owns it.
         self.sync_mounted_visibility(cx);
-        #[cfg(target_os = "android")]
         if let Some(error) =
             active.and_then(|key| self.lifecycle_entity().read(cx).load_error(key, cx))
         {
@@ -422,6 +444,22 @@ impl PreviewPanel {
                             )
                             .into_owned(),
                         ),
+                )
+                .child(body)
+                .into_any_element();
+        }
+        #[cfg(target_os = "macos")]
+        if self.store.read(cx).is_remote() {
+            return v_flex()
+                .size_full()
+                .child(
+                    div()
+                        .flex_none()
+                        .px_2()
+                        .py_1()
+                        .text_size(px(12.))
+                        .text_color(cx.theme().muted_foreground)
+                        .child(crate::tr!("preview.remote_forwarding").into_owned()),
                 )
                 .child(body)
                 .into_any_element();
@@ -619,11 +657,25 @@ impl PreviewPanel {
             .ready_view(key)
             .map(|view| view.read(cx).metadata());
         let (status_reply, status_result) = async_channel::bounded(1);
-        cx.spawn(async move |_, _| {
+        let lifecycle = self.lifecycle_entity().downgrade();
+        let status_key = key.to_owned();
+        cx.spawn(async move |_, cx| {
             let result = match status_result.recv().await {
                 Ok(Ok(PreviewResponse::Json(mut value))) => {
                     if let Some(object) = value.as_object_mut() {
                         object.insert("canvas".into(), canvas);
+                        if let Some(actual) = object
+                            .get("url")
+                            .and_then(serde_json::Value::as_str)
+                            .map(str::to_owned)
+                            && let Ok(logical) = lifecycle.update(cx, |lifecycle, _| {
+                                lifecycle.logical_url(&status_key, &actual)
+                            })
+                            && logical != actual
+                        {
+                            object.insert("actual_url".into(), actual.into());
+                            object.insert("url".into(), logical.into());
+                        }
                         #[cfg(target_os = "android")]
                         if let Some((url, title)) = native_metadata {
                             object.insert("url".into(), url.into());
@@ -680,11 +732,7 @@ impl PreviewPanel {
         }
         let cold = !self.lifecycle_entity().read(cx).is_warm(key);
         let key = key.to_string();
-        let probe = js::wait_for_probe(
-            selector.as_deref(),
-            text.as_deref(),
-            url_includes.as_deref(),
-        );
+        let probe = js::wait_for_probe(selector.as_deref(), text.as_deref(), None);
         let mut pending = Vec::new();
         if selector.is_some() {
             pending.push("selector".to_string());
@@ -758,7 +806,7 @@ impl PreviewPanel {
                     })
                     .detach();
 
-                let value = match probe_result.recv().await {
+                let mut value = match probe_result.recv().await {
                     Ok(Ok(PreviewResponse::Json(value))) => value,
                     Ok(Ok(PreviewResponse::Image { .. })) => {
                         let _ = reply
@@ -777,6 +825,28 @@ impl PreviewPanel {
                         return;
                     }
                 };
+                if let Some(actual) = value
+                    .get("url")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned)
+                    && let Ok(logical) = this.update(cx, |panel, cx| {
+                        panel.lifecycle_entity().read(cx).logical_url(&key, &actual)
+                    })
+                {
+                    if logical != actual {
+                        value["actual_url"] = actual.into();
+                    }
+                    value["url"] = logical.clone().into();
+                    if url_includes
+                        .as_ref()
+                        .is_some_and(|needle| !logical.contains(needle))
+                    {
+                        value["matched"] = false.into();
+                        if let Some(pending) = value["pending"].as_array_mut() {
+                            pending.push("urlIncludes".into());
+                        }
+                    }
+                }
                 if value.get("matched").and_then(serde_json::Value::as_bool) == Some(true) {
                     let _ = reply.send(Ok(PreviewResponse::Json(value))).await;
                     return;

--- a/crates/ui/src/preview_panel/lifecycle.rs
+++ b/crates/ui/src/preview_panel/lifecycle.rs
@@ -79,7 +79,11 @@ enum WebViewSlot {
         phase: CreationPhase,
         pending_url: Option<String>,
     },
-    Ready(Entity<WebView>),
+    Ready {
+        view: Entity<WebView>,
+        #[cfg(target_os = "macos")]
+        remote: Option<super::remote::RemoteBrowser>,
+    },
 }
 
 impl WebViewSlot {
@@ -89,7 +93,7 @@ impl WebViewSlot {
             Self::Creating { .. } => None,
             #[cfg(test)]
             Self::Stub => None,
-            Self::Ready(view) => Some(view),
+            Self::Ready { view, .. } => Some(view),
         }
     }
 
@@ -103,7 +107,7 @@ impl WebViewSlot {
             Self::Creating { phase, .. } => Availability::Starting(*phase),
             #[cfg(test)]
             Self::Stub => Availability::Unavailable,
-            Self::Ready(view) => Availability::Ready(view.clone()),
+            Self::Ready { view, .. } => Availability::Ready(view.clone()),
         }
     }
 }
@@ -219,6 +223,20 @@ impl BrowserLifecycle {
                 // asynchronous didStart, so a wait_for issued right after
                 // this navigation cannot fail on the old record.
                 load_error::forget(raw);
+                #[cfg(target_os = "macos")]
+                let mapped = match self
+                    .remote_browser(key)
+                    .map(|remote| remote.navigate(url))
+                    .transpose()
+                {
+                    Ok(mapped) => mapped,
+                    Err(_) => {
+                        cx.notify();
+                        return availability;
+                    }
+                };
+                #[cfg(target_os = "macos")]
+                let url = mapped.as_deref().unwrap_or(url);
                 match raw.load_url(url) {
                     Ok(()) => {
                         self.warm.insert(key.to_string());
@@ -331,7 +349,55 @@ impl BrowserLifecycle {
     /// The last navigation failure the platform reported for this browser, if
     /// the current page is still the one it left behind.
     pub(super) fn load_error(&self, key: &str, cx: &App) -> Option<LoadError> {
-        load_error::get(self.ready_view(key)?.read(cx).raw())
+        #[cfg(target_os = "macos")]
+        if let Some(remote) = self.remote_browser(key) {
+            let routes = remote.routes.borrow();
+            if let Some(message) = routes.error() {
+                return Some(LoadError {
+                    url: routes.current_url().unwrap_or_default().into(),
+                    code: "RemotePreview".into(),
+                    message,
+                });
+            }
+        }
+        let mut error = load_error::get(self.ready_view(key)?.read(cx).raw())?;
+        error.url = self.logical_url(key, &error.url);
+        Some(error)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn remote_browser(&self, key: &str) -> Option<&super::remote::RemoteBrowser> {
+        match self.slots.get(key)? {
+            WebViewSlot::Ready { remote, .. } => remote.as_ref(),
+            #[cfg(test)]
+            WebViewSlot::Stub => None,
+        }
+    }
+
+    pub(super) fn logical_url(&self, _key: &str, actual: &str) -> String {
+        #[cfg(target_os = "macos")]
+        if let Some(remote) = self.remote_browser(_key) {
+            return remote.routes.borrow().logical_url(actual);
+        }
+        actual.into()
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(super) fn remote_url(&self, key: &str) -> Option<String> {
+        self.remote_browser(key)?
+            .routes
+            .borrow()
+            .current_url()
+            .map(str::to_owned)
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(super) fn external_url(&self, key: &str, logical: &str) -> Option<String> {
+        match self.remote_browser(key) {
+            Some(remote) => remote.routes.borrow().external_url(logical),
+            None if self.proxy.is_some() => None,
+            None => Some(logical.into()),
+        }
     }
 
     fn forget_load_error(&self, key: &str, cx: &App) {
@@ -530,7 +596,8 @@ impl BrowserLifecycle {
             set_webview_visible(&mut view, false);
             view
         });
-        self.slots.insert(key.clone(), WebViewSlot::Ready(webview));
+        self.slots
+            .insert(key.clone(), WebViewSlot::Ready { view: webview });
         if warm {
             self.warm.insert(key);
         }
@@ -615,9 +682,19 @@ mod platform {
             set_webview_visible(&mut view, false);
             view
         });
-        lifecycle
-            .slots
-            .insert(key.to_string(), WebViewSlot::Ready(webview.clone()));
+        #[cfg(target_os = "macos")]
+        let remote = lifecycle
+            .proxy
+            .clone()
+            .map(|host| super::super::remote::RemoteBrowser::install(&webview, host, cx));
+        lifecycle.slots.insert(
+            key.to_string(),
+            WebViewSlot::Ready {
+                view: webview.clone(),
+                #[cfg(target_os = "macos")]
+                remote,
+            },
+        );
         Availability::Ready(webview)
     }
 }
@@ -926,7 +1003,7 @@ mod platform {
                         }
                         let view = cx.new(|cx| WebView::new(raw, events, cx));
                         cx.observe(&view, |_, _, cx| cx.notify()).detach();
-                        lifecycle.slots.insert(key, WebViewSlot::Ready(view));
+                        lifecycle.slots.insert(key, WebViewSlot::Ready { view });
                         cx.notify();
                     }
                 }

--- a/crates/ui/src/preview_panel/proxy.rs
+++ b/crates/ui/src/preview_panel/proxy.rs
@@ -5,25 +5,23 @@ pub(super) fn builder<'a>(
     builder: wry::WebViewBuilder<'a>,
     host: Option<&PairedHost>,
 ) -> Result<wry::WebViewBuilder<'a>, String> {
-    let Some(host) = host else {
+    let Some(_host) = host else {
         return Ok(builder);
     };
-    let origin = url::Url::parse(&host.origin).map_err(|e| e.to_string())?;
-    if origin.scheme() != "http" {
-        return Err("remote desktop preview requires a direct HTTP machine origin".into());
-    }
     #[cfg(target_os = "macos")]
     {
-        // WebKit applies NWProxyConfig to public destinations but silently
-        // bypasses destinations on the client's local interfaces, even with
-        // no excluded domains and failover disabled. A navigation-only guard
-        // cannot protect subresources or names resolving to those interfaces.
-        // Refuse creation until the backend can enforce the machine boundary.
-        Err(crate::tr!("preview.machine_proxy_unavailable").to_string())
+        // Every attached browser gets a separate nonpersistent WK store.
+        // Cookies are scoped by hostname, not by our allocated viewing ports.
+        Ok(builder.with_incognito(true))
     }
     #[cfg(target_os = "windows")]
     {
         use wry::WebViewBuilderExtWindows as _;
+        let host = _host;
+        let origin = url::Url::parse(&host.origin).map_err(|e| e.to_string())?;
+        if origin.scheme() != "http" {
+            return Err("remote desktop preview requires a direct HTTP machine origin".into());
+        }
         let builder = builder
             .with_incognito(true)
             .with_proxy_config(wry::ProxyConfig::Http(wry::ProxyEndpoint {
@@ -86,25 +84,4 @@ pub(super) fn authenticate(raw: &wry::WebView, host: Option<&PairedHost>) -> Res
     // SAFETY: the webview retains the callback until its owning view is destroyed.
     unsafe { webview.add_BasicAuthenticationRequested(&handler, &mut token) }
         .map_err(|e| e.to_string())
-}
-
-#[cfg(all(test, target_os = "macos"))]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn attached_preview_fails_closed_before_webview_creation() {
-        let host = PairedHost {
-            host_id: "machine".into(),
-            name: "Machine".into(),
-            origin: "http://192.0.2.10:47420".into(),
-            token: "test-device-token".into(),
-            last_connected_unix: None,
-        };
-        assert!(builder(wry::WebViewBuilder::new(), None).is_ok());
-        let result = builder(wry::WebViewBuilder::new(), Some(&host));
-        assert!(
-            matches!(result, Err(error) if error == crate::tr!("preview.machine_proxy_unavailable"))
-        );
-    }
 }

--- a/crates/ui/src/preview_panel/remote.rs
+++ b/crates/ui/src/preview_panel/remote.rs
@@ -1,0 +1,175 @@
+//! The macOS slot's native navigation boundary. The transport owns URL identity;
+//! this adapter preserves WebKit requests and resumes them on GPUI's foreground.
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+};
+
+use gpui::{Context, Entity, Task};
+use gpui_wry::WebView;
+use objc2::{
+    DefinedClass as _, MainThreadOnly, define_class, msg_send,
+    rc::Retained,
+    runtime::{AnyObject, ProtocolObject, Sel},
+};
+use objc2_foundation::{
+    NSMutableCopying as _, NSObject, NSObjectProtocol, NSString, NSURL, NSURLRequest,
+};
+use objc2_web_kit::{
+    WKNavigationAction, WKNavigationActionPolicy, WKNavigationDelegate, WKWebView,
+};
+use tcode_remote::preview::PreviewRoutes;
+use wry::WebViewExtMacOS as _;
+
+use super::lifecycle::BrowserLifecycle;
+
+pub(super) struct RemoteBrowser {
+    pub(super) routes: Rc<RefCell<PreviewRoutes>>,
+    generation: Rc<Cell<u64>>,
+    _delegate: Retained<NavigationDelegate>,
+    _events: Task<()>,
+}
+
+struct Navigation {
+    generation: u64,
+    request: Option<Retained<NSURLRequest>>,
+}
+
+pub struct DelegateState {
+    original: Retained<ProtocolObject<dyn WKNavigationDelegate>>,
+    routes: std::rc::Weak<RefCell<PreviewRoutes>>,
+    generation: Rc<Cell<u64>>,
+    events: async_channel::Sender<Navigation>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "TcodePreviewNavigationDelegate"]
+    #[thread_kind = MainThreadOnly]
+    #[ivars = DelegateState]
+    struct NavigationDelegate;
+
+    unsafe impl NSObjectProtocol for NavigationDelegate {
+        #[unsafe(method(respondsToSelector:))]
+        fn responds_to(&self, selector: Sel) -> bool {
+            // WebKit caches optional delegate methods at installation time.
+            (unsafe { msg_send![super(self), respondsToSelector: selector] })
+                || self.ivars().original.respondsToSelector(selector)
+        }
+    }
+
+    impl NavigationDelegate {
+        #[unsafe(method(forwardingTargetForSelector:))]
+        fn forward_to(&self, _selector: Sel) -> *const AnyObject {
+            Retained::as_ptr(&self.ivars().original).cast()
+        }
+    }
+
+    unsafe impl WKNavigationDelegate for NavigationDelegate {
+        #[unsafe(method(webView:decidePolicyForNavigationAction:decisionHandler:))]
+        fn policy(&self, webview: &WKWebView, action: &WKNavigationAction,
+            handler: &block2::Block<dyn Fn(WKNavigationActionPolicy)>) {
+            // lb-wry's URL-only callback loses frame identity and request bytes.
+            // Keep its policy for subframes and pass the full request for a
+            // top-level redirect, including method/body/site authorization.
+            let main_frame = unsafe { action.targetFrame() }.is_some_and(|frame| unsafe { frame.isMainFrame() });
+            let request = unsafe { action.request() };
+            let actual = request.URL().and_then(|url| url.absoluteString()).map(|url| url.to_string());
+            if main_frame && let Some(actual) = actual && let Some(routes) = self.ivars().routes.upgrade() {
+                let mapped = routes.borrow_mut().navigation(&actual);
+                let generation = self.ivars().generation.get().wrapping_add(1);
+                self.ivars().generation.set(generation);
+                match mapped {
+                    Ok(mapped) if mapped != actual => {
+                        if let Some(url) = NSURL::URLWithString(&NSString::from_str(&mapped)) {
+                            let request = request.mutableCopy();
+                            request.setURL(Some(&url));
+                            let _ = self.ivars().events.try_send(Navigation { generation, request: Some(request.into_super()) });
+                        }
+                        handler.call((WKNavigationActionPolicy::Cancel,));
+                        return;
+                    }
+                    Err(_) => {
+                        let _ = self.ivars().events.try_send(Navigation { generation, request: None });
+                        handler.call((WKNavigationActionPolicy::Cancel,));
+                        return;
+                    }
+                    Ok(_) => {
+                        let _ = self.ivars().events.try_send(Navigation { generation, request: None });
+                    }
+                }
+            }
+            unsafe { self.ivars().original.webView_decidePolicyForNavigationAction_decisionHandler(webview, action, handler); }
+        }
+    }
+);
+
+impl RemoteBrowser {
+    pub(super) fn install(
+        view: &Entity<WebView>,
+        host: tcode_client::pairing::PairedHost,
+        cx: &mut Context<BrowserLifecycle>,
+    ) -> Self {
+        let routes = Rc::new(RefCell::new(PreviewRoutes::new(host)));
+        let generation = Rc::new(Cell::new(0_u64));
+        let (events, received) = async_channel::unbounded::<Navigation>();
+        let native = view.read(cx).raw().webview();
+        let original =
+            unsafe { native.navigationDelegate() }.expect("wry installs a navigation delegate");
+        let delegate = NavigationDelegate::alloc(native.mtm()).set_ivars(DelegateState {
+            original,
+            routes: Rc::downgrade(&routes),
+            generation: generation.clone(),
+            events,
+        });
+        let delegate: Retained<NavigationDelegate> = unsafe { msg_send![super(delegate), init] };
+        unsafe {
+            native.setNavigationDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+        }
+        let errors = routes.borrow().changes();
+        let weak_view = view.downgrade();
+        let live_generation = generation.clone();
+        let task = cx.spawn(async move |this, cx| {
+            while let Ok(navigation) =
+                futures_lite::future::race(async { received.recv().await.map(Some) }, async {
+                    errors.recv().await.map(|_| None)
+                })
+                .await
+            {
+                let result = this.update(cx, |_, cx| {
+                    let Some(navigation) = navigation else {
+                        cx.notify();
+                        return;
+                    };
+                    if live_generation.get() != navigation.generation {
+                        return;
+                    }
+                    if let Some(view) = weak_view.upgrade()
+                        && let Some(request) = navigation.request
+                    {
+                        let raw = view.read(cx).raw();
+                        super::load_error::forget(raw);
+                        unsafe {
+                            raw.webview().loadRequest(&request);
+                        }
+                    }
+                    cx.notify();
+                });
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
+        Self {
+            routes,
+            generation,
+            _delegate: delegate,
+            _events: task,
+        }
+    }
+
+    pub(super) fn navigate(&self, intent: &str) -> Result<String, String> {
+        self.generation.set(self.generation.get().wrapping_add(1));
+        self.routes.borrow_mut().navigate(intent)
+    }
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -794,17 +794,34 @@ than dead back/reload/screenshot controls, agent automation requests are
 answered with an explicit "unsupported" instead of timing out, and such a client
 does not subscribe as an owner of the session's preview at all. Localhost port
 discovery scans the client, so it is offered only for a local desktop workspace; a host
-URL typed into the field is relative to the attached machine. Remote Windows and Android embedded previews route all HTTP(S) traffic through the
-machine's token-authenticated forward proxy, including localhost; the URL bar
-never substitutes the machine's LAN address. Proxy setup completes before page
-navigation and follows attachment teardown. Unsupported proxy capabilities fail
-closed through the existing unavailable/load-error presentation. macOS attached
-previews refuse WebView creation and explain that the machine proxy cannot be
-applied safely: WebKit bypasses it for client-local destinations, including
-subresources. URL entry, copy, and open externally remain available. Local desktop
-attachments use no preview proxy. Hosting enables the proxy automatically on the
-hosting port, without another setting. See [remote networking](remote.md#networking)
-for platform requirements and the token's network-access implications.
+URL typed into the field is relative to the attached machine for loopback Preview.
+Remote Windows and Android embedded previews route HTTP(S) through the machine's
+token-authenticated forward proxy, including localhost. Local desktop attachments
+use no preview proxy.
+
+On macOS, attached Preview forwards HTTP(S) loopback URLs (`localhost`, loopback
+IPv4 and `::1`) through a browser-owned local port to the paired host's CONNECT
+service. A short note below the toolbar states that other addresses use this Mac:
+public and LAN URLs use ordinary viewer networking. Each attached browser uses
+its own nonpersistent website store, separate from local Preview and other slots.
+The address bar, copy, stored URL and automation status `url` use the logical
+remote URL, including path/query. Status adds `actual_url` when forwarded;
+`wait_for` matches the logical URL. JavaScript, including `evaluate` and
+`window.location`, sees the actual local port and origin. Native back/forward and
+reload reuse live routes; top-level loopback links and redirects allocate new
+routes as needed. The navigation adapter preserves the native request when it
+changes its URL. Browser-side subresources are not generally rewritten.
+
+Open externally uses the live forwarded URL for a mapped page, so it cannot
+silently open an unrelated service at the viewer's original port. The link lasts
+only while its owning preview is open. If no suitable live route exists, the
+existing notification surface explains that the page must first be opened in
+Preview. Closing a slot, pruning its session, or changing attachment destroys its
+listeners, active tunnels and website store; hiding a retained slot does not.
+Transport and navigation failures appear in the existing load-error presentation
+and automation responses. Hosting enables CONNECT on the existing hosting port,
+without another setting. See [remote networking](remote.md#networking) for the
+origin/port compatibility tradeoffs and the token's network-access implications.
 
 Right-panel state (open/closed, Diff/Plan/Preview tab, expansion and selected
 turn), each Preview WebView, and the bottom terminal workspace all belong to the

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -326,7 +326,7 @@ Enter the machine's overlay address and port when it does not appear nearby.
 Nearby-machine search advertises identity and address hints; it does not grant
 access.
 
-### Preview browses from the machine
+### Remote Preview routing
 
 Windows and Android embedded previews use the connected machine's network for
 all HTTP and HTTPS traffic. `http://localhost:5173/app` opens the dev server on
@@ -355,13 +355,50 @@ localhost bypasses, waits for the override before navigation, and clears it when
 the attachment's views are destroyed. The override is process-wide, so embedded
 preview views belong to one attachment.
 
-macOS attached previews are unavailable: WebKit bypasses its Network proxy
-configuration for destinations on the client’s local interfaces, including
-localhost and its own LAN addresses. Clearing excluded domains, explicit match
-domains, disabling failover, and installing the authenticated configuration before
-creating the WebView do not prevent this bypass. Tcode refuses attached WebView
-creation through the existing error surface so navigations, redirects, and
-subresources cannot connect directly. Local macOS previews remain available.
+macOS attached Preview uses per-port forwarding for HTTP(S) loopback URLs:
+`localhost`, IPv4 loopback addresses and `::1`. The requested host and port are
+sent unchanged to the paired host's existing CONNECT service. The viewing Mac
+allocates its own loopback port, so a viewer service at the remote port cannot
+collide with it. `localhost` reserves both IPv4 and IPv6 listeners at that port.
+Numeric loopback URLs need that same address to be bindable on the viewing Mac;
+unassigned addresses such as `127.0.0.2` can report an allocation error. Tcode does
+not add loopback aliases to the OS. No OS DNS, hosts file or proxy settings are changed. Public/LAN destinations are
+**direct from the viewer**, as the Preview note explains; this is a remote dev
+server workflow, not arbitrary remote browsing.
+
+Each browser slot owns its forwarding table and a separate nonpersistent WebKit
+website store. Relative assets and WebSockets derived from the page's actual
+location use the same forwarded port. Top-level loopback links/redirects pass
+through the same mapper, including redirects to another port. The native request
+is retained when changing its URL; HTTP bodies, site authorization, WebSocket
+frames and TLS records are not interpreted by the forwarding transport. Closing
+the preview or changing attachment drops listeners and accepted tunnels; merely
+hiding a retained preview keeps them alive. A new attachment receives new routes
+and a fresh store, including when its paired credential changes.
+
+The address bar, copy and stored URL retain logical remote intent. Native
+back/forward/reload reuse the live mappings. `preview_status.url` and
+`preview_wait_for` use the logical remote URL; `actual_url` is added when it differs.
+`preview_evaluate`, page scripts and `window.location` see the **actual local URL**.
+Open externally uses that live mapped URL and stops working when the owning slot
+closes. Without a suitable live route, it reports that Preview must open the page
+first, rather than opening the viewer's unrelated original-port service.
+
+Mapping preserves the requested hostname but changes its port. The HTTP Host
+header and browser Origin therefore contain the viewing port. HTTPS retains the
+hostname/SNI and normal WebKit certificate validation; a development certificate
+must already be trusted and cover that hostname. Port-sensitive host/origin
+allowlists, CORS, CSP and OAuth callbacks can need app configuration. Cookies are
+not isolated by port, which is why attached slots use separate website stores.
+There is no blanket certificate bypass or credential injection into site auth.
+
+Absolute subresource URLs, hardcoded API/HMR ports and worker-owned endpoints are
+not automatically rewritten. Configure them to derive their endpoint from the
+actual page location or an explicitly resolved live forward; entering an
+additional page URL creates its mapping but does not rewrite application code.
+Navigation, transport and authentication failures use Preview's existing error
+surface and automation errors. Local macOS Preview retains ordinary direct
+networking and its existing store.
 
 Windows uses WebView2's proxy configuration and proxy authentication callback, with implicit
 loopback bypass disabled. Unsupported proxy facilities fail closed; there is no

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -857,7 +857,8 @@ attach:
   too_large: "'%{name}' exceeds the 10MB attachment limit."
   too_many: "You can attach up to 8 images per message."
 preview:
-  machine_proxy_unavailable: "The machine proxy could not be applied safely on macOS. WebKit bypasses it for local destinations, so the attached preview is unavailable."
+  external_unavailable: "Open the remote page in Preview first. Its forwarded browser link works only while this preview stays open."
+  remote_forwarding: "Remote loopback URLs are forwarded. Other addresses open from this Mac."
   load_error: "Could not load %{url}: %{message} (%{code})"
   title: "Preview"
   no_session: "Open a session to use the preview browser."

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -851,7 +851,8 @@ attach:
   too_large: "'%{name}' 超过了 10MB 的附件大小限制。"
   too_many: "每条消息最多只能附加 8 张图片。"
 preview:
-  machine_proxy_unavailable: "无法在 macOS 上安全应用主机代理。WebKit 会绕过代理访问本机地址，因此连接主机时无法使用内嵌预览。"
+  external_unavailable: "请先在预览中打开远程页面。转发后的浏览器链接仅在此预览保持打开时有效。"
+  remote_forwarding: "远程回环地址通过转发访问，其他地址从此 Mac 直接访问。"
   load_error: "无法加载 %{url}：%{message}（%{code}）"
   title: "预览"
   no_session: "打开一个会话以使用预览浏览器。"


### PR DESCRIPTION
macOS attached Preview can now open a loopback dev server through the paired host instead of refusing to create its WKWebView. For example, entering `http://localhost:5173/app?mode=dev` allocates a viewing-Mac loopback port, opens an authenticated CONNECT to the original host/port, and forwards the browser's bytes unchanged.

Related to #375. This implements the bounded remote development workflow; it does not claim the historical issue's full network policy or close it automatically.

### Behavior and ownership

- Each browser slot owns its route table, listener/accepted-connection tasks, native navigation adapter and separate nonpersistent WK store. Closing/pruning the slot or changing attachment disposes them. Local Preview and Windows/Android proxy behavior retain their existing paths.
- Explicit URL entry and native navigation reentry are distinct. Reload/history reuse live routes; top-level loopback redirects, including another port, retain the native request while changing its URL. The small delegate adapter preserves frame identity and method/body/headers, which lb-wry's URL-only callback does not expose.
- Address bar, copy, persisted URL and status `url` represent the logical remote URL. Status adds `actual_url`; URL waits match logical URLs. JavaScript/evaluate/window.location expose the real local URL and origin. Open externally resolves an existing live route instead of opening the viewer's unrelated original port.
- A localized note states the routing boundary: loopback HTTP(S) is forwarded; public/LAN addresses use viewer networking. Documentation covers changed ports, site origins, cookies, certificate validation, additional API/HMR ports and link lifetime.

### Evidence

All required local commands passed on pre-correction head `262b2dbf04d4c1461b70e7e8e684909924806ce9`, using the shared target directory and `CARGO_PROFILE_DEV_DEBUG=line-tables-only`:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo build --workspace --locked`
- `cargo test --workspace --locked`
- Direct `cargo-machete` binary, version **0.9.2**
- `RUSTFLAGS='-D warnings' IPHONEOS_DEPLOYMENT_TARGET=26.0 cargo check -p tcode-ios --target aarch64-apple-ios-sim --locked`
- `RUSTFLAGS='-D warnings' CARGO_NDK_PLATFORM=26 cargo ndk -t arm64-v8a check -p tcode-android --locked` with NDK **27.1.12297006**
- `RUSTFLAGS='-D warnings' cargo check -p tcode-web --target wasm32-unknown-unknown --locked`

Nine real listener/pairing proxy integration tests pass. New production-entry coverage checks opaque browser bytes/site authorization, allocated-port collisions, explicit intent versus native reentry, IPv6, cross-port navigation, errors/retry, half-close and owner disposal. Verified TLS is exercised both directly and through the new forwarder. The routing regression fails when production mapping is bypassed; the retired blanket-rejection test is removed. Real GUI verification caught and fixed a false error caused by normal macOS socket teardown.

An actual isolated Tcode bundle, attached to the production headless host, rendered `REMOTE_DEVSERVER`, loaded relative assets and completed same-port WebSocket echo. A controlled loopback relay simulated the remote port namespace while a viewer sentinel occupied the same logical port; only the explicit local-Preview control reached that sentinel. Relative links, absolute same-port and cross-port redirects, logical-URL positive/negative waits, native Back, copy/reload, close/reopen and attachment switching were exercised. Closing/switching produced EOF on an accepted socket and closed both localhost listeners. Reopening used new ports and an empty cookie store. Light/dark, wide/compact and native TLS-error PNGs were saved.

GUI binary SHA-256: `fb1ee837bed20a1802a24ec4005f2d78701e09a42a861d77e2b3ede3788d4733`. Detailed command results and PNGs are available to the lead under `/tmp/tcode-375-implementation/evidence/`.

### Limits

- Single-Mac controlled topology, not a real second machine. Same-port WS echo was tested; no arbitrary-framework HMR claim. Public/LAN destinations and absolute subresources are not automatically sent remotely, and hardcoded additional API/HMR ports require application configuration.
- The actual port changes Host/Origin. TLS retains the hostname/SNI and native validation: WK rejected the untrusted localhost fixture with `-1202`, while server evidence recorded SNI `localhost`. No trust settings were changed. Unassigned numeric loopback addresses such as `127.0.0.2` may fail local allocation on macOS.
- Windows/Android native GUI and iOS/Web functionality were not expanded. Their compile/test checks are reported separately from macOS GUI evidence. No #376 reachability work, dependency fork or upstream PR.
- GUI tooling caveat: one post-quit CUA observation auto-relaunched the test bundle without its isolation environment. That process was verified and stopped before any UI action on the default profile; startup effects on that profile were not audited. Subsequent launches were explicitly environment/PID-verified. The original user app process was not operated on.

The macOS debug link emitted the existing large `__eh_frame` linker warning; Clippy and all warnings-denied mobile/Web checks passed. Pre-correction GitHub checks were all successful at `262b2dbf04d4c1461b70e7e8e684909924806ce9`: [CI run](https://github.com/Tryanks/tcode/actions/runs/34235038727). Lead review/acceptance and merge remain separate.

CI history: the first run failed on Linux/macOS in the unchanged `store::tests::session_replica_matches_live_timeline_for_synthetic_turn` (incremental-replica timeout / stale contents). The same test passed in the full local suite and a focused local rerun. Failed jobs were retried once without source changes; original failure logs are retained in the evidence directory.

The first retry passed macOS but Linux failed in the unchanged terminal replication test with a shell-title mismatch (`bash` versus `sh`); that test had passed on the first attempt. A targeted retry for this distinct failure passed Linux. All six final-head checks are now successful. No source changes, skipped tests or weakened assertions were used for retries.

### Review correction

Head `441aa390a6bf10f299b0d094c1ae17e7c0cd61df` restores the original effective TCP port when a mapped URL changes scheme. For example, a route first allocated for `http://localhost/` and reused for `https://localhost:80/` now reports port80 correctly; the reverse HTTPS-default/HTTP443 case is covered too. Both remain one TCP route. The existing production navigation regression went red on the lost port and all nine proxy tests passed after the owner correction. The CONNECT handshake statements were expanded for readability with no protocol change. All eight required local command groups passed on this corrected head, including full-workspace fmt/Clippy/build/tests, direct machete0.9.2, and iOS/Android/Web checks. All six exact-head GitHub checks passed on the first attempt: [CI run](https://github.com/Tryanks/tcode/actions/runs/34239384774). Final-source logs/checks.json are under `/tmp/tcode-375-implementation/scheme-port-correction/`.

All GUI PNGs remain evidence for pre-correction head `262b2dbf` and the previously listed binary hash; no app was launched for this isolated correction. `final-light-wide.png` is a light/wide layout and remote-content capture showing **WebSocket: failed**, not a WS-success image. Retained `fixture.jsonl` line62 records echo at `2026-09-08T13:38:59.927Z`; image mtime is `13:40:25Z`, about85 seconds later, beyond the host's60-second idle limit. No per-connection timeout/close-reason log was retained for that frame, so idle expiry is a supported inference, not a proven cause. Reload/echo at line70 (`13:40:51.443Z`) and subsequent5-second echoes, plus dark-narrow/crossport PNGs, provide the successful WS evidence. Exact labels and provenance are in `evidence/gui-evidence-notes.md` and `gui-manifest.json`. The CUA incident disclosure above remains unchanged; no profile audit/reversion was attempted.
