### PR TITLE
Fix mobile safe-area themes and keyboard focus

### DIFF
--- a/crates/android/host/app/src/main/java/com/tryanks/tcode/GpuiActivity.java
+++ b/crates/android/host/app/src/main/java/com/tryanks/tcode/GpuiActivity.java
@@ -38,6 +38,7 @@ public final class GpuiActivity extends NativeActivity {
 
     public PreviewHost previewHost;
     private GpuiInputView inputView;
+    private Boolean appBackgroundDark;
     private boolean keyboardVisible;
     private boolean keyboardShowPending;
     private long cameraRequest;
@@ -124,8 +125,9 @@ public final class GpuiActivity extends NativeActivity {
     @SuppressWarnings("deprecation")
     private void configureEdgeToEdgeWindow() {
         Window window = getWindow();
-        boolean lightAppearance = (getResources().getConfiguration().uiMode
-                & Configuration.UI_MODE_NIGHT_MASK) != Configuration.UI_MODE_NIGHT_YES;
+        boolean lightAppearance = appBackgroundDark != null ? !appBackgroundDark
+                : (getResources().getConfiguration().uiMode
+                    & Configuration.UI_MODE_NIGHT_MASK) != Configuration.UI_MODE_NIGHT_YES;
         window.setStatusBarColor(Color.TRANSPARENT);
         window.setNavigationBarColor(Color.TRANSPARENT);
         if (Build.VERSION.SDK_INT >= 29) {
@@ -151,6 +153,17 @@ public final class GpuiActivity extends NativeActivity {
             }
             window.getDecorView().setSystemUiVisibility(visibility);
         }
+    }
+
+    /** GPUI resolves app preferences independently of Android's system appearance. */
+    public void gpuiSetAppBackgroundDark(boolean dark) {
+        appBackgroundDark = dark;
+        Configuration configuration = new Configuration(getResources().getConfiguration());
+        configuration.uiMode = (configuration.uiMode & ~Configuration.UI_MODE_NIGHT_MASK)
+                | (dark ? Configuration.UI_MODE_NIGHT_YES : Configuration.UI_MODE_NIGHT_NO);
+        int canvas = createConfigurationContext(configuration).getColor(R.color.canvas);
+        getWindow().setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(canvas));
+        configureEdgeToEdgeWindow();
     }
 
     @SuppressWarnings("deprecation")

--- a/crates/android/src/host.rs
+++ b/crates/android/src/host.rs
@@ -99,6 +99,23 @@ impl JavaBridge {
         })
     }
 
