### PR TITLE
Remove the DEV channel badge from the sidebar and wordmark

### DIFF
--- a/crates/ui/src/material.rs
+++ b/crates/ui/src/material.rs
@@ -201,7 +201,7 @@ pub fn plain_list(rows: Vec<gpui::AnyElement>, cx: &App) -> Div {
     list
 }
 
-/// Shared wordmark and DEV channel badge.
+/// Shared wordmark.
 pub fn brand_wordmark(cx: &App) -> impl IntoElement {
     gpui_base::h_flex()
         .items_center()
@@ -212,17 +212,6 @@ pub fn brand_wordmark(cx: &App) -> impl IntoElement {
                 .font_bold()
                 .text_color(cx.theme().sidebar_foreground)
                 .child(crate::tr!("app.name")),
-        )
-        .child(
-            div()
-                .px_1()
-                .py(px(1.))
-                .rounded_sm()
-                .bg(cx.theme().muted)
-                .text_color(cx.theme().muted_foreground)
-                .text_size(px(9.))
-                .font_semibold()
-                .child("DEV"),
         )
 }
 

--- a/crates/ui/src/material.rs
+++ b/crates/ui/src/material.rs
@@ -203,16 +203,13 @@ pub fn plain_list(rows: Vec<gpui::AnyElement>, cx: &App) -> Div {
 
 /// Shared wordmark.
 pub fn brand_wordmark(cx: &App) -> impl IntoElement {
-    gpui_base::h_flex()
-        .items_center()
-        .gap_2()
-        .child(
-            div()
-                .text_size(px(14.))
-                .font_bold()
-                .text_color(cx.theme().sidebar_foreground)
-                .child(crate::tr!("app.name")),
-        )
+    gpui_base::h_flex().items_center().gap_2().child(
+        div()
+            .text_size(px(14.))
+            .font_bold()
+            .text_color(cx.theme().sidebar_foreground)
+            .child(crate::tr!("app.name")),
+    )
 }
 
 /// The scrim behind a bottom sheet, at the `overlay` token's values

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -1183,17 +1183,6 @@ impl SessionsSidebar {
                 .text_color(cx.theme().sidebar_foreground)
                 .child(crate::tr!("app.name")),
         )
-        .child(
-            div()
-                .px_1()
-                .py(px(1.))
-                .rounded_sm()
-                .bg(cx.theme().muted)
-                .text_color(cx.theme().muted_foreground)
-                .text_size(px(9.))
-                .font_semibold()
-                .child("DEV"),
-        )
         // The collapse toggle lives in the chat header (`crate::chat`), not
         // here: collapsing takes the sidebar to zero width, so a control that
         // rode the sidebar would take itself off screen.


### PR DESCRIPTION
Drops the small DEV badge next to the app name in the sidebar app row and in the shared brand wordmark (settings page header).