### PR TITLE
Switch gpui-base to crates.io 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,8 +3196,9 @@ dependencies = [
 
 [[package]]
 name = "gpui-base"
-version = "0.6.0"
-source = "git+https://github.com/longbridge/gpui-kit?rev=9d9bd9bfa9b4c3af25475078458b3e3c7abd2981#9d9bd9bfa9b4c3af25475078458b3e3c7abd2981"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d45dcaaeac889bf1e7757db1beb26c9043c8ea3156651facc11c6be56bb6722"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -61,7 +61,7 @@ tcode-core = { path = "../core", default-features = false }
 tcode-protocol = { path = "../protocol", default-features = false }
 qrcode = { version = "0.14", default-features = false }
 gpui = { package = "gpui-pre", version = "0.3.1" }
-gpui-base = { git = "https://github.com/longbridge/gpui-kit", rev = "9d9bd9bfa9b4c3af25475078458b3e3c7abd2981" } # 0.6.0 on crates.io pulls an unused gpui-pre-platform that breaks iOS/Android; switch back once 0.6.1 ships
+gpui-base = "0.6.1"
 gpui-component-assets = { package = "gpui-kit-assets", version = "0.6.0" }
 gpui-component-macros = "0.6.0"
 image = { version = "0.25.10", default-features = false, features = ["png", "jpeg", "gif", "webp", "bmp", "tiff"] }


### PR DESCRIPTION
Replaces the github rev pin with `gpui-base = "0.6.1"`. Upstream 0.6.1 no longer pulls `gpui-pre-platform`, which was the reason for the pin.

Cargo.lock only changes the gpui-base entry; `cargo check -p tcode-ui` passes.