### PR TITLE
Enable default wasm32 features in wasm-opt release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -418,6 +418,7 @@ jobs:
           wasm-bindgen --target web --out-dir crates/web/dist --out-name tcode_web \
             target/wasm32-unknown-unknown/release/tcode_web.wasm
           wasm-opt -Oz --enable-bulk-memory --enable-nontrapping-float-to-int \
+            --enable-sign-ext --enable-mutable-globals --enable-reference-types --enable-multivalue \
             crates/web/dist/tcode_web_bg.wasm \
             -o crates/web/dist/tcode_web_bg.optimized.wasm
           mv crates/web/dist/tcode_web_bg.optimized.wasm crates/web/dist/tcode_web_bg.wasm


### PR DESCRIPTION
Stable Rust now emits sign-extension ops for wasm32 by default; wasm-opt rejected the v0.1.51 web bundle with `all used features should be allowed` on `i32.extend16_s`. Enable sign-ext plus the other current default wasm32 features.