### PR TITLE
Fix theme text inheritance for overlays

### DIFF
--- a/crates/ui/src/overlay/mod.rs
+++ b/crates/ui/src/overlay/mod.rs
@@ -144,6 +144,8 @@ impl Render for OverlayHost {
             .relative()
             .size_full()
             .bg(cx.theme().background)
+            .text_color(cx.theme().foreground)
+            .font_family(cx.theme().font_family.clone())
             .child(self.view.clone())
             .when(!dialogs.is_empty(), |root| {
                 root.child(

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -111,6 +111,11 @@ Separate reading regions with space and material contrast; use faded or inset
 hairlines where a rule is needed. Hover and focus must not change geometry.
 Diff additions and deletions use the success and danger colors consistently.
 
+The window root supplies the active theme's foreground color and UI font to
+the shell, dialogs and toasts. Overlay text inherits these defaults, including
+when switching between light and dark mode; explicit semantic colors and
+monospace text override them where needed.
+
 ## Window material
 
 The persistent main window uses native backdrop material: macOS keeps its


### PR DESCRIPTION
Dialogs and notifications could use the wrong text color or font, making them look different from the rest of the app. This was especially noticeable when switching between light and dark themes.

They now get the current theme’s text color and font from the shared part of the interface that displays them. Text with its own color or font, such as status messages and code, keeps that styling. The design guide has been updated.

No automated test was added because a test of the assigned styles would not show whether the text actually looks right.

| Before | After |
| --- | --- |
| <img width="1100" height="760" alt="image" src="https://github.com/user-attachments/assets/ac491e91-5c1c-40b0-8bab-43de5db39579" />|<img width="1100" height="760" alt="image" src="https://github.com/user-attachments/assets/67e3c569-f172-4b0c-9e0c-c7d44644eda9" />|

Implemented with GPT-6 Astra in Tcode