### PR TITLE
Copy auth.mjs into the web dist bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -422,7 +422,7 @@ jobs:
             crates/web/dist/tcode_web_bg.wasm \
             -o crates/web/dist/tcode_web_bg.optimized.wasm
           mv crates/web/dist/tcode_web_bg.optimized.wasm crates/web/dist/tcode_web_bg.wasm
-          cp crates/web/static/index.html crates/web/dist/index.html
+          cp crates/web/static/index.html crates/web/static/auth.mjs crates/web/dist/
           ls -lh crates/web/dist
 
       - name: Upload browser bundle

--- a/crates/web/build.sh
+++ b/crates/web/build.sh
@@ -19,6 +19,6 @@ if command -v wasm-opt >/dev/null 2>&1; then
 else
   echo 'Notice: wasm-opt unavailable; keeping the unoptimized wasm-bindgen output.' >&2
 fi
-cp "${SCRIPT_DIR}/static/index.html" "${DIST_DIR}/index.html"
+cp "${SCRIPT_DIR}/static/index.html" "${SCRIPT_DIR}/static/auth.mjs" "${DIST_DIR}/"
 python3 "${SCRIPT_DIR}/build_auth.py"
 printf 'Built browser bundle: %s\n' "${DIST_DIR}"


### PR DESCRIPTION
Headless Linux release builds failed on v0.1.51: `include_bytes!("../../web/dist/auth.mjs")` in tcode-headless, but the release workflow and build.sh only copied index.html into dist.