### PR TITLE
Fix header controls starting window drags

### DIFF
--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -1807,6 +1807,8 @@ impl ChatView {
         // collapsed sidebar occupies no width at all (`crate::shell`), so a
         // control mounted inside it would have nowhere to be.
         let sidebar_toggle = Button::new("toggle-sidebar")
+            .debug_selector(|| "toggle-sidebar".into())
+            .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| cx.stop_propagation())
             .ghost()
             .small()
             .compact()
@@ -1884,6 +1886,9 @@ impl ChatView {
                             .gap_1()
                             .child(
                                 Button::new("panel-layout")
+                                    .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| {
+                                        cx.stop_propagation()
+                                    })
                                     .ghost()
                                     .small()
                                     .compact()
@@ -1897,6 +1902,9 @@ impl ChatView {
                             )
                             .child(
                                 Button::new("plan-panel")
+                                    .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| {
+                                        cx.stop_propagation()
+                                    })
                                     .ghost()
                                     .small()
                                     .compact()
@@ -1913,6 +1921,9 @@ impl ChatView {
                             // where there is no embedded browser to drive.
                             .child(
                                 Button::new("preview-panel")
+                                    .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| {
+                                        cx.stop_propagation()
+                                    })
                                     .ghost()
                                     .small()
                                     .compact()
@@ -1926,6 +1937,9 @@ impl ChatView {
                             )
                             .child(
                                 Button::new("diff-panel")
+                                    .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| {
+                                        cx.stop_propagation()
+                                    })
                                     .ghost()
                                     .small()
                                     .compact()
@@ -2069,6 +2083,7 @@ impl ChatView {
                 .border_color(border)
                 .overflow_hidden()
                 .child(main)
+                .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| cx.stop_propagation())
                 .child(div().w_px().h(px(16.)).bg(border))
                 .child(chevron)
                 .into_any_element(),
@@ -2201,6 +2216,7 @@ impl ChatView {
         h_flex()
             .flex_none()
             .h(px(28.))
+            .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| cx.stop_propagation())
             .items_center()
             .rounded(px(8.))
             .border_1()

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -1239,6 +1239,7 @@ fn nav_bar(
 /// Back control labelled with the parent destination's short fixed label.
 fn back_button(id: &'static str, parent: SharedString, cx: &App) -> gpui::Stateful<Div> {
     crate::material::accessible_clickable(h_flex(), id, Role::Button, parent.clone(), cx)
+        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
         .flex_none()
         .h(px(44.))
         .pl(px(4.))
@@ -1276,6 +1277,7 @@ fn nav_icon_button(
 ) -> gpui::Stateful<Div> {
     let theme = cx.theme();
     crate::material::accessible_clickable(div(), id, Role::Button, aria_label.into(), cx)
+        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
         .size(px(44.))
         .flex_none()
         .flex()
@@ -3361,6 +3363,61 @@ mod tests {
     #[gpui::test]
     fn wide_project_choice_opens_a_focused_draft(cx: &mut TestAppContext) {
         new_thread_from_projects(cx, 2, false);
+    }
+
+    #[gpui::test]
+    fn header_controls_activate_after_pointer_jitter_without_dragging(cx: &mut TestAppContext) {
+        cx.update(crate::theme::init);
+        let (shell, host, cx) = mount(cx);
+        for (topic, event) in [
+            (
+                Topic::Index,
+                ServerEvent::IndexSnapshot(IndexSnapshot {
+                    title_generating: Default::default(),
+                    activity: Default::default(),
+                    sessions: Vec::new(),
+                    projects: Vec::new(),
+                }),
+            ),
+            (
+                Topic::Settings,
+                ServerEvent::SettingsSnapshot(Default::default()),
+            ),
+        ] {
+            host.incoming
+                .try_send(
+                    encode_line(&HostMessage::Event(EventEnvelope {
+                        request_id: None,
+                        topic,
+                        event,
+                    }))
+                    .unwrap(),
+                )
+                .unwrap();
+        }
+        await_restore_update(&shell, cx, |store| !store.chat_loading());
+        let state = shell.read_with(cx, |shell, _| shell.window_state());
+        for (width, selector) in [(1024., "toggle-sidebar"), (393., "compact-search")] {
+            resize(cx, width);
+            cx.executor().advance_clock(Duration::from_millis(250));
+            draw(cx);
+            let start = cx
+                .debug_bounds(selector)
+                .unwrap_or_else(|| panic!("missing {selector}"))
+                .center();
+            let end = start + gpui::point(px(1.), px(1.));
+            cx.simulate_mouse_down(start, MouseButton::Left, gpui::Modifiers::default());
+            // TestWindow rejects native window moves, so a leaked press fails here.
+            cx.simulate_mouse_move(end, Some(MouseButton::Left), gpui::Modifiers::default());
+            cx.simulate_mouse_up(end, MouseButton::Left, gpui::Modifiers::default());
+            state.read_with(cx, |state, _| {
+                if width >= 900. {
+                    assert!(state.sidebar_collapsed);
+                } else {
+                    assert!(state.palette_open);
+                }
+            });
+        }
     }
 
     fn mount(cx: &mut TestAppContext) -> (Entity<AppShell>, MountedShell, &mut VisualTestContext) {

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -3373,7 +3373,6 @@ mod tests {
             (
                 Topic::Index,
                 ServerEvent::IndexSnapshot(IndexSnapshot {
-                    title_generating: Default::default(),
                     activity: Default::default(),
                     sessions: Vec::new(),
                     projects: Vec::new(),

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -151,7 +151,9 @@ so startup never exposes a default white/black window or decorative backdrop.
   edge reveals the sidebar as an **overlay** (see Sidebar below).
 - Window top is seamless: no app titlebar — the sidebar's first row (traffic
   lights inset 74px, wordmark + channel pill) and the chat header (52px) form
-  the top strip; both are window-drag areas.
+  the top strip; both are window-drag areas. Header controls, including compact
+  navigation and split buttons, consume left mouse presses so clicking them
+  with slight pointer movement does not start a window drag.
 - Chat content column: max-width 720px, centered, ≥24px horizontal padding
   (must reflow, never clip, when the diff panel narrows the chat region).
 - Composer: floating opaque card with the shared composer radius, a hairline


### PR DESCRIPTION
Clicking a header button could drag the window if the mouse moved slightly during the click. This could also stop the button from doing anything. Header buttons now keep those clicks from starting a window drag.

This covers the sidebar, Git, Open, terminal, plan, preview, and diff controls, along with the back and icon buttons in narrow windows. The design guide has been updated.

The new test presses the sidebar button in a wide window, moves the mouse by one pixel, and releases it. It checks that the sidebar closes.

Implemented with GPT-6 Astra in Tcode