### PR TITLE
Clip overlong model names in the compact model picker

### DIFF
--- a/crates/ui/src/composer/components/pickers.rs
+++ b/crates/ui/src/composer/components/pickers.rs
@@ -201,7 +201,9 @@ impl Composer {
 
         let trigger = Button::new("model-picker")
             .debug_selector(|| "model-picker".into())
-            .when(self.compact, |button| button.max_w(px(160.)).min_w_0())
+            .when(self.compact, |button| {
+                button.max_w(px(160.)).min_w_0().overflow_hidden()
+            })
             .ghost()
             .compact()
             .h(px(28.))
@@ -210,6 +212,7 @@ impl Composer {
             .rounded(crate::material::radius_input())
             .child(
                 h_flex()
+                    .when(self.compact, |el| el.min_w_0().overflow_hidden())
                     .gap_1p5()
                     .items_center()
                     .text_size(px(13.))


### PR DESCRIPTION
On mobile (compact composer), a long model name overflowed the model-picker trigger and overlapped the traits/effort chip beside it: the trigger had `max_w(160px)` but never clipped overflow, and its inner `h_flex` lacked `min_w_0`, so the label's `.truncate()` had no constrained width to work against.

This mirrors the sibling `traits-chip` trigger's pattern — `overflow_hidden()` on the compact button and `min_w_0().overflow_hidden()` on the inner `h_flex` — so the label truncates inside the 160px cap instead of spilling. Compact-only; the desktop layout is unchanged.