### PR TITLE
Prepare unified native remote establishment and trusted stream admission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8913,6 +8913,7 @@ dependencies = [
  "tcode-runtime",
  "tcode-services",
  "tcode-voice",
+ "tempfile",
  "url",
  "web-time",
  "webview2-com",

--- a/crates/remote/Cargo.toml
+++ b/crates/remote/Cargo.toml
@@ -24,7 +24,7 @@ dirs = { version = "6", optional = true }
 async-tungstenite = { version = "0.30", default-features = false, features = ["handshake"] }
 base64 = { version = "0.23", optional = true }
 futures-lite = "2"
-futures-util = { version = "0.3", features = ["sink"] }
+futures-util = { version = "0.3", features = ["sink", "io"] }
 getrandom = { version = "0.3", optional = true }
 if-addrs = { version = "0.13", optional = true }
 log = "0.4"

--- a/crates/remote/src/client.rs
+++ b/crates/remote/src/client.rs
@@ -1,17 +1,13 @@
-use rustls::pki_types::ServerName;
 use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::io;
-use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::path::Path;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use async_channel::{Receiver, Sender};
 use async_tungstenite::WebSocketStream;
 use futures_util::{FutureExt as _, StreamExt as _};
 use serde::Deserialize;
-use smol::Async;
 use tungstenite::Message;
 
 pub use tcode_client::pairing::{
@@ -38,12 +34,20 @@ struct PairResponse {
 }
 
 pub fn pair(origin: &str, code: &str, device_name: &str) -> Result<PairedHost, String> {
+    smol::block_on(pair_async(origin, code, device_name))
+}
+
+pub(crate) async fn pair_async(
+    origin: &str,
+    code: &str,
+    device_name: &str,
+) -> Result<PairedHost, String> {
     let origin = tcode_client::pairing::parse_origin(origin)?;
     if !is_pairing_code(code) || device_name.is_empty() || device_name.len() > 256 {
         return Err("invalid pairing request".into());
     }
     let body = serde_json::json!({ "code": code, "device_name": device_name }).to_string();
-    let bytes = http(&origin, "POST", "/pair", &body)?;
+    let bytes = http_request(&origin, "POST", "/pair", &body).await?;
     let response: PairResponse =
         serde_json::from_slice(&bytes).map_err(|_| "invalid pairing response")?;
     Ok(PairedHost {
@@ -57,7 +61,15 @@ pub fn pair(origin: &str, code: &str, device_name: &str) -> Result<PairedHost, S
 
 /// Bounded HTTP/1.1; HTTPS origins use the standard WebPKI trust roots.
 pub fn http(origin: &str, method: &str, path: &str, body: &str) -> Result<Vec<u8>, String> {
-    use std::io::{Read as _, Write as _};
+    smol::block_on(http_request(origin, method, path, body))
+}
+
+async fn http_request(
+    origin: &str,
+    method: &str,
+    path: &str,
+    body: &str,
+) -> Result<Vec<u8>, String> {
     if !matches!(
         (method, path),
         ("POST", "/pair" | "/auth/setup" | "/auth/login")
@@ -67,53 +79,43 @@ pub fn http(origin: &str, method: &str, path: &str, body: &str) -> Result<Vec<u8
     {
         return Err("invalid HTTP request".into());
     }
-    let url = url::Url::parse(origin).map_err(|e| e.to_string())?;
-    let addr = url
-        .host_str()
-        .ok_or("missing host")?
-        .trim_matches(['[', ']']);
-    let port = url.port_or_known_default().ok_or("missing port")?;
-    let socket = TcpStream::connect_timeout(&socket_addr(addr, port)?, Duration::from_secs(5))
-        .map_err(|e| e.to_string())?;
-    socket
-        .set_read_timeout(Some(Duration::from_secs(
+    let endpoint = crate::endpoint::Endpoint::new(origin)?;
+    futures_lite::future::race(http_async(&endpoint, method, path, body), async {
+        smol::Timer::after(Duration::from_secs(
             if matches!(path, "/auth/setup" | "/auth/login") {
                 60
             } else {
                 5
             },
-        )))
-        .map_err(|e| e.to_string())?;
-    socket
-        .set_write_timeout(Some(Duration::from_secs(5)))
-        .map_err(|e| e.to_string())?;
-    trait HttpStream: std::io::Read + std::io::Write {}
-    impl<T: std::io::Read + std::io::Write> HttpStream for T {}
-    let mut stream: Box<dyn HttpStream> = if url.scheme() == "https" {
-        let session = rustls::ClientConnection::new(
-            tls_client_config()?,
-            ServerName::try_from(addr.to_owned()).map_err(|e| e.to_string())?,
-        )
-        .map_err(|e| e.to_string())?;
-        Box::new(rustls::StreamOwned::new(session, socket))
-    } else if url.scheme() == "http" {
-        Box::new(socket)
-    } else {
-        return Err("unsupported scheme".into());
-    };
+        ))
+        .await;
+        Err("HTTP request timed out".into())
+    })
+    .await
+}
+
+pub(crate) async fn http_async(
+    endpoint: &crate::endpoint::Endpoint,
+    method: &str,
+    path: &str,
+    body: &str,
+) -> Result<Vec<u8>, String> {
+    use futures_lite::io::{AsyncReadExt as _, AsyncWriteExt as _};
+    let mut stream = endpoint.connect().await.map_err(|e| e.to_string())?;
     let request = format!(
         "{method} {path} HTTP/1.1\r\nHost: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-        authority(addr, port),
+        endpoint.authority(),
         body.len()
     );
     stream
         .write_all(request.as_bytes())
+        .await
         .map_err(|e| e.to_string())?;
-    stream.flush().map_err(|e| e.to_string())?;
+    stream.flush().await.map_err(|e| e.to_string())?;
     let mut bytes = Vec::new();
     // A tunnel may close TLS without close_notify. Require the complete
     // Content-Length-delimited response before accepting such a close.
-    let read = (&mut stream).take(65537).read_to_end(&mut bytes);
+    let read = (&mut stream).take(65537).read_to_end(&mut bytes).await;
     if bytes.len() > 65536 {
         return Err("HTTP response too large".into());
     }
@@ -217,7 +219,7 @@ async fn connection_loop(
         let mut stable_ms = 0;
         let mut interrupted = None;
         let opened = futures_lite::future::race(
-            async { Ok(race_addresses(&host, &device_name).await) },
+            async { Ok(establish_websocket(&host, &device_name).await) },
             async { Err(outgoing.wake.recv().await) },
         )
         .await;
@@ -343,64 +345,22 @@ async fn connection_loop(
     incoming.close();
 }
 
-trait SocketStream: futures_lite::io::AsyncRead + futures_lite::io::AsyncWrite + Unpin + Send {}
-impl<T: futures_lite::io::AsyncRead + futures_lite::io::AsyncWrite + Unpin + Send> SocketStream
-    for T
-{
-}
-type WebSocket = WebSocketStream<Box<dyn SocketStream>>;
+type WebSocket = WebSocketStream<crate::endpoint::Stream>;
 
 fn connection_failure(error: String) -> ConnectionFailure {
     log::debug!("remote connection failed: {error}");
     ConnectionFailure::Unreachable
 }
 
-async fn race_addresses(
+async fn establish_websocket(
     host: &PairedHost,
     device_name: &str,
 ) -> Result<WebSocket, ConnectionFailure> {
     let url = url::Url::parse(&host.origin).map_err(|e| connection_failure(e.to_string()))?;
-    let name = url
-        .host_str()
-        .ok_or(ConnectionFailure::Unreachable)?
-        .trim_matches(['[', ']'])
-        .to_owned();
-    let port = url
-        .port_or_known_default()
-        .ok_or(ConnectionFailure::Unreachable)?;
-    let addresses = futures_lite::future::race(
-        async {
-            smol::net::resolve((name.as_str(), port))
-                .await
-                .map_err(|e| connection_failure(e.to_string()))
-        },
-        async {
-            smol::Timer::after(Duration::from_secs(5)).await;
-            Err(ConnectionFailure::Timeout)
-        },
-    )
-    .await?;
-    let mut attempts = futures_util::stream::FuturesUnordered::new();
-    for (index, address) in addresses.into_iter().enumerate() {
-        let url = &url;
-        attempts.push(async move {
-            smol::Timer::after(Duration::from_millis(250 * index as u64)).await;
-            futures_lite::future::race(open_websocket(address, url, host, device_name), async {
-                smol::Timer::after(Duration::from_secs(15)).await;
-                Err(ConnectionFailure::Timeout)
-            })
-            .await
-        });
-    }
-    let mut failure = ConnectionFailure::Unreachable;
-    while let Some(result) = attempts.next().await {
-        match result {
-            Ok(socket) => return Ok(socket),
-            Err(error) if error.is_terminal() => return Err(error),
-            Err(error) => failure = error,
-        }
-    }
-    Err(failure)
+    let endpoint = crate::endpoint::Endpoint::new(&host.origin).map_err(connection_failure)?;
+    endpoint
+        .establish(|stream| open_websocket(stream, &url, host, device_name))
+        .await
 }
 
 async fn send_interruptible(
@@ -439,35 +399,12 @@ async fn send_before(
     .await
 }
 
-async fn open_websocket(
-    address: SocketAddr,
+pub(crate) async fn open_websocket(
+    stream: crate::endpoint::Stream,
     origin: &url::Url,
     host: &PairedHost,
     device_name: &str,
 ) -> Result<WebSocket, ConnectionFailure> {
-    let tcp = Async::<TcpStream>::connect(address)
-        .await
-        .map_err(|e| connection_failure(e.to_string()))?;
-    let stream: Box<dyn SocketStream> = if origin.scheme() == "https" {
-        let name = origin
-            .host_str()
-            .ok_or(ConnectionFailure::Unreachable)?
-            .trim_matches(['[', ']'])
-            .to_owned();
-        Box::new(
-            futures_rustls::TlsConnector::from(tls_client_config().map_err(connection_failure)?)
-                .connect(
-                    ServerName::try_from(name).map_err(|e| connection_failure(e.to_string()))?,
-                    tcp,
-                )
-                .await
-                .map_err(|e| connection_failure(e.to_string()))?,
-        )
-    } else if origin.scheme() == "http" {
-        Box::new(tcp)
-    } else {
-        return Err(ConnectionFailure::Unreachable);
-    };
     let mut url = origin.clone();
     url.set_scheme(if origin.scheme() == "https" {
         "wss"
@@ -701,37 +638,6 @@ fn remember_subscription(line: &str, subscriptions: &mut HashMap<String, String>
     }
 }
 
-fn authority(address: &str, port: u16) -> String {
-    if address.contains(':') && !address.starts_with('[') {
-        format!("[{address}]:{port}")
-    } else {
-        format!("{address}:{port}")
-    }
-}
-
-fn socket_addr(address: &str, port: u16) -> Result<SocketAddr, String> {
-    if address.len() > 253 || address.contains(['\r', '\n', '/', ' ']) {
-        return Err("invalid host address".into());
-    }
-    (address.trim_matches(['[', ']']), port)
-        .to_socket_addrs()
-        .map_err(|e| format!("DNS: {e}"))?
-        .next()
-        .ok_or_else(|| "DNS returned no addresses".into())
-}
-
-fn tls_client_config() -> Result<Arc<rustls::ClientConfig>, String> {
-    let roots = rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-    let config = rustls::ClientConfig::builder_with_provider(Arc::new(
-        rustls::crypto::ring::default_provider(),
-    ))
-    .with_safe_default_protocol_versions()
-    .map_err(|e| e.to_string())?
-    .with_root_certificates(roots)
-    .with_no_client_auth();
-    Ok(Arc::new(config))
-}
-
 fn jitter_sample() -> f64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     // Timing entropy decorrelates clients without adding a cryptographic RNG.
@@ -740,4 +646,66 @@ fn jitter_sample() -> f64 {
         .unwrap_or_default()
         .subsec_nanos();
     f64::from(nanos % 1_000_001) / 1_000_000.
+}
+
+#[cfg(test)]
+mod establishment_tests {
+    use super::*;
+    use futures_lite::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    #[test]
+    fn stalled_http_times_out_and_cancelled_pairing_closes_its_stream() {
+        smol::block_on(async {
+            for cancel in [false, true] {
+                let listener = smol::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+                let origin = format!("http://{}", listener.local_addr().unwrap());
+                let (received, request_received) = async_channel::bounded(1);
+                let peer = smol::spawn(async move {
+                    let (mut stream, _) = listener.accept().await.unwrap();
+                    let mut head = vec![];
+                    while !head.ends_with(b"\r\n\r\n") {
+                        let mut byte = [0];
+                        stream.read_exact(&mut byte).await.unwrap();
+                        head.push(byte[0]);
+                    }
+                    received.send(()).await.unwrap();
+                    if !cancel {
+                        stream
+                            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\nx")
+                            .await
+                            .unwrap();
+                    }
+                    let mut remaining = vec![];
+                    stream.read_to_end(&mut remaining).await.unwrap();
+                });
+                let started = Instant::now();
+                if cancel {
+                    let task = smol::spawn(async move {
+                        pair_async(&origin, "123456", "cancelled device").await
+                    });
+                    request_received.recv().await.unwrap();
+                    task.cancel().await;
+                } else {
+                    assert_eq!(
+                        http_request(&origin, "GET", "/auth/state", "")
+                            .await
+                            .unwrap_err(),
+                        "HTTP request timed out"
+                    );
+                    assert!(started.elapsed() >= Duration::from_secs(5));
+                    assert!(started.elapsed() < Duration::from_secs(8));
+                }
+                futures_lite::future::race(
+                    async {
+                        peer.await;
+                    },
+                    async {
+                        smol::Timer::after(Duration::from_secs(2)).await;
+                        panic!("cancelled HTTP stream remained open");
+                    },
+                )
+                .await;
+            }
+        });
+    }
 }

--- a/crates/remote/src/client_host.rs
+++ b/crates/remote/src/client_host.rs
@@ -183,21 +183,8 @@ impl ClientHost for NativeClientHost {
 
     fn pair(&self, request: PairRequest) -> HostFuture<'_, Result<PairedHost, String>> {
         let device_name = self.device_name();
-        let (sender, receiver) = async_channel::bounded(1);
-        let spawn = std::thread::Builder::new()
-            .name("tcode-pair".into())
-            .spawn(move || {
-                let result = crate::client::pair(&request.origin, &request.code, &device_name);
-                let _ = sender.send_blocking(result);
-            });
         Box::pin(async move {
-            if let Err(error) = spawn {
-                return Err(format!("failed to start pairing: {error}"));
-            }
-            receiver
-                .recv()
-                .await
-                .unwrap_or_else(|error| Err(error.to_string()))
+            crate::client::pair_async(&request.origin, &request.code, &device_name).await
         })
     }
 

--- a/crates/remote/src/endpoint.rs
+++ b/crates/remote/src/endpoint.rs
@@ -1,0 +1,277 @@
+//! Native connection establishment shared by HTTP, WebSocket and CONNECT.
+use futures_lite::io::{AsyncRead, AsyncWrite};
+use futures_util::StreamExt as _;
+use std::{io, net::SocketAddr, sync::Arc, time::Duration};
+
+pub(crate) trait Socket: AsyncRead + AsyncWrite + Unpin + Send {}
+impl<T: AsyncRead + AsyncWrite + Unpin + Send> Socket for T {}
+pub(crate) type Stream = Box<dyn Socket>;
+
+pub(crate) struct Endpoint {
+    url: url::Url,
+    #[cfg(test)]
+    roots: Option<rustls::RootCertStore>,
+}
+
+impl Endpoint {
+    pub(crate) fn new(origin: &str) -> Result<Self, String> {
+        let origin = tcode_client::pairing::parse_origin(origin)?;
+        Ok(Self {
+            url: url::Url::parse(&origin).map_err(|e| e.to_string())?,
+            #[cfg(test)]
+            roots: None,
+        })
+    }
+
+    pub(crate) fn authority(&self) -> String {
+        format!(
+            "{}:{}",
+            self.url.host_str().unwrap(),
+            self.url.port_or_known_default().unwrap()
+        )
+    }
+
+    pub(crate) async fn connect(&self) -> io::Result<Stream> {
+        self.establish(|stream| async { Ok(stream) })
+            .await
+            .map_err(|error| io::Error::other(format!("{error:?}")))
+    }
+
+    /// Race complete protocol handshakes, not just TCP connects: a reachable
+    /// address that stalls during TLS or hello must not hide a healthy address.
+    pub(crate) async fn establish<T, F, Fut>(
+        &self,
+        handshake: F,
+    ) -> Result<T, tcode_client::ConnectionFailure>
+    where
+        F: Fn(Stream) -> Fut,
+        Fut: std::future::Future<Output = Result<T, tcode_client::ConnectionFailure>>,
+    {
+        use tcode_client::ConnectionFailure;
+        let addresses = futures_lite::future::race(
+            async {
+                smol::net::resolve((
+                    self.url.host_str().unwrap().trim_matches(['[', ']']),
+                    self.url.port_or_known_default().unwrap(),
+                ))
+                .await
+                .map_err(|_| ConnectionFailure::Unreachable)
+            },
+            async {
+                smol::Timer::after(Duration::from_secs(5)).await;
+                Err(ConnectionFailure::Timeout)
+            },
+        )
+        .await?;
+        let mut attempts = futures_util::stream::FuturesUnordered::new();
+        for (index, address) in addresses.into_iter().enumerate() {
+            let handshake = &handshake;
+            attempts.push(async move {
+                smol::Timer::after(Duration::from_millis(250 * index as u64)).await;
+                futures_lite::future::race(
+                    async {
+                        let stream = self.connect_address(address).await.map_err(|error| {
+                            log::debug!("remote connection failed: {error}");
+                            ConnectionFailure::Unreachable
+                        })?;
+                        handshake(stream).await
+                    },
+                    async {
+                        smol::Timer::after(Duration::from_secs(15)).await;
+                        Err(ConnectionFailure::Timeout)
+                    },
+                )
+                .await
+            });
+        }
+        let mut failure = ConnectionFailure::Unreachable;
+        while let Some(result) = attempts.next().await {
+            match result {
+                Ok(value) => return Ok(value),
+                Err(error) if error.is_terminal() => return Err(error),
+                Err(error) => failure = error,
+            }
+        }
+        Err(failure)
+    }
+
+    async fn connect_address(&self, address: SocketAddr) -> io::Result<Stream> {
+        let tcp = smol::net::TcpStream::connect(address).await?;
+        if self.url.scheme() == "http" {
+            return Ok(Box::new(tcp));
+        }
+        let roots =
+            rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        #[cfg(test)]
+        let roots = self.roots.clone().unwrap_or(roots);
+        let config = rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .map_err(io::Error::other)?
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+        let name = rustls::pki_types::ServerName::try_from(
+            self.url
+                .host_str()
+                .unwrap()
+                .trim_matches(['[', ']'])
+                .to_owned(),
+        )
+        .map_err(io::Error::other)?;
+        Ok(Box::new(
+            futures_rustls::TlsConnector::from(Arc::new(config))
+                .connect(name, tcp)
+                .await?,
+        ))
+    }
+}
+
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    use super::*;
+    use futures_lite::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    #[test]
+    fn tls_entry_preserves_pair_ws_connect_and_denies_imported_admin() {
+        smol::block_on(async {
+            let root = std::env::temp_dir().join(format!("tcode-entry-{}", uuid::Uuid::new_v4()));
+            let (to_host, _commands) = async_channel::unbounded();
+            let (_events, from_host) = async_channel::unbounded();
+            let server = Arc::new(
+                crate::serve(
+                    crate::HostMux::new(to_host, from_host),
+                    crate::RemoteConfig {
+                        listen: "127.0.0.1:0".parse().unwrap(),
+                        host_name: "entry fixture".into(),
+                        data_dir: root.clone(),
+                        static_bundle: None,
+                        browser_password: false,
+                    },
+                )
+                .unwrap(),
+            );
+            let certificate = rustls::pki_types::CertificateDer::from(
+                include_bytes!("../tests/fixtures/localhost.der").to_vec(),
+            );
+            let key = rustls::pki_types::PrivatePkcs8KeyDer::from(
+                include_bytes!("../tests/fixtures/localhost-key.der").to_vec(),
+            );
+            let config = rustls::ServerConfig::builder_with_provider(Arc::new(
+                rustls::crypto::ring::default_provider(),
+            ))
+            .with_safe_default_protocol_versions()
+            .unwrap()
+            .with_no_client_auth()
+            .with_single_cert(vec![certificate.clone()], key.into())
+            .unwrap();
+            let acceptor = futures_rustls::TlsAcceptor::from(Arc::new(config));
+            let listener = smol::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let origin = format!(
+                "https://localhost:{}",
+                listener.local_addr().unwrap().port()
+            );
+            let host = server.clone();
+            let accepting = smol::spawn(async move {
+                let mut tasks = Vec::new();
+                while let Ok((tcp, _)) = listener.accept().await {
+                    let acceptor = acceptor.clone();
+                    let host = host.clone();
+                    tasks.push(smol::spawn(async move {
+                        if let Ok(tls) = acceptor.accept(tcp).await {
+                            let _ = host.admit(tls).await;
+                        }
+                    }));
+                }
+            });
+            // Public roots must reject the private fixture, never silently downgrade.
+            assert!(Endpoint::new(&origin).unwrap().connect().await.is_err());
+            let mut endpoint = Endpoint::new(&origin).unwrap();
+            let mut roots = rustls::RootCertStore::empty();
+            roots.add(certificate).unwrap();
+            endpoint.roots = Some(roots);
+            let direct = Endpoint::new(&format!("http://{}", server.local_addr())).unwrap();
+            assert!(
+                crate::client::http_async(&direct, "GET", "/admin/pair", "")
+                    .await
+                    .is_ok()
+            );
+            let mut imported = endpoint.connect().await.unwrap();
+            imported.write_all(b"GET /admin/pair HTTP/1.1\r\nHost: localhost\r\nX-Forwarded-For: 127.0.0.1\r\n\r\n").await.unwrap();
+            let mut reply = vec![];
+            let _ = imported.read_to_end(&mut reply).await;
+            assert!(reply.starts_with(b"HTTP/1.1 403 Forbidden\r\n"));
+            let code = server.new_pairing_code().code;
+            let body = serde_json::json!({"code":code,"device_name":"tls device"}).to_string();
+            let response = crate::client::http_async(&endpoint, "POST", "/pair", &body)
+                .await
+                .unwrap();
+            let response: serde_json::Value = serde_json::from_slice(&response).unwrap();
+            let paired = tcode_client::pairing::PairedHost {
+                origin: origin.clone(),
+                token: response["token"].as_str().unwrap().into(),
+                host_id: response["host_id"].as_str().unwrap().into(),
+                name: "entry fixture".into(),
+                last_connected_unix: None,
+            };
+            let url = url::Url::parse(&origin).unwrap();
+            let ws = endpoint
+                .establish(|stream| {
+                    crate::client::open_websocket(stream, &url, &paired, "tls device")
+                })
+                .await
+                .unwrap();
+            drop(ws);
+            let destination = smol::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let address = destination.local_addr().unwrap();
+            let echo = smol::spawn(async move {
+                let (mut socket, _) = destination.accept().await.unwrap();
+                let mut bytes = vec![];
+                socket.read_to_end(&mut bytes).await.unwrap();
+                assert_eq!(bytes, b"request after CONNECT");
+                socket.write_all(b"reply after EOF").await.unwrap();
+                socket.close().await.unwrap();
+            });
+            let viewing = smol::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let mut tunnel = smol::net::TcpStream::connect(viewing.local_addr().unwrap())
+                .await
+                .unwrap();
+            let (browser, _) = viewing.accept().await.unwrap();
+            let token = paired.token.clone();
+            let endpoint = Arc::new(endpoint);
+            let forwarding_endpoint = endpoint.clone();
+            let forwarding = smol::spawn(async move {
+                crate::preview::forward(
+                    browser,
+                    &forwarding_endpoint,
+                    &token,
+                    &address.to_string(),
+                )
+                .await
+                .unwrap();
+            });
+            tunnel.write_all(b"request after CONNECT").await.unwrap();
+            tunnel.close().await.unwrap();
+            let mut reply = vec![];
+            tunnel.read_to_end(&mut reply).await.unwrap();
+            assert_eq!(reply, b"reply after EOF");
+            echo.await;
+            forwarding.await;
+            server.revoke_device(&server.devices()[0].id).unwrap();
+            assert!(matches!(
+                endpoint
+                    .establish(|stream| crate::client::open_websocket(
+                        stream,
+                        &url,
+                        &paired,
+                        "tls device"
+                    ))
+                    .await,
+                Err(tcode_client::ConnectionFailure::AuthenticationRejected)
+            ));
+            drop(accepting);
+            drop(server);
+            std::fs::remove_dir_all(root).unwrap();
+        });
+    }
+}

--- a/crates/remote/src/lib.rs
+++ b/crates/remote/src/lib.rs
@@ -25,3 +25,6 @@ pub use server::{DeviceInfo, PairingCode, RemoteConfig, RemoteServer, StaticBund
 
 #[cfg(feature = "client")]
 pub mod preview;
+
+#[cfg(feature = "client")]
+mod endpoint;

--- a/crates/remote/src/preview.rs
+++ b/crates/remote/src/preview.rs
@@ -112,10 +112,7 @@ impl PreviewRoutes {
         if !loopback(&url) {
             return Ok(intent.into());
         }
-        let proxy = Url::parse(&self.host.origin).map_err(|_| "Invalid paired host origin")?;
-        if proxy.scheme() != "http" {
-            return Err("Remote preview requires a direct HTTP paired host connection".into());
-        }
+        let endpoint = Arc::new(crate::endpoint::Endpoint::new(&self.host.origin)?);
         let destination = authority(&url).ok_or("Missing preview port")?;
         let port = if let Some(route) = self.routes.get(&destination) {
             route.port
@@ -131,6 +128,7 @@ impl PreviewRoutes {
                 let listener = TcpListener::try_from(listener)
                     .map_err(|_| "Could not start preview listener")?;
                 let host = self.host.clone();
+                let endpoint = endpoint.clone();
                 let destination = destination.clone();
                 let error = self.error.clone();
                 let changed = self.changed.clone();
@@ -139,12 +137,15 @@ impl PreviewRoutes {
                     while let Ok((socket, _)) = listener.accept().await {
                         connections.retain(|task: &smol::Task<()>| !task.is_finished());
                         let host = host.clone();
+                        let endpoint = endpoint.clone();
                         let destination = destination.clone();
                         let error = error.clone();
                         let changed = changed.clone();
                         connections.push(smol::spawn(async move {
                             let keepalive = socket.clone();
-                            if let Err(failure) = forward(socket, &host, &destination).await {
+                            if let Err(failure) =
+                                forward(socket, &endpoint, &host.token, &destination).await
+                            {
                                 *error.lock().unwrap() = Some((destination, failure.to_string()));
                                 let _ = changed.try_send(());
                             }
@@ -230,19 +231,16 @@ fn bind_loopback(url: &Url) -> io::Result<Vec<std::net::TcpListener>> {
     ))
 }
 
-async fn forward(socket: TcpStream, host: &PairedHost, destination: &str) -> io::Result<()> {
-    let mut remote = future::race(
+pub(crate) async fn forward(
+    socket: TcpStream,
+    endpoint: &crate::endpoint::Endpoint,
+    token: &str,
+    destination: &str,
+) -> io::Result<()> {
+    let remote = future::race(
         async {
-            let proxy = Url::parse(&host.origin).map_err(io::Error::other)?;
-            let address = proxy
-                .host_str()
-                .ok_or_else(|| io::Error::other("Missing paired host"))?
-                .trim_matches(['[', ']']);
-            let port = proxy.port_or_known_default().unwrap();
-            let mut remote = TcpStream::connect((address, port)).await.map_err(|_| {
-                io::Error::other("Cannot connect to the paired host preview service")
-            })?;
-            let auth = STANDARD.encode(format!("tcode:{}", host.token));
+            let mut remote = endpoint.connect().await?;
+            let auth = STANDARD.encode(format!("tcode:{token}"));
             let request = format!(
                 "CONNECT {destination} HTTP/1.1\r\nHost: {destination}\r\nProxy-Authorization: Basic {auth}\r\n\r\n"
             );
@@ -272,14 +270,14 @@ async fn forward(socket: TcpStream, host: &PairedHost, destination: &str) -> io:
     )
     .await?;
     let mut browser = socket.clone();
-    let mut outbound = remote.clone();
+    let (mut remote, mut outbound) = futures_util::io::AsyncReadExt::split(remote);
     // Once CONNECT succeeds, normal browser cancellation and peer shutdown
     // can return NotConnected/BrokenPipe. WebKit owns page-load errors; a
     // closed keepalive socket must not overwrite a successfully loaded page.
     let _ = future::try_zip(
         async {
             futures_lite::io::copy(&mut browser, &mut outbound).await?;
-            outbound.shutdown(Shutdown::Write)
+            outbound.close().await
         },
         async {
             futures_lite::io::copy(&mut remote, &mut socket.clone()).await?;
@@ -288,4 +286,57 @@ async fn forward(socket: TcpStream, host: &PairedHost, destination: &str) -> io:
     )
     .await;
     Ok(())
+}
+
+/// Attachment-owned bridge for native browser engines that require an OS proxy
+/// address. The browser's existing proxy protocol and authentication pass through
+/// unchanged to the same paired host entry as pairing and the main WebSocket.
+/// Dropping the bridge cancels its listener and all accepted connections.
+pub struct NativeProxy {
+    origin: String,
+    _listener: smol::Task<()>,
+}
+
+impl NativeProxy {
+    pub fn new(host: &PairedHost) -> Result<Self, String> {
+        let endpoint = Arc::new(crate::endpoint::Endpoint::new(&host.origin)?);
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").map_err(|e| e.to_string())?;
+        let origin = format!(
+            "http://{}",
+            listener.local_addr().map_err(|e| e.to_string())?
+        );
+        let listener = TcpListener::try_from(listener).map_err(|e| e.to_string())?;
+        let task = smol::spawn(async move {
+            let mut connections = Vec::new();
+            while let Ok((browser, _)) = listener.accept().await {
+                connections.retain(|task: &smol::Task<()>| !task.is_finished());
+                let endpoint = endpoint.clone();
+                connections.push(smol::spawn(async move {
+                    let Ok(remote) = endpoint.connect().await else {
+                        return;
+                    };
+                    let (mut reader, mut writer) = futures_util::io::AsyncReadExt::split(remote);
+                    let _ = future::try_zip(
+                        async {
+                            futures_lite::io::copy(&mut browser.clone(), &mut writer).await?;
+                            writer.close().await
+                        },
+                        async {
+                            futures_lite::io::copy(&mut reader, &mut browser.clone()).await?;
+                            browser.shutdown(Shutdown::Write)
+                        },
+                    )
+                    .await;
+                }));
+            }
+        });
+        Ok(Self {
+            origin,
+            _listener: task,
+        })
+    }
+
+    pub fn origin(&self) -> &str {
+        &self.origin
+    }
 }

--- a/crates/remote/src/proxy.rs
+++ b/crates/remote/src/proxy.rs
@@ -1,12 +1,10 @@
 //! Token-authenticated host-network egress. HTTPS stays an opaque byte tunnel.
 use std::io;
-use std::net::{SocketAddr, TcpStream};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use futures_lite::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
-use smol::Async;
 use url::Url;
 
 use crate::{server::Shared, wire::Request};
@@ -22,16 +20,14 @@ fn credential(request: &Request) -> Option<String> {
     (user == "tcode").then(|| token.to_owned())
 }
 
-pub(crate) async fn handle(
-    mut stream: Async<TcpStream>,
-    request: Request,
-    peer: SocketAddr,
-    shared: &Shared,
-) -> io::Result<()> {
+pub(crate) async fn handle<S>(mut stream: S, request: Request, shared: &Shared) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     let token =
         credential(&request).filter(|token| shared.auth.lock().unwrap().token_is_valid(token));
     let Some(token) = token else {
-        log::warn!("preview proxy authentication rejected from {peer}");
+        log::warn!("preview proxy authentication rejected");
         return stream.write_all(b"HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"tcode-preview\"\r\nContent-Length: 0\r\nConnection: close\r\n\r\n").await;
     };
     let connect = request.method == "CONNECT";
@@ -141,7 +137,7 @@ pub(crate) async fn handle(
         }
     };
     log::info!(
-        "preview proxy {} {authority} from {peer}",
+        "preview proxy {} {authority}",
         if connect { "CONNECT" } else { "HTTP" }
     );
     if connect {
@@ -149,18 +145,19 @@ pub(crate) async fn handle(
             .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
             .await?;
     }
+    let (mut reader, mut writer) = futures_util::io::AsyncReadExt::split(stream);
     let activity = Mutex::new(Instant::now());
     futures_lite::future::race(
         async {
             if connect || upgrade {
                 futures_lite::future::try_zip(
                     async {
-                        copy(&stream, socket.clone(), &activity).await?;
+                        copy(&mut reader, socket.clone(), &activity).await?;
                         socket.shutdown(std::net::Shutdown::Write)
                     },
                     async {
-                        copy(socket.clone(), &stream, &activity).await?;
-                        stream.get_ref().shutdown(std::net::Shutdown::Write)
+                        copy(socket.clone(), &mut writer, &activity).await?;
+                        writer.close().await
                     },
                 )
                 .await
@@ -169,7 +166,7 @@ pub(crate) async fn handle(
                 futures_lite::future::race(
                     async {
                         upload(
-                            &stream,
+                            &mut reader,
                             socket.clone(),
                             length,
                             chunked.is_some(),
@@ -180,7 +177,7 @@ pub(crate) async fn handle(
                         // a pipelined Proxy-Authorization header to the destination.
                         std::future::pending::<io::Result<()>>().await
                     },
-                    copy(socket.clone(), &stream, &activity),
+                    copy(socket.clone(), &mut writer, &activity),
                 )
                 .await
             }

--- a/crates/remote/src/server.rs
+++ b/crates/remote/src/server.rs
@@ -12,7 +12,6 @@ use futures_lite::io::AsyncWriteExt as _;
 use futures_util::{FutureExt as _, StreamExt as _};
 use serde::{Deserialize, Serialize};
 use sha1::{Digest as _, Sha1};
-use smol::Async;
 use tungstenite::Message;
 use tungstenite::protocol::Role;
 
@@ -79,7 +78,33 @@ pub struct RemoteServer {
     thread: Option<JoinHandle<()>>,
 }
 
+/// Ingress provenance is established by the listener, never by request headers.
+#[derive(Clone, Copy, Debug)]
+enum Ingress {
+    Direct(SocketAddr),
+    Imported,
+}
+
+impl Ingress {
+    fn local_admin(self) -> bool {
+        matches!(self, Self::Direct(peer) if peer.ip().is_loopback())
+    }
+}
+
 impl RemoteServer {
+    /// Admit a remotely supplied duplex stream into the existing host dispatch.
+    /// Dropping this future cancels the connection. Imported streams never gain
+    /// local administration rights, including streams forwarded over loopback.
+    pub fn admit<S>(
+        &self,
+        stream: S,
+    ) -> impl std::future::Future<Output = io::Result<()>> + Send + use<S>
+    where
+        S: futures_lite::io::AsyncRead + futures_lite::io::AsyncWrite + Unpin + Send,
+    {
+        admit(stream, Ingress::Imported, self.shared.clone())
+    }
+
     pub fn local_addr(&self) -> SocketAddr {
         self.local_addr
     }
@@ -136,7 +161,6 @@ impl Drop for RemoteServer {
 pub fn serve(mux: HostMux, config: RemoteConfig) -> io::Result<RemoteServer> {
     let auth = AuthStore::open(&config.data_dir, &config.host_name)?;
     let listener = TcpListener::bind(config.listen)?;
-    listener.set_nonblocking(true)?;
     let local_addr = listener.local_addr()?;
     let (shutdown, shutdown_rx) = async_channel::bounded::<()>(1);
     let shared = Arc::new(Shared {
@@ -154,7 +178,7 @@ pub fn serve(mux: HostMux, config: RemoteConfig) -> io::Result<RemoteServer> {
         .name("tcode-remote-server".into())
         .spawn(move || {
             smol::block_on(async move {
-                let listener = match Async::new(listener) {
+                let listener = match smol::net::TcpListener::try_from(listener) {
                     Ok(listener) => listener,
                     Err(error) => {
                         log::error!("remote listener initialization failed: {error}");
@@ -163,7 +187,7 @@ pub fn serve(mux: HostMux, config: RemoteConfig) -> io::Result<RemoteServer> {
                 };
                 loop {
                     enum Next {
-                        Accepted(io::Result<(Async<std::net::TcpStream>, SocketAddr)>),
+                        Accepted(io::Result<(smol::net::TcpStream, SocketAddr)>),
                         Shutdown,
                     }
                     let next = futures_lite::future::race(
@@ -176,15 +200,9 @@ pub fn serve(mux: HostMux, config: RemoteConfig) -> io::Result<RemoteServer> {
                     .await;
                     match next {
                         Next::Accepted(Ok((stream, peer))) => {
-                            use std::sync::atomic::Ordering;
-                            if thread_shared.connections.fetch_add(1, Ordering::Relaxed) >= 256 {
-                                thread_shared.connections.fetch_sub(1, Ordering::Relaxed);
-                                continue;
-                            }
                             let shared = thread_shared.clone();
                             smol::spawn(async move {
-                                let result = handle_connection(stream, peer, shared.clone()).await;
-                                shared.connections.fetch_sub(1, Ordering::Relaxed);
+                                let result = admit(stream, Ingress::Direct(peer), shared).await;
                                 if let Err(error) = result {
                                     log::debug!("remote connection ended: {error}");
                                 }
@@ -207,14 +225,40 @@ pub fn serve(mux: HostMux, config: RemoteConfig) -> io::Result<RemoteServer> {
     })
 }
 
-async fn handle_connection(
-    stream: Async<std::net::TcpStream>,
-    peer: SocketAddr,
-    shared: Arc<Shared>,
-) -> io::Result<()> {
+async fn admit<S>(stream: S, ingress: Ingress, shared: Arc<Shared>) -> io::Result<()>
+where
+    S: futures_lite::io::AsyncRead + futures_lite::io::AsyncWrite + Unpin + Send,
+{
+    use std::sync::atomic::Ordering;
+    struct Permit(Arc<Shared>);
+    impl Drop for Permit {
+        fn drop(&mut self) {
+            self.0.connections.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+    let previous = shared.connections.fetch_add(1, Ordering::Relaxed);
+    let _permit = Permit(shared.clone());
+    if previous >= 256 || shared.shutdown.is_closed() {
+        return Err(io::Error::other("server unavailable"));
+    }
+    handle_connection(stream, ingress, shared).await
+}
+
+async fn handle_connection<S>(stream: S, ingress: Ingress, shared: Arc<Shared>) -> io::Result<()>
+where
+    S: futures_lite::io::AsyncRead + futures_lite::io::AsyncWrite + Unpin + Send,
+{
     let mut stream = stream;
     let request = match futures_lite::future::race(read_request(&mut stream), async {
-        smol::Timer::after(Duration::from_secs(5)).await;
+        futures_lite::future::race(
+            async {
+                smol::Timer::after(Duration::from_secs(5)).await;
+            },
+            async {
+                let _ = shared.shutdown.recv().await;
+            },
+        )
+        .await;
         Err(io::Error::new(
             io::ErrorKind::TimedOut,
             "HTTP request timed out",
@@ -224,6 +268,9 @@ async fn handle_connection(
     {
         Ok(request) => request,
         Err(error) => {
+            if shared.shutdown.is_closed() {
+                return Ok(());
+            }
             let _ = response(
                 &mut stream,
                 "400 Bad Request",
@@ -234,13 +281,36 @@ async fn handle_connection(
             return Err(error);
         }
     };
+    if request.method == "GET" && request.path == "/ws" && is_websocket_upgrade(&request) {
+        // The WS loop sends its existing close frame. Bound teardown as well
+        // when an admitted stream is blocked writing to an unresponsive peer.
+        return futures_lite::future::race(websocket(stream, request, shared.clone()), async {
+            let _ = shared.shutdown.recv().await;
+            smol::Timer::after(Duration::from_secs(1)).await;
+            Ok(())
+        })
+        .await;
+    }
+    futures_lite::future::race(dispatch(stream, request, ingress, &shared), async {
+        let _ = shared.shutdown.recv().await;
+        Ok(())
+    })
+    .await
+}
+
+async fn dispatch<S>(
+    mut stream: S,
+    request: Request,
+    ingress: Ingress,
+    shared: &Arc<Shared>,
+) -> io::Result<()>
+where
+    S: futures_lite::io::AsyncRead + futures_lite::io::AsyncWrite + Unpin + Send,
+{
     if request.method == "CONNECT" || request.path.starts_with("http://") {
-        return crate::proxy::handle(stream, request, peer, &shared).await;
+        return crate::proxy::handle(stream, request, shared).await;
     }
     match (request.method.as_str(), request.path.as_str()) {
-        ("GET", "/ws") if is_websocket_upgrade(&request) => {
-            websocket(stream, request, shared).await
-        }
         ("GET", "/auth/state") => {
             let state = if shared.browser_password {
                 serde_json::json!({"mode": "password", "configured": shared.auth.lock().unwrap().password_configured()})
@@ -250,11 +320,11 @@ async fn handle_connection(
             json_response(&mut stream, "200 OK", &state).await
         }
         ("POST", "/auth/setup" | "/auth/login") if shared.browser_password => {
-            password_auth(&mut stream, request, shared).await
+            password_auth(&mut stream, request, shared.clone()).await
         }
-        ("POST", "/pair") => pair(&mut stream, request, &shared).await,
+        ("POST", "/pair") => pair(&mut stream, request, shared).await,
         ("GET", "/admin/pair")
-            if peer.ip().is_loopback()
+            if ingress.local_admin()
                 && shared.browser_password
                 && !shared.auth.lock().unwrap().pairing_enabled =>
         {
@@ -265,8 +335,8 @@ async fn handle_connection(
             )
             .await
         }
-        ("GET", "/admin/pair") if peer.ip().is_loopback() => {
-            json_response(&mut stream, "200 OK", &mint_pairing_code(&shared)).await
+        ("GET", "/admin/pair") if ingress.local_admin() => {
+            json_response(&mut stream, "200 OK", &mint_pairing_code(shared)).await
         }
         ("GET", "/admin/pair") => {
             response(
@@ -278,7 +348,7 @@ async fn handle_connection(
             .await
         }
         ("GET" | "HEAD", path) => {
-            serve_static(&mut stream, path, &shared, request.method == "HEAD").await
+            serve_static(&mut stream, path, shared, request.method == "HEAD").await
         }
         _ => {
             response(
@@ -591,11 +661,10 @@ struct Hello {
     token: String,
 }
 
-async fn websocket(
-    mut stream: Async<std::net::TcpStream>,
-    request: Request,
-    shared: Arc<Shared>,
-) -> io::Result<()> {
+async fn websocket<S>(mut stream: S, request: Request, shared: Arc<Shared>) -> io::Result<()>
+where
+    S: futures_lite::io::AsyncRead + futures_lite::io::AsyncWrite + Unpin + Send,
+{
     let key = request
         .headers
         .get("sec-websocket-key")

--- a/crates/remote/tests/proxy.rs
+++ b/crates/remote/tests/proxy.rs
@@ -550,3 +550,128 @@ fn browser_keepalive_shutdown_does_not_report_a_failed_navigation() {
     browser.read_exact(&mut [0; 4]).unwrap();
     assert_eq!(routes.error(), None);
 }
+
+#[test]
+fn native_bridge_preserves_reverse_half_close_auth_and_attachment_lifetime() {
+    for bridged in [false, true] {
+        let machine = Machine::new();
+        let server = machine.server.as_ref().unwrap();
+        let host = tcode_remote::client::PairedHost {
+            origin: format!("http://{}", server.local_addr()),
+            host_id: String::new(),
+            name: String::new(),
+            token: String::new(),
+            last_connected_unix: None,
+        };
+        let bridge = bridged.then(|| tcode_remote::preview::NativeProxy::new(&host).unwrap());
+        let address = bridge
+            .as_ref()
+            .map(|bridge| bridge.origin().trim_start_matches("http://").to_owned())
+            .unwrap_or_else(|| server.local_addr().to_string());
+        let target = TcpListener::bind("127.0.0.1:0").unwrap();
+        let destination = target.local_addr().unwrap();
+        let target = std::thread::spawn(move || {
+            let (mut target, _) = target.accept().unwrap();
+            target
+                .set_read_timeout(Some(Duration::from_secs(10)))
+                .unwrap();
+            target.write_all(b"response first").unwrap();
+            target.shutdown(std::net::Shutdown::Write).unwrap();
+            let mut request = String::new();
+            target.read_to_string(&mut request).unwrap();
+            assert_eq!(request, "request after remote EOF");
+        });
+        let mut browser = TcpStream::connect(&address).unwrap();
+        browser
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        browser
+            .write_all(format!("CONNECT {destination} HTTP/1.1\r\n{}\r\n", machine.auth).as_bytes())
+            .unwrap();
+        assert!(head(&mut browser).starts_with("HTTP/1.1 200 "));
+        let mut reply = String::new();
+        browser.read_to_string(&mut reply).unwrap();
+        assert_eq!(reply, "response first");
+        browser.write_all(b"request after remote EOF").unwrap();
+        browser.shutdown(std::net::Shutdown::Write).unwrap();
+        target.join().unwrap();
+        if let Some(bridge) = bridge {
+            let mut unauthorized = TcpStream::connect(&address).unwrap();
+            unauthorized
+                .set_read_timeout(Some(Duration::from_secs(10)))
+                .unwrap();
+            unauthorized
+                .write_all(b"CONNECT localhost:1 HTTP/1.1\r\n\r\n")
+                .unwrap();
+            assert!(head(&mut unauthorized).starts_with("HTTP/1.1 407 "));
+            let mut pending = TcpStream::connect(&address).unwrap();
+            pending
+                .set_read_timeout(Some(Duration::from_secs(10)))
+                .unwrap();
+            pending.write_all(b"GET ").unwrap();
+            drop(bridge);
+            match pending.read(&mut [0]) {
+                Ok(0) => {}
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionAborted
+                    ) => {}
+                result => panic!("bridge did not close its pending connection: {result:?}"),
+            }
+        }
+    }
+}
+
+#[test]
+fn admitted_pending_streams_cancel_and_stop_without_retaining_server() {
+    smol::block_on(async {
+        use futures_lite::io::{AsyncReadExt as _, AsyncWriteExt as _};
+        for shutdown in [false, true] {
+            let mut machine = Machine::new();
+            let listener = smol::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let mut peer = smol::net::TcpStream::connect(listener.local_addr().unwrap())
+                .await
+                .unwrap();
+            let (stream, _) = listener.accept().await.unwrap();
+            let admission = machine.server.as_ref().unwrap().admit(stream);
+            let mut admission = Box::pin(admission);
+            assert!(
+                futures_lite::future::poll_once(&mut admission)
+                    .await
+                    .is_none()
+            );
+            peer.write_all(b"GET /admin").await.unwrap();
+            assert!(
+                futures_lite::future::poll_once(&mut admission)
+                    .await
+                    .is_none()
+            );
+            if shutdown {
+                machine.server.take().unwrap().shutdown();
+                admission.await.unwrap();
+            } else {
+                drop(admission);
+            }
+            futures_lite::future::race(
+                async {
+                    match peer.read(&mut [0]).await {
+                        Ok(0) => {}
+                        Err(error)
+                            if matches!(
+                                error.kind(),
+                                std::io::ErrorKind::ConnectionReset
+                                    | std::io::ErrorKind::ConnectionAborted
+                            ) => {}
+                        result => panic!("admitted stream did not close: {result:?}"),
+                    }
+                },
+                async {
+                    smol::Timer::after(Duration::from_secs(2)).await;
+                    panic!("admitted stream survived cancellation or shutdown");
+                },
+            )
+            .await;
+        }
+    });
+}

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -44,6 +44,7 @@ native-preview = [
     "dep:objc2-foundation",
     "dep:webview2-com",
     "dep:windows-core",
+    "dep:tempfile",
 ]
 # macOS 26 dictation in the composer.
 voice = ["dep:tcode-voice"]
@@ -122,6 +123,7 @@ features = ["WKNavigationDelegate", "WKNavigationAction", "WKFrameInfo", "WKSnap
 optional = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
+tempfile = { version = "3", optional = true }
 # Pinned to the version lb-wry resolves, so both drive the same WebView2 objects.
 webview2-com = { version = "0.38.2", optional = true }
 windows-core = { version = "0.61", optional = true }

--- a/crates/ui/src/preview_panel/lifecycle.rs
+++ b/crates/ui/src/preview_panel/lifecycle.rs
@@ -132,6 +132,8 @@ pub struct BrowserLifecycle {
     active_identity: Option<(String, String)>,
     creator: Creator,
     proxy: Option<tcode_client::pairing::PairedHost>,
+    #[cfg(any(target_os = "windows", target_os = "android"))]
+    _native_proxy: Option<tcode_remote::preview::NativeProxy>,
 }
 
 pub(super) struct KeyReconciliation {
@@ -144,6 +146,18 @@ impl BrowserLifecycle {
         owner: Weak<()>,
         proxy: Result<Option<tcode_client::pairing::PairedHost>, String>,
     ) -> Self {
+        #[cfg(any(target_os = "windows", target_os = "android"))]
+        let mut native_proxy = None;
+        #[cfg(any(target_os = "windows", target_os = "android"))]
+        let proxy = proxy.and_then(|host| {
+            host.map(|mut host| {
+                let bridge = tcode_remote::preview::NativeProxy::new(&host)?;
+                host.origin = bridge.origin().to_owned();
+                native_proxy = Some(bridge);
+                Ok(host)
+            })
+            .transpose()
+        });
         let creator = match proxy
             .as_ref()
             .map_err(Clone::clone)
@@ -161,6 +175,8 @@ impl BrowserLifecycle {
         Self {
             owner,
             proxy: proxy.ok().flatten(),
+            #[cfg(any(target_os = "windows", target_os = "android"))]
+            _native_proxy: native_proxy,
             slots: HashMap::new(),
             warm: HashSet::new(),
             active_identity: None,
@@ -711,7 +727,7 @@ mod platform {
     const SMOKE_CREATION_PAUSE: Duration = Duration::from_millis(50);
 
     pub(super) struct Adapter {
-        web_context: Rc<async_lock::Mutex<wry::WebContext>>,
+        web_context: Rc<async_lock::Mutex<(wry::WebContext, Option<tempfile::TempDir>)>>,
         next_creation_id: u64,
         smoke_creation_pause: bool,
     }
@@ -720,23 +736,25 @@ mod platform {
         pub(super) fn new(
             _proxy: Option<&tcode_client::pairing::PairedHost>,
         ) -> Result<Self, String> {
-            // WebView2 environments with different proxy arguments cannot share
-            // a user-data directory. Keep the existing local profile and isolate
-            // each remote machine's environment under the client-owned root.
-            let user_data_dir = crate::client_data_dir()
+            // Proxy arguments include an attachment-specific loopback port.
+            // WebView2 cannot share a user-data directory between environments
+            // with different arguments, even while an old creation is finishing.
+            let local_profile = crate::client_data_dir()
                 .ok_or_else(|| "client data directory was not set at startup".to_string())?
                 .join("WebView2");
-            let user_data_dir = if let Some(host) = _proxy {
-                user_data_dir.join(format!(
-                    "remote-{}",
-                    host.host_id
-                        .chars()
-                        .filter(|c| c.is_ascii_alphanumeric() || *c == '-')
-                        .collect::<String>()
-                ))
+            let temporary = if _proxy.is_some() {
+                Some(
+                    tempfile::Builder::new()
+                        .prefix("tcode-preview-")
+                        .tempdir()
+                        .map_err(|error| error.to_string())?,
+                )
             } else {
-                user_data_dir
+                None
             };
+            let user_data_dir = temporary
+                .as_ref()
+                .map_or(local_profile, |directory| directory.path().to_path_buf());
             std::fs::create_dir_all(&user_data_dir).map_err(|error| {
                 format!(
                     "failed to create WebView2 user-data directory {}: {error}",
@@ -748,9 +766,10 @@ mod platform {
                 user_data_dir.display()
             );
             Ok(Self {
-                web_context: Rc::new(async_lock::Mutex::new(wry::WebContext::new(Some(
-                    user_data_dir,
-                )))),
+                web_context: Rc::new(async_lock::Mutex::new((
+                    wry::WebContext::new(Some(user_data_dir)),
+                    temporary,
+                ))),
                 next_creation_id: 0,
                 // Preserve the harness's deterministic in-flight cancellation
                 // window without putting smoke routing state back in the panel.
@@ -826,7 +845,7 @@ mod platform {
             // discard unless the same window/panel/generation are still live.
             let parent = unsafe { raw_window_handle::WindowHandle::borrow_raw(parent) };
             let built = {
-                let builder = wry::WebViewBuilder::new_with_web_context(&mut web_context)
+                let builder = wry::WebViewBuilder::new_with_web_context(&mut web_context.0)
                     .with_devtools(true)
                     .with_url("about:blank");
                 let builder = match super::super::proxy::builder(builder, proxy.as_ref()) {

--- a/crates/ui/src/preview_panel/proxy.rs
+++ b/crates/ui/src/preview_panel/proxy.rs
@@ -19,9 +19,6 @@ pub(super) fn builder<'a>(
         use wry::WebViewBuilderExtWindows as _;
         let host = _host;
         let origin = url::Url::parse(&host.origin).map_err(|e| e.to_string())?;
-        if origin.scheme() != "http" {
-            return Err("remote desktop preview requires a direct HTTP machine origin".into());
-        }
         let builder = builder
             .with_incognito(true)
             .with_proxy_config(wry::ProxyConfig::Http(wry::ProxyEndpoint {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1171,3 +1171,16 @@ invalidate pending feedback and clear the current marker on the main queue.
 Cancellation is session-scoped: it cannot clear another session's newer marker.
 Closing or hiding the target window retires its marker even when its process
 stays open. See [Computer use](computer-use.md) for the native verification path.
+
+## Native paired Preview connection ownership
+
+Windows and Android retain native proxy routing and logical URLs, with an
+attachment-owned loopback bridge carrying their existing authenticated proxy
+bytes to the paired HTTP(S) entry. Native proxy authentication uses that local
+bridge origin; attachment teardown cancels its listener and connections.
+Windows remote WebView2 environments use temporary directories owned with the
+environment, since each attachment has different proxy arguments. Local Preview
+retains its existing directory.
+macOS retains its per-browser URL mappings and route lifetimes, now using the
+same HTTP(S) establishment owner. No new controls or transport selections are
+introduced. See [Remote Preview routing](remote.md#remote-preview-routing).

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -347,7 +347,7 @@ There is nothing new to configure in hosting settings.
 The listener admits at most 256 concurrent connections, including WebSockets.
 Proxy connection setup times out after 10 seconds, and traffic idle for 60 seconds
 is closed. Revoked proxy tokens are rechecked every five seconds; stopping hosting
-closes tunnels. Connection logs contain destination host/port and peer, never
+closes tunnels. Connection logs contain destination host/port, never
 request bodies or tokens. For headless diagnostics use `RUST_LOG=tcode_remote=info`.
 
 Android requires WebView's `PROXY_OVERRIDE` capability. It removes implicit
@@ -402,8 +402,12 @@ networking and its existing store.
 
 Windows uses WebView2's proxy configuration and proxy authentication callback, with implicit
 loopback bypass disabled. Unsupported proxy facilities fail closed; there is no
-unauthenticated IP allowlist or direct-network fallback. Desktop proxying currently
-requires a direct HTTP machine origin, typically over a trusted LAN or VPN.
+unauthenticated IP allowlist or direct-network fallback. Windows and Android use
+an attachment-owned loopback bridge to the paired HTTP(S) origin. It forwards
+the existing proxy bytes and authentication unchanged; closing the attachment
+cancels the listener and active connections. The native authentication callback
+uses this local proxy origin and the existing paired token. macOS keeps its
+per-browser URL mapping and uses the same native HTTP(S) connection establishment.
 HTTP reverse-proxy tunnels must support forward-proxy requests and CONNECT to
 carry preview traffic; ordinary website forwarding is insufficient.
 
@@ -627,3 +631,33 @@ accept it. A version-3 host ignores `key` and still works, but cannot deduplicat
 redelivery; a lost Ack can therefore repeat a mutation. Upgrade both ends for the
 bounded deduplication guarantee. Hosts older than version 3 remain incompatible
 with bounded history replay.
+
+### Native connection and imported stream ownership
+
+[`endpoint.rs`](../crates/remote/src/endpoint.rs) owns native origin validation,
+DNS, staggered address attempts and TCP/TLS establishment for pairing HTTP,
+the main WebSocket and paired Preview. WebSocket attempts race through hello,
+so a stalled handshake cannot hide a healthy address. NativeClientHost keeps
+pairing and attachment ownership; cancelling pairing drops its asynchronous
+request. HTTP requests retain bounded responses and a five-second request
+budget (60 seconds for password setup/login).
+
+[`RemoteServer::admit`](../crates/remote/src/server.rs) accepts a duplex async
+stream into the same HTTP/WS/CONNECT dispatch as the direct listener. Imported
+streams always have remote provenance; request headers, including
+X-Forwarded-For, cannot grant local administration. The direct listener derives
+local administration from its actual peer. Both entries share admission limits,
+authentication and shutdown. Stream adapters must implement write-half close
+through AsyncWrite while preserving reads; dispatch requires neither TCP nor
+clonable streams. Existing password initialization and pairing policy is unchanged.
+An external process forwarding to the ordinary loopback listener still appears
+local; it must use an explicitly remote admission integration to avoid that trust.
+
+This preparation adds no iroh transport. Integration still needs live endpoint
+ownership, dialing and admission adapters, route/identity and discovery decisions,
+and their cancellation/shutdown implementation. WebHost still uses browser fetch
+and WebSocket at the page origin; iroh WASM support does not make those browser
+interfaces consume a native Rust stream. Browser application transport integration
+and browser Preview delivery remain concrete platform work. iOS still has no
+embedded Preview backend. Native bridges do not publish arbitrary web pages or
+make ordinary HTTP reverse proxies support CONNECT.


### PR DESCRIPTION
## What changes

Prepares the existing unified remote entry for a later transport adapter; this does not implement iroh. Relates to #376.

Existing native HTTP/HTTPS pairing, the main WebSocket and paired Preview now share origin validation, DNS, staggered address attempts and TCP/TLS establishment. WebSocket address attempts still race through the full upgrade and hello, preserving terminal authentication failures and the existing handshake deadline. NativeClientHost pairing uses cancellable async I/O while synchronous CLI callers keep their existing interface. HTTPS /pair already used the same code-to-token flow; this adds no certificate-based pairing or new authentication mechanism.

RemoteServer admits generic duplex streams into the existing HTTP, WebSocket, NDJSON and CONNECT dispatch. Imported streams always have remote provenance and cannot gain local administration from loopback forwarding or X-Forwarded-For. Actual direct peers retain existing authorization and first-time password/pairing behavior. Both entries share connection limits and shutdown. Async split I/O preserves read/write concurrency and write-half close; native accept uses async-net's TCP close contract.

macOS keeps its existing Preview URL mapping and slot lifetime, now including HTTPS paired origins. Windows/Android use an attachment-owned raw loopback bridge to the same host entry, retaining native proxy authentication and bypass behavior. Windows' callback and Android's proxy configuration receive the bridge origin and existing token. Remote WebView2 environments use temporary directories owned with the environment because attachment proxy arguments differ; local Preview retains its existing directory.

## Why these seams

TCP versus TLS and direct versus imported streams are current variability. Establishment policy disappears from individual callers; protocol, auth, replay/recovery, URL mapping and host dispatch remain at their existing owners. The native bridge does not parse or recreate HTTP and adds no business protocol, global route table, persisted identity format, account, registry or iroh dependency.

## Regression evidence

Targeted production-entry tests passed during implementation, including existing HTTPS pairing compatibility, WS/Preview CONNECT over verified TLS, imported local-admin denial with a spoofed header, existing direct-local admin, token rejection, HTTP timeout/cancellation, native bridge authentication and reverse half-close, admission cancellation/shutdown, existing Preview mapping/lifetime, reconnect and replay tests.

All required local checks passed (exit 0) on `6b33382054f3629a7ad004ce6ef8c95549c27f87`:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo build --workspace --locked`
- `cargo test --workspace --locked`, including existing runtime `remote_liveness` stalled-address, rejected-token and stopped-host tests; existing ignored environment-dependent fixtures remain ignored.
- `RUSTFLAGS='-D warnings' IPHONEOS_DEPLOYMENT_TARGET=26.0 cargo check -p tcode-ios --target aarch64-apple-ios-sim --locked`
- `RUSTFLAGS='-D warnings' ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ANDROID_NDK_HOME=/opt/homebrew/share/android-commandlinetools/ndk/27.1.12297006 cargo ndk -t arm64-v8a check -p tcode-android --locked`
- `RUSTFLAGS='-D warnings' cargo check -p tcode-web --target wasm32-unknown-unknown --locked`
- `cargo-machete .` using direct binary version 0.9.2 (avoids the known wrapper invocation bug).

Local Cargo checks used `CARGO_TARGET_DIR=/Users/tryanks/RustroverProjects/tcode/target` and `CARGO_PROFILE_DEV_DEBUG=line-tables-only`. Build emitted the macOS linker large-unwind-table warning; Cargo also reports the existing `block` 0.1.6 future-compatibility notice. Neither is a Clippy/source warning failure.

Hosted CI run [34258034479](https://github.com/Tryanks/tcode/actions/runs/34258034479) passed on that same head: plan, dependency hygiene (8s), mobile/Web (2m32s), Linux (7m55s), macOS (10m2s), and Windows (10m33s). The existing-run watcher exited 0. All required checks passed. The lead inspected the final source and head-bound local evidence before merging.

## Remaining integration and validation scope

No iroh endpoint ownership, dialing/admission adapter, route/identity/discovery integration, relay deployment or browser transport integration is included. WebHost still uses browser fetch and WebSocket at the page origin. Iroh WASM support does not automatically adapt those interfaces or arbitrary Preview page networking. iOS still lacks embedded Preview.

Native Windows/Android UI acceptance was not run; local platform compilation passed as listed above. No provider prompt, user profile or original checkout was used for acceptance. Merged after lead source/evidence review and all required checks passed.