+    fn set_app_background_dark(&self, dark: bool) {
+        let object = self.object.clone();
+        self.app.run_on_java_main_thread(Box::new(move || {
+            if let Err(error) = object.with_env(|env, activity| {
+                env.call_method(
+                    activity,
+                    "gpuiSetAppBackgroundDark",
+                    "(Z)V",
+                    &[JValue::Bool(u8::from(dark))],
+                )?;
+                Ok(())
+            }) {
+                log::error!("Android system bar appearance JNI call failed: {error}");
+            }
+        }));
+    }
+
     fn start_camera(&self, request_id: u64) {
         let object = self.object.clone();
         self.app.run_on_java_main_thread(Box::new(move || {
@@ -123,6 +140,13 @@ pub(crate) fn native_host(
     cx: &mut App,
 ) -> Result<(NativeClientHost, Option<String>), String> {
     let bridge = JavaBridge::new(app)?;
+    let appearance_bridge = bridge.clone();
+    // Keep system chrome in sync with explicit app themes as well as system mode.
+    cx.observe_global::<tcode_ui::theme::Theme>(move |cx| {
+        appearance_bridge
+            .set_app_background_dark(cx.global::<tcode_ui::theme::Theme>().mode.is_dark());
+    })
+    .detach();
     let data_dir = bridge
         .object
         .call_string("gpuiDataDir")?

--- a/crates/ios/host/Sources/GPUIHostView.swift
+++ b/crates/ios/host/Sources/GPUIHostView.swift
@@ -115,6 +115,7 @@ final class GPUIHostViewController: UIViewController {
         view.backgroundColor = UIColor(named: "LaunchBackground")?.resolvedColor(
             with: UITraitCollection(userInterfaceStyle: dark ? .dark : .light)
         )
+        view.window?.backgroundColor = view.backgroundColor
         setNeedsStatusBarAppearanceUpdate()
     }
 

--- a/crates/ios/host/Sources/MobileHostServices.swift
+++ b/crates/ios/host/Sources/MobileHostServices.swift
@@ -326,3 +326,8 @@ func startHostBrowse(_ requestID: UInt64) {
         browse.start()
     }
 }
+
+@_cdecl("tcode_ios_host_set_app_background_dark")
+public func tcodeHostSetAppBackgroundDark(_ dark: UInt8) {
+    GPUIHostBridge.controller?.setAppBackgroundDark(dark != 0)
+}

--- a/crates/ios/src/entry.rs
+++ b/crates/ios/src/entry.rs
@@ -22,7 +22,7 @@ pub extern "C" fn tcode_ios_start() {
         let handle = Application::with_platform(gpui_ios::platform())
             .with_assets(tcode_ui::assets::Assets)
             .run_embedded(|cx| {
-                let (native_host, system_locale) = crate::host::native_host();
+                let (native_host, system_locale) = crate::host::native_host(cx);
                 let host: Rc<dyn ClientHost> = Rc::new(native_host);
                 tcode_ui::run_shell(
                     cx,

--- a/crates/ios/src/host.rs
+++ b/crates/ios/src/host.rs
@@ -21,13 +21,21 @@ thread_local! {
 static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 
 unsafe extern "C" {
+    fn tcode_ios_host_set_app_background_dark(dark: u8);
     fn tcode_ios_host_device_name(destination: *mut u8, capacity: usize) -> usize;
     fn tcode_ios_host_system_locale(destination: *mut u8, capacity: usize) -> usize;
     fn tcode_ios_host_start_camera_scan(request_id: u64);
     fn tcode_ios_host_browse(request_id: u64);
 }
 
-pub(crate) fn native_host() -> (NativeClientHost, Option<String>) {
+pub(crate) fn native_host(cx: &mut gpui::App) -> (NativeClientHost, Option<String>) {
+    // Native chrome follows the resolved app theme, which may differ from UIKit.
+    cx.observe_global::<tcode_ui::theme::Theme>(|cx| {
+        let dark = cx.global::<tcode_ui::theme::Theme>().mode.is_dark();
+        // SAFETY: GPUI's foreground observer runs on the UIKit main thread.
+        unsafe { tcode_ios_host_set_app_background_dark(u8::from(dark)) };
+    })
+    .detach();
     let device_name = read_native_string(|destination, capacity| {
         // SAFETY: Swift writes no more than `capacity` bytes during the call.
         unsafe { tcode_ios_host_device_name(destination, capacity) }

--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -437,14 +437,17 @@ impl ChatView {
             vec![
                 cx.observe_in(&workspace_store, window, |this, store, window, cx| {
                     this.sync_markdown_states(cx);
-                    // Opening the terminal (button, palette, or any other route
-                    // through the store) should hand keyboard focus to it, so the
-                    // user can type a command without clicking into the panel.
+                    // Desktop can type immediately after opening the terminal.
+                    // On software-keyboard devices this also runs during restore,
+                    // so wait for a tap on the grid before raising the keyboard.
                     let open = store.read(cx).panel_state().terminal_open;
                     if open && !this.terminal_was_open {
                         let drawer = this.terminal_drawer.clone();
                         window.defer(cx, move |window, cx| {
-                            gpui::Focusable::focus_handle(drawer.read(cx), cx).focus(window, cx);
+                            if !crate::window_seam::uses_soft_keyboard(cx) {
+                                gpui::Focusable::focus_handle(drawer.read(cx), cx)
+                                    .focus(window, cx);
+                            }
                         });
                     }
                     this.terminal_was_open = open;

--- a/crates/ui/src/composer/mod.rs
+++ b/crates/ui/src/composer/mod.rs
@@ -194,7 +194,7 @@ impl Composer {
     }
 
     pub fn focus(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if !self.compact {
+        if !self.compact && !crate::window_seam::uses_soft_keyboard(cx) {
             self.input.update(cx, |input, cx| input.focus(window, cx));
         }
     }
@@ -458,13 +458,14 @@ impl Composer {
         self.set_input_text(prefill, window, cx);
     }
 
-    /// Replace the composer text with `text`, caret at the end; focus in wide layout.
+    /// Replace the composer text with `text`, caret at the end.
+    /// Software-keyboard devices wait for an explicit tap to focus.
     fn set_input_text(&mut self, text: String, window: &mut Window, cx: &mut Context<Self>) {
         let cursor = text.len();
         self.input.update(cx, |state, cx| {
             state.set_value(text, window, cx);
             state.set_selected_range(cursor..cursor, cx);
-            if !self.compact {
+            if !self.compact && !crate::window_seam::uses_soft_keyboard(cx) {
                 state.focus(window, cx);
             }
         });
@@ -487,7 +488,7 @@ impl Composer {
         self.input.update(cx, |state, cx| {
             state.set_value(text, window, cx);
             state.set_selected_range(selection, cx);
-            if !self.compact {
+            if !self.compact && !crate::window_seam::uses_soft_keyboard(cx) {
                 state.focus(window, cx);
             }
         });

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -353,7 +353,7 @@ impl AppShell {
             // gets the same push or pop out of it.
             cx.observe_in(&window_state, window, |this, _, window, cx| {
                 if this.mounted != this.window_state.read(cx).history() {
-                    this.blur_compact_navigation(window, cx);
+                    this.blur_navigation(window, cx);
                 }
                 this.sync_nav(NavMotion::Animated, cx);
                 this.schedule_navigation_save(cx);
@@ -595,7 +595,7 @@ impl AppShell {
             log::error!("this client cannot reach {target:?}");
             return;
         }
-        self.blur_compact_navigation(window, cx);
+        self.blur_navigation(window, cx);
         self.attach(target, window, cx);
     }
 
@@ -660,7 +660,7 @@ impl AppShell {
                     && attachment.observed_session_id != selected
                 {
                     attachment.observed_session_id = selected.clone();
-                    this.blur_compact_navigation(window, cx);
+                    this.blur_navigation(window, cx);
                     if selected.is_some() {
                         this.window_state
                             .update(cx, |state, cx| state.leave_route_for_chat(cx));
@@ -895,8 +895,8 @@ impl AppShell {
         self.mounted.extend(pushed);
     }
 
-    fn blur_compact_navigation(&self, window: &mut Window, cx: &mut Context<Self>) {
-        if self.compact(cx) {
+    fn blur_navigation(&self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.compact(cx) || crate::window_seam::uses_soft_keyboard(cx) {
             window.blur(cx);
         }
     }
@@ -918,7 +918,7 @@ impl AppShell {
         {
             self.pending_navigation_restore = None;
         }
-        self.blur_compact_navigation(window, cx);
+        self.blur_navigation(window, cx);
         if self.compact(cx) {
             self.go(Destination::Thread, cx);
         } else {
@@ -1817,7 +1817,7 @@ impl AppShell {
         }
         div()
             .size_full()
-            .bg(crate::material::content_surface(cx))
+            .bg(crate::material::opaque_canvas(cx))
             .pt(seam.top)
             .pb(seam.bottom)
             .pl(seam.left)
@@ -2470,6 +2470,21 @@ mod tests {
         Rc<ReturningClient>,
         &'a mut VisualTestContext,
     ) {
+        mount_restored_at_width(cx, history, machine_exists, 393., "plan")
+    }
+
+    fn mount_restored_at_width<'a>(
+        cx: &'a mut TestAppContext,
+        history: &[&str],
+        machine_exists: bool,
+        width: f32,
+        panel: &str,
+    ) -> (
+        Entity<AppShell>,
+        MountedShell,
+        Rc<ReturningClient>,
+        &'a mut VisualTestContext,
+    ) {
         cx.update(crate::theme::init);
         let (to_host, outgoing) = async_channel::unbounded();
         let (incoming, from_host) = async_channel::unbounded();
@@ -2492,7 +2507,7 @@ mod tests {
                     "history": history,
                     "host_id": "last-host",
                     "session_id": "thread-a",
-                    "panel": "plan"
+                    "panel": panel
                 })),
                 ..Default::default()
             }),
@@ -2501,7 +2516,7 @@ mod tests {
             outbox: None,
         });
         let setup_client = client.clone();
-        let window = cx.open_window(size(px(393.), px(852.)), move |window, cx| {
+        let window = cx.open_window(size(px(width), px(852.)), move |window, cx| {
             let state = cx.new(|_| WindowState::new(false));
             AppShell::new(
                 state,
@@ -3046,6 +3061,147 @@ mod tests {
         cx.update(|window, _| assert!(focus.is_focused(window)));
     }
 
+    #[gpui::test]
+    fn software_keyboard_restored_terminal_does_not_raise_keyboard(cx: &mut TestAppContext) {
+        cx.update(|cx| crate::window_seam::override_soft_keyboard_for_test(cx, true));
+        let (shell, host, _, cx) = mount_restored_at_width(
+            cx,
+            &["hosts", "threads", "thread", "panel"],
+            true,
+            1024.,
+            "terminal",
+        );
+        restore_index(&shell, &host, true, cx);
+        let mut status = session_status("thread-a", std::path::Path::new("/project"));
+        status.terminal_open = true;
+        host.incoming
+            .try_send(
+                encode_line(&HostMessage::Event(EventEnvelope {
+                    request_id: None,
+                    topic: Topic::SessionStatus {
+                        session_id: "thread-a".into(),
+                    },
+                    event: ServerEvent::SessionStatusReplaced(status),
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+        await_restore_update(&shell, cx, |store| store.chat_active_session().is_some());
+        host.incoming
+            .try_send(
+                encode_line(&HostMessage::Event(EventEnvelope {
+                    request_id: None,
+                    topic: Topic::Settings,
+                    event: ServerEvent::SettingsSnapshot(Default::default()),
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+        host.incoming
+            .try_send(
+                encode_line(&HostMessage::Event(EventEnvelope {
+                    request_id: None,
+                    topic: Topic::SessionEvents {
+                        session_id: "thread-a".into(),
+                    },
+                    event: ServerEvent::SessionSnapshot {
+                        total: 0,
+                        total_turns: 0,
+                        truncated: false,
+                        from: 0,
+                        records: vec![],
+                    },
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+        await_restore_update(&shell, cx, |store| !store.chat_loading());
+        assert!(store_of(&shell, cx).read_with(cx, |store, _| store.panel_state().terminal_open));
+        cx.executor().advance_clock(Duration::from_secs(1));
+        draw(cx);
+        cx.update(|window, cx| {
+            assert!(
+                window.focused(cx).is_none(),
+                "a restored terminal must not steal focus after navigation has blurred"
+            )
+        });
+    }
+
+    #[gpui::test]
+    fn software_keyboard_wide_cold_restore_stays_unfocused(cx: &mut TestAppContext) {
+        cx.update(|cx| crate::window_seam::override_soft_keyboard_for_test(cx, true));
+        let (shell, host, _, cx) =
+            mount_restored_at_width(cx, &["hosts", "threads", "thread"], true, 1024., "plan");
+        restore_index(&shell, &host, true, cx);
+        restore_status(&shell, &host, cx);
+        let focus = shell.read_with(cx, |shell, cx| {
+            shell
+                .attachment
+                .as_ref()
+                .unwrap()
+                .chat
+                .read(cx)
+                .composer()
+                .read(cx)
+                .input_focus_handle(cx)
+        });
+        for width in [1024., 393., 1024.] {
+            resize(cx, width);
+            cx.update(|window, _| assert!(!focus.is_focused(window)));
+        }
+    }
+
+    #[gpui::test]
+    fn software_keyboard_navigation_stays_unfocused_at_both_widths(cx: &mut TestAppContext) {
+        cx.update(|cx| crate::window_seam::override_soft_keyboard_for_test(cx, true));
+        let (shell, _host, cx) = mount(cx);
+        let store = store_of(&shell, cx);
+        let focus = shell.read_with(cx, |shell, cx| {
+            shell
+                .attachment
+                .as_ref()
+                .unwrap()
+                .chat
+                .read(cx)
+                .composer()
+                .read(cx)
+                .input_focus_handle(cx)
+        });
+        for width in [1024., 393., 1024.] {
+            resize(cx, width);
+            for id in ["thread-1", "thread-2"] {
+                cx.update(|window, cx| {
+                    focus.focus(window, cx);
+                    store.update(cx, |store, _| store.select_session(id.into()));
+                    shell
+                        .read(cx)
+                        .window_state()
+                        .update(cx, |_, cx| cx.emit(OpenThread));
+                });
+                draw(cx);
+                cx.update(|window, _| {
+                    assert!(
+                        !focus.is_focused(window),
+                        "navigation must dismiss the software keyboard at width {width}"
+                    )
+                });
+            }
+        }
+        // A user who is editing keeps focus through reflows and ordinary frames.
+        cx.update(|window, cx| focus.focus(window, cx));
+        for width in [393., 1024., 393.] {
+            resize(cx, width);
+            draw(cx);
+            cx.update(|window, _| assert!(focus.is_focused(window)));
+        }
+    }
+
+    #[gpui::test]
+    fn software_keyboard_wide_project_choice_opens_an_unfocused_draft(cx: &mut TestAppContext) {
+        cx.update(|cx| crate::window_seam::override_soft_keyboard_for_test(cx, true));
+        new_thread_from_projects(cx, 2, false);
+    }
+
     fn new_thread_from_projects(cx: &mut TestAppContext, project_count: usize, compact: bool) {
         use tcode_core::project::Project;
         use tcode_runtime::pipe::{HostServices, spawn_host};
@@ -3154,7 +3310,29 @@ mod tests {
                 );
                 std::thread::sleep(std::time::Duration::from_millis(5));
             }
-            cx.update(|window, _| assert_eq!(focus.is_focused(window), !compact));
+            cx.update(|window, cx| {
+                assert_eq!(
+                    focus.is_focused(window),
+                    !compact && !crate::window_seam::uses_soft_keyboard(cx)
+                )
+            });
+            if cx.update(|_, cx| crate::window_seam::uses_soft_keyboard(cx)) {
+                let card = cx.debug_bounds("composer-card").expect("draft composer");
+                cx.simulate_click(
+                    gpui::point(card.center().x, card.top() + px(24.)),
+                    gpui::Modifiers::default(),
+                );
+                draw(cx);
+                cx.update(|window, _| {
+                    assert!(focus.is_focused(window), "explicit composer tap focuses")
+                });
+                for width in [393., 1024.] {
+                    resize(cx, width);
+                    cx.update(|window, _| {
+                        assert!(focus.is_focused(window), "rotation preserves editing focus")
+                    });
+                }
+            }
             let selected = store.read_with(cx, |store, _| store.active_session_id());
             assert!(selected.is_some());
             if reopen {

--- a/crates/ui/src/terminal_key_bar.rs
+++ b/crates/ui/src/terminal_key_bar.rs
@@ -397,7 +397,7 @@ impl Render for TerminalKeyBar {
 }
 
 pub(crate) fn should_show_terminal_key_bar(terminal_focused: bool, cx: &App) -> bool {
-    crate::window_seam::soft_keyboard_for_key_bar(cx) && terminal_focused
+    crate::window_seam::uses_soft_keyboard(cx) && terminal_focused
 }
 
 #[cfg(test)]

--- a/crates/ui/src/window_seam.rs
+++ b/crates/ui/src/window_seam.rs
@@ -144,7 +144,7 @@ pub const fn soft_keyboard() -> bool {
     cfg!(any(target_os = "ios", target_os = "android"))
 }
 
-pub(crate) fn soft_keyboard_for_key_bar(_cx: &App) -> bool {
+pub(crate) fn uses_soft_keyboard(_cx: &App) -> bool {
     #[cfg(test)]
     if let Some(override_) = _cx.try_global::<SoftKeyboardOverride>() {
         return override_.0;

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -365,10 +365,18 @@ indicator or a software keyboard can cover part of it. Those edges belong to the
 There is one safe content rectangle, shared by pages, the palette, dialogs and
 toasts. Bottom avoidance is **max(safe area, keyboard)**, never their sum — a
 keyboard that already covers the home indicator does not need it counted twice.
-Backgrounds paint edge to edge; only interactive content is constrained, and
+Backgrounds paint edge to edge: safe-area bands use the opaque T0 theme canvas,
+not the near-white T1 reading surface. Only interactive content is constrained, and
 only once. The browser canvas is already resized around its on-screen keyboard,
 so the client adds no inset of its own there and takes its size from the actual
 canvas.
+
+On iOS and Android the native host observes the resolved application theme,
+including an explicit light/dark choice that differs from the system. Status-bar
+icons, Android navigation controls, and the native fallback canvas follow that
+choice at startup and during live theme changes. System bars remain transparent
+over the shared shell's edge-to-edge background; native hosts do not add content
+padding or resize it again for the keyboard.
 
 Insets change without a timer: the platform schedules a frame when they move, so
 the layout follows the keyboard immediately.
@@ -1070,11 +1078,16 @@ dispatch response.
 
 The workspace does not sit on a blank page. When no conversation is open — at
 launch, or because the thread on screen was archived or deleted — it opens the
-new-thread draft of the project the user last interacted with. In wide layout
-the composer is focused and ready. Compact conversations start unfocused,
-including restored conversations and drafts; only tapping the composer focuses
-it. Compact navigation away from or between conversations blurs the focused
-element and dismisses the software keyboard. "Last interacted" is set by user navigation only (opening a thread,
+new-thread draft of the project the user last interacted with. With a hardware
+keyboard in wide layout the composer is focused and ready. Compact conversations
+and software-keyboard devices at every width start unfocused, including restored
+conversations and drafts; only tapping the composer focuses it. Navigation away
+from or between conversations on these devices blurs the focused element and
+dismisses the software keyboard. Rotation or resizing alone neither focuses nor
+blurs the composer; active editing keeps its focus. Composer text prefill does
+not open the software keyboard. Restoring an open terminal also waits for an
+explicit tap on its grid before opening the keyboard. "Last interacted" is set by user navigation only
+(opening a thread,
 starting a draft); background model activity and archive timestamps never move
 it, and it is persisted, so a launch lands where the user left off. A remembered
 project that no longer exists falls back to the first project in the sidebar.


### PR DESCRIPTION
Mobile safe-area bands used the near-white T1 reading surface instead of the T0 window canvas. Use the existing opaque canvas for those bands and synchronize iOS/Android system-bar contrast and native fallback backgrounds with the resolved app theme, including explicit themes opposite to the OS setting. Content insets still have one owner and retain `max(safe area, IME)`.

Software-keyboard devices now wait for a tap before focusing the composer at either width. Navigation dismisses focus, while rotation preserves active editing. Restoring an open terminal no longer steals focus through a deferred callback. This extends the existing window/input capability policy and updates `docs/DESIGN.md`.

Validation:
- The reporting user installed the signed ARM64 debug APK on their physical tablet and confirmed the behavior is correct.
- iPad iOS 26.4 and Android API 35 simulator checks covered themes, wide/narrow layouts, live theme changes and actual software-keyboard display after a tap, using isolated profiles. Screenshot pixel regression failed before the canvas fix and passed afterward: light safe-area RGB changed from `(252,253,251)` to T0 `(242,244,247)`; dark edges match `(21,23,28)`.
- Focus regressions were demonstrated red/green through production shell paths. They cover wide mobile drafts, navigation, cold restore, deferred terminal focus, explicit taps and preserving editing focus during reflow. Final UI validation passed 396 unit tests, 1 integration test and Clippy.
- Pre-rebase workspace formatting, Clippy, build and tests passed; the full-workspace test run preceded the final terminal-focus patch. Final local iOS, Android and Web checks passed with `RUSTFLAGS='-D warnings'`; both native packages built successfully. `cargo-machete .` 0.9.2 passed after the local `cargo machete` entry point misinterpreted its subcommand as a directory. macOS debug linking reported a large unwind-table warning and dependency `block` reported future incompatibility.
- Rebased onto current main without conflicts; `git range-diff` confirms the accepted patch is unchanged and formatting passes after rebase. Final-head CI passed all six jobs (Plan CI scope, Dependency hygiene, macOS arm64, Linux x64, Windows x64, and Mobile and web checks) on `f9a4e5e4765461f1b57a73851ec3a05493934c59`: [run 34331985107, attempt 2](https://github.com/Tryanks/tcode/actions/runs/34331985107). Windows initially failed the existing `pipelined_request_and_chunk_trailers_never_reach_origin` proxy test with ConnectionReset (10054); one diagnostic rerun without code changes passed that test and all 11 proxy integration tests. The reset root cause remains unproven; this PR does not claim to fix a network race.

Other OEMs, older Android APIs and the complete real-device restored-terminal matrix were not exercised. APKs and local screenshot/probe artifacts are not included in this PR.
