### PR TITLE
Fix Android autocomplete text replacement

### DIFF
--- a/crates/android/host/app/build.gradle.kts
+++ b/crates/android/host/app/build.gradle.kts
@@ -10,6 +10,7 @@ android {
         targetSdk = 36
         versionCode = 1
         versionName = System.getenv("TCODE_BUILD_VERSION") ?: "0.1.0"
+        testInstrumentationRunner = "android.test.InstrumentationTestRunner"
         ndk { abiFilters += "arm64-v8a" }
     }
 
@@ -30,6 +31,8 @@ android {
 }
 
 dependencies {
+    // The device provides the platform test runner; only its compile stubs are needed here.
+    androidTestCompileOnly(files("${android.sdkDirectory}/platforms/android-${android.compileSdk}/optional/android.test.base.jar"))
     implementation("androidx.webkit:webkit:1.12.1")
     implementation("androidx.core:core:1.15.0")
     implementation("androidx.core:core-splashscreen:1.0.1")

--- a/crates/android/host/app/src/androidTest/AndroidManifest.xml
+++ b/crates/android/host/app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <uses-library android:name="android.test.runner" />
+        <uses-library android:name="android.test.base" android:required="false" />
+    </application>
+</manifest>

--- a/crates/android/host/app/src/androidTest/java/com/tryanks/tcode/GpuiInputConnectionTest.java
+++ b/crates/android/host/app/src/androidTest/java/com/tryanks/tcode/GpuiInputConnectionTest.java
@@ -1,0 +1,58 @@
+package com.tryanks.tcode;
+
+import android.test.AndroidTestCase;
+import android.text.Selection;
+import android.text.SpannableStringBuilder;
+import android.view.View;
+import java.util.ArrayList;
+
+/** Exercises the production connection against Android's real Editable/InputConnection code. */
+@SuppressWarnings("deprecation")
+public final class GpuiInputConnectionTest extends AndroidTestCase {
+    public void testAutocompletePublishesTheCompleteReplacementOnce() {
+        for (boolean composing : new boolean[] {false, true}) {
+            SpannableStringBuilder text = new SpannableStringBuilder("an exmple here");
+            Selection.setSelection(text, 9);
+            ArrayList<GpuiInputConnection.State> sent = new ArrayList<>();
+            GpuiInputConnection input = new GpuiInputConnection(new View(getContext()), text, sent::add);
+            input.beginBatchEdit();
+            if (composing) {
+                input.setComposingRegion(3, 9);
+            } else {
+                input.deleteSurroundingText(6, 0);
+            }
+            input.commitText("example", 1);
+            assertTrue(sent.isEmpty());
+            input.endBatchEdit();
+            assertEquals(1, sent.size());
+            assertEquals(new GpuiInputConnection.State("an example here", 10, 10, -1, -1), sent.get(0));
+        }
+    }
+
+    public void testSelectionAndUnicodeDeletionReachTheComposer() {
+        SpannableStringBuilder text = new SpannableStringBuilder("😀word中");
+        Selection.setSelection(text, text.length());
+        ArrayList<GpuiInputConnection.State> sent = new ArrayList<>();
+        GpuiInputConnection input = new GpuiInputConnection(new View(getContext()), text, sent::add);
+        input.setSelection(2, 6);
+        assertEquals(new GpuiInputConnection.State("😀word中", 2, 6, -1, -1), sent.get(0));
+        input.commitText("example", 0);
+        assertEquals(new GpuiInputConnection.State("😀example中", 2, 2, -1, -1), sent.get(1));
+        input.deleteSurroundingTextInCodePoints(1, 0);
+        assertEquals(new GpuiInputConnection.State("example中", 0, 0, -1, -1), sent.get(2));
+        input.deleteSurroundingText(0, 7);
+        assertEquals(new GpuiInputConnection.State("中", 0, 0, -1, -1), sent.get(3));
+    }
+
+    public void testRetiredConnectionCannotChangeTheNextDraft() {
+        SpannableStringBuilder text = new SpannableStringBuilder("old");
+        Selection.setSelection(text, text.length());
+        ArrayList<GpuiInputConnection.State> sent = new ArrayList<>();
+        GpuiInputConnection input = new GpuiInputConnection(new View(getContext()), text, sent::add);
+        input.closeConnection();
+        text.replace(0, text.length(), "new");
+        input.commitText("stale suggestion", 1);
+        assertEquals("new", text.toString());
+        assertTrue(sent.isEmpty());
+    }
+}

--- a/crates/android/host/app/src/main/java/com/tryanks/tcode/GpuiActivity.java
+++ b/crates/android/host/app/src/main/java/com/tryanks/tcode/GpuiActivity.java
@@ -15,7 +15,9 @@ import android.os.Build;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.InputType;
+import android.text.Selection;
 import android.text.SpannableStringBuilder;
+import android.text.method.TextKeyListener;
 import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.View;
@@ -64,6 +66,8 @@ public final class GpuiActivity extends NativeActivity {
     private native void nativeSetComposingText(String text);
     private native void nativeFinishComposingText();
     private native void nativeDeleteBackward();
+    private native void nativeInputState(long revision, long serial, String text,
+            int selectionStart, int selectionEnd, int composingStart, int composingEnd);
     private native void nativeKeyEvent(int keyCode, boolean down, int unicodeCodePoint, int metaState);
     private native void nativeOnInsets(int left, int top, int right, int bottom, int imeBottom);
     private native void nativeOnBack(boolean enabled);
@@ -234,6 +238,12 @@ public final class GpuiActivity extends NativeActivity {
         ((InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE)).restartInput(inputView);
     }
 
+    public void gpuiSyncInput(long revision, long serial, String text,
+            int selectionStart, int selectionEnd, int composingStart, int composingEnd) {
+        inputView.syncInput(revision, serial, text, selectionStart, selectionEnd,
+                composingStart, composingEnd);
+    }
+
     public int[] gpuiRasterizeEmoji(int glyph, float size) throws java.io.IOException {
         return SystemEmoji.rasterize(glyph, size);
     }
@@ -319,10 +329,47 @@ public final class GpuiActivity extends NativeActivity {
         private int inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
         private int imeOptions = EditorInfo.IME_ACTION_NONE;
         private final Editable editable = new SpannableStringBuilder();
+        private GpuiInputConnection connection;
+        private boolean textEditable;
+        private long revision;
+        private long serial;
 
         GpuiInputView(Context context) {
             super(context);
+            Selection.setSelection(editable, 0);
             if (Build.VERSION.SDK_INT >= 33) setAutoHandwritingEnabled(false);
+        }
+
+        void syncInput(long nextRevision, long acknowledgedSerial, String text,
+                int selectionStart, int selectionEnd, int composingStart, int composingEnd) {
+            // A frame acknowledging an earlier keystroke must not undo newer IME edits.
+            // A new revision is an app edit (send, paste, cursor move, or focus change).
+            if (nextRevision < revision || (nextRevision == revision && acknowledgedSerial < serial)) return;
+            boolean externalEdit = nextRevision != revision;
+            revision = nextRevision;
+            textEditable = text != null;
+            String value = textEditable ? text : "";
+            if (!value.contentEquals(editable)) editable.replace(0, editable.length(), value);
+            BaseInputConnection.removeComposingSpans(editable);
+            if (composingStart >= 0) {
+                new BaseInputConnection(this, true) {
+                    @Override public Editable getEditable() { return editable; }
+                }.setComposingRegion(composingStart, composingEnd);
+            }
+            Selection.setSelection(editable, selectionStart, selectionEnd);
+            if (connection != null) connection.rememberState();
+            InputMethodManager manager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+            if (externalEdit) manager.restartInput(this);
+            manager.updateSelection(this, selectionStart, selectionEnd, composingStart, composingEnd);
+        }
+
+        private void publishInput(GpuiInputConnection.State state) {
+            if (!textEditable) return;
+            nativeInputState(revision, ++serial, state.text(), state.selectionStart(), state.selectionEnd(),
+                    state.composingStart(), state.composingEnd());
+            ((InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE))
+                    .updateSelection(this, state.selectionStart(), state.selectionEnd(),
+                            state.composingStart(), state.composingEnd());
         }
 
         void configure(boolean autocorrect, int autocapitalize, boolean suggestions, int action, boolean multiLine) {
@@ -352,38 +399,56 @@ public final class GpuiActivity extends NativeActivity {
         public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
             outAttrs.inputType = inputType;
             outAttrs.imeOptions = imeOptions | EditorInfo.IME_FLAG_NO_EXTRACT_UI;
-            outAttrs.initialSelStart = editable.length();
-            outAttrs.initialSelEnd = editable.length();
-            return new BaseInputConnection(this, true) {
-                @Override public Editable getEditable() { return editable; }
+            outAttrs.initialSelStart = Selection.getSelectionStart(editable);
+            outAttrs.initialSelEnd = Selection.getSelectionEnd(editable);
+            if (connection != null) connection.closeConnection();
+            connection = new GpuiInputConnection(this, editable, this::publishInput) {
                 @Override public boolean commitText(CharSequence text, int cursor) {
-                    nativeCommitText(text == null ? "" : text.toString());
+                    if (getEditable() == null) return false;
+                    if (!textEditable) nativeCommitText(text.toString());
                     return super.commitText(text, cursor);
                 }
                 @Override public boolean setComposingText(CharSequence text, int cursor) {
-                    nativeSetComposingText(text == null ? "" : text.toString());
+                    if (getEditable() == null) return false;
+                    if (!textEditable) nativeSetComposingText(text.toString());
                     return super.setComposingText(text, cursor);
                 }
                 @Override public boolean finishComposingText() {
-                    nativeFinishComposingText(); return super.finishComposingText();
+                    if (getEditable() == null) return false;
+                    if (!textEditable) nativeFinishComposingText();
+                    return super.finishComposingText();
                 }
                 @Override public boolean deleteSurroundingText(int before, int after) {
-                    if (before > 0) nativeDeleteBackward();
+                    if (getEditable() == null) return false;
+                    if (!textEditable && before > 0) nativeDeleteBackward();
                     return super.deleteSurroundingText(before, after);
                 }
                 @Override public boolean deleteSurroundingTextInCodePoints(int before, int after) {
-                    if (before > 0) nativeDeleteBackward();
+                    if (getEditable() == null) return false;
+                    if (!textEditable && before > 0) nativeDeleteBackward();
                     return super.deleteSurroundingTextInCodePoints(before, after);
                 }
                 @Override public boolean sendKeyEvent(KeyEvent event) {
+                    if (getEditable() == null) return false;
+                    if (textEditable && event.getKeyCode() == KeyEvent.KEYCODE_DEL
+                            && event.hasNoModifiers()) {
+                        if (event.getAction() == KeyEvent.ACTION_DOWN) {
+                            TextKeyListener.getInstance().onKeyDown(GpuiInputView.this, editable,
+                                    event.getKeyCode(), event);
+                            publishChanges();
+                        }
+                        return true;
+                    }
                     forwardKeyEvent(event); return true;
                 }
                 @Override public boolean performEditorAction(int actionCode) {
+                    if (getEditable() == null) return false;
                     nativeKeyEvent(KeyEvent.KEYCODE_ENTER, true, '\n', 0);
                     nativeKeyEvent(KeyEvent.KEYCODE_ENTER, false, '\n', 0);
                     return true;
                 }
             };
+            return connection;
         }
 
         @Override public boolean onKeyDown(int keyCode, KeyEvent event) {

--- a/crates/android/host/app/src/main/java/com/tryanks/tcode/GpuiInputConnection.java
+++ b/crates/android/host/app/src/main/java/com/tryanks/tcode/GpuiInputConnection.java
@@ -1,0 +1,67 @@
+package com.tryanks.tcode;
+
+import android.text.Editable;
+import android.text.Selection;
+import android.view.View;
+import android.view.inputmethod.BaseInputConnection;
+import java.util.function.Consumer;
+
+/** Publish Android's completed edits, including selection and composing-span changes. */
+class GpuiInputConnection extends BaseInputConnection {
+    record State(String text, int selectionStart, int selectionEnd, int composingStart, int composingEnd) {}
+    private final Editable editable;
+    private final Consumer<State> changed;
+    private int batchDepth;
+    private boolean closed;
+    private State lastState;
+
+    GpuiInputConnection(View view, Editable editable, Consumer<State> changed) {
+        super(view, true);
+        this.editable = editable;
+        this.changed = changed;
+        rememberState();
+    }
+
+    @Override public Editable getEditable() { return closed ? null : editable; }
+
+    @Override public void closeConnection() {
+        // restartInput retires the old connection after the app has supplied its new state.
+        // BaseInputConnection.closeConnection would clear that new composing region.
+        closed = true;
+    }
+
+    @Override public boolean beginBatchEdit() {
+        batchDepth++;
+        return true;
+    }
+
+    @Override public boolean endBatchEdit() {
+        if (batchDepth == 0) return false;
+        batchDepth--;
+        publishChanges();
+        return batchDepth > 0;
+    }
+
+    @Override public boolean setSelection(int start, int end) {
+        boolean result = super.setSelection(start, end);
+        publishChanges();
+        return result;
+    }
+
+    void publishChanges() {
+        if (closed || batchDepth != 0) return;
+        State state = readState();
+        if (!state.equals(lastState)) {
+            lastState = state;
+            changed.accept(state);
+        }
+    }
+
+    void rememberState() { lastState = readState(); }
+
+    private State readState() {
+        return new State(editable.toString(), Selection.getSelectionStart(editable),
+                Selection.getSelectionEnd(editable), getComposingSpanStart(editable),
+                getComposingSpanEnd(editable));
+    }
+}

--- a/crates/android/src/lib.rs
+++ b/crates/android/src/lib.rs
@@ -165,6 +165,35 @@ mod jni_exports {
     }
 
     #[unsafe(no_mangle)]
+    pub extern "system" fn Java_com_tryanks_tcode_GpuiActivity_nativeInputState(
+        mut env: JNIEnv,
+        _activity: JObject,
+        revision: jlong,
+        serial: jlong,
+        text: JString,
+        selection_start: jint,
+        selection_end: jint,
+        composing_start: jint,
+        composing_end: jint,
+    ) {
+        if let Ok(text) = env.get_string(&text) {
+            let selection = selection_start.min(selection_end).max(0) as usize
+                ..selection_start.max(selection_end).max(0) as usize;
+            let marked = (composing_start >= 0 && composing_end > composing_start)
+                .then_some(composing_start as usize..composing_end as usize);
+            gpui_android::jni_input_state(
+                revision as u64,
+                serial as u64,
+                gpui_android::TextInputState {
+                    text: text.into(),
+                    selection,
+                    marked,
+                },
+            );
+        }
+    }
+
+    #[unsafe(no_mangle)]
     pub extern "system" fn Java_com_tryanks_tcode_GpuiActivity_nativeKeyEvent(
         _env: JNIEnv,
         _activity: JObject,

--- a/crates/platform/gpui-android/README.md
+++ b/crates/platform/gpui-android/README.md
@@ -52,8 +52,12 @@ callbacks to this backend. Rust calls activity methods on Android's Java UI
 thread; incoming callbacks are queued for the native activity/GPUI thread.
 Keep the method signatures at these two ends synchronized.
 
-Committed and composing text is applied through `PlatformInputHandler` using
-UTF-16 ranges. Hardware/IME key events become GPUI `KeyDown`/`KeyUp` events.
+Editable fields publish Android's text, selection and composing region after
+each completed IME batch. GPUI applies the changed UTF-16 range and sends its
+state back after app edits, cursor moves and draft clears. Revision and edit
+serial checks prevent delayed updates from restoring stale text. Terminal
+handlers keep the committed-text and control-key path because they expose no
+editable buffer. Hardware/IME key events become GPUI `KeyDown`/`KeyUp` events.
 System-bar, display-cutout, and IME geometry becomes `WindowInsets`. A GPUI
 window back handler takes precedence; `set_back_callback` exposes otherwise
 unhandled system back actions to the host application.
@@ -88,6 +92,18 @@ The script builds the arm64 Rust library and Gradle Debug APK. Set
 the script's defaults are Homebrew paths. `CARGO_NDK_PLATFORM` defaults to 26.
 The debug build embeds the shared font/SVG assets so it does not depend on
 source paths from the development machine.
+
+The keyboard bridge has device tests using Android's real `BaseInputConnection`.
+With an emulator or device attached, run from `crates/android/host`:
+
+```sh
+./gradlew connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=com.tryanks.tcode.GpuiInputConnectionTest
+```
+
+These cover batched word replacement, composing regions, selection, Unicode
+deletion and retired connections. Native range/synchronization tests run with
+`cargo test -p gpui-android --lib --locked` from the repository root.
 
 For testing performance on a phone, run `crates/android/host/build.sh --release`.
 This uses the `android-release` Cargo profile: optimization level 3, fat LTO,

--- a/crates/platform/gpui-android/src/android/host.rs
+++ b/crates/platform/gpui-android/src/android/host.rs
@@ -1,3 +1,4 @@
+use crate::text_input::TextInputState;
 use android_activity::AndroidApp;
 use gpui::TextInputConfiguration;
 use jni::{
@@ -13,6 +14,11 @@ pub(crate) enum HostEvent {
     SetComposingText(String),
     FinishComposing,
     DeleteBackward,
+    InputState {
+        revision: u64,
+        serial: u64,
+        state: TextInputState,
+    },
     Key {
         key_code: i32,
         down: bool,
@@ -50,13 +56,17 @@ pub(crate) fn drain() -> Vec<HostEvent> {
 enum OwnedArgument {
     Bool(bool),
     Int(i32),
+    Long(u64),
+    Text(Option<String>),
 }
 
 impl OwnedArgument {
-    fn as_jvalue(&self) -> JValue<'static, 'static> {
+    fn as_jvalue<'a>(&self, text: &'a JObject<'a>) -> JValue<'a, 'a> {
         match self {
             Self::Bool(value) => JValue::Bool(u8::from(*value)),
             Self::Int(value) => JValue::Int(*value),
+            Self::Long(value) => JValue::Long(*value as i64),
+            Self::Text(_) => JValue::Object(text),
         }
     }
 }
@@ -78,9 +88,25 @@ fn with_activity(method: &'static str, signature: &'static str, args: Vec<OwnedA
         };
         // SAFETY: `activity_as_ptr` is the live NativeActivity instance.
         let activity = unsafe { JObject::from_raw(callback_app.activity_as_ptr().cast()) };
+        let strings = args
+            .iter()
+            .map(|arg| match arg {
+                OwnedArgument::Text(Some(text)) => env.new_string(text).map(JObject::from),
+                _ => Ok(JObject::null()),
+            })
+            .collect::<jni::errors::Result<Vec<_>>>();
+        let strings = match strings {
+            Ok(strings) => strings,
+            Err(error) => {
+                log::error!("JNI {method} string allocation failed: {error}");
+                let _ = env.exception_clear();
+                return;
+            }
+        };
         let args = args
             .iter()
-            .map(OwnedArgument::as_jvalue)
+            .zip(&strings)
+            .map(|(arg, text)| arg.as_jvalue(text))
             .collect::<Vec<_>>();
         if let Err(error) = env.call_method(&activity, method, signature, &args) {
             log::error!("JNI {method} failed: {error}");
@@ -185,6 +211,32 @@ pub fn finish_composing_text() {
 
 pub fn delete_backward() {
     enqueue(HostEvent::DeleteBackward);
+}
+
+pub fn input_state(revision: u64, serial: u64, state: TextInputState) {
+    enqueue(HostEvent::InputState {
+        revision,
+        serial,
+        state,
+    });
+}
+
+pub(crate) fn sync_input(revision: u64, serial: u64, state: Option<TextInputState>) {
+    let selection = state.as_ref().map_or(0..0, |state| state.selection.clone());
+    let marked = state.as_ref().and_then(|state| state.marked.clone());
+    with_activity(
+        "gpuiSyncInput",
+        "(JJLjava/lang/String;IIII)V",
+        vec![
+            OwnedArgument::Long(revision),
+            OwnedArgument::Long(serial),
+            OwnedArgument::Text(state.map(|state| state.text)),
+            OwnedArgument::Int(selection.start as i32),
+            OwnedArgument::Int(selection.end as i32),
+            OwnedArgument::Int(marked.as_ref().map_or(-1, |range| range.start as i32)),
+            OwnedArgument::Int(marked.as_ref().map_or(-1, |range| range.end as i32)),
+        ],
+    );
 }
 
 pub fn key_event(key_code: i32, down: bool, unicode_code_point: i32, meta_state: i32) {

--- a/crates/platform/gpui-android/src/android/mod.rs
+++ b/crates/platform/gpui-android/src/android/mod.rs
@@ -14,8 +14,8 @@ pub(crate) use platform::AndroidPlatform;
 #[doc(hidden)]
 pub use host::{
     commit_text as jni_commit_text, delete_backward as jni_delete_backward,
-    finish_composing_text as jni_finish_composing_text, key_event as jni_key_event,
-    on_back as jni_on_back, on_insets as jni_on_insets,
+    finish_composing_text as jni_finish_composing_text, input_state as jni_input_state,
+    key_event as jni_key_event, on_back as jni_on_back, on_insets as jni_on_insets,
     set_composing_text as jni_set_composing_text,
 };
 

--- a/crates/platform/gpui-android/src/android/window.rs
+++ b/crates/platform/gpui-android/src/android/window.rs
@@ -107,6 +107,7 @@ pub(crate) struct AndroidWindowInner {
     frame_requested: Cell<bool>,
     forced_frame_requested: Cell<bool>,
     keyboard_tap: Cell<Option<Point<Pixels>>>,
+    input_sync: RefCell<crate::text_input::InputSync>,
 }
 
 #[derive(Clone)]
@@ -162,6 +163,7 @@ impl AndroidWindow {
             frame_requested: Cell::new(true),
             forced_frame_requested: Cell::new(true),
             keyboard_tap: Cell::new(None),
+            input_sync: RefCell::new(Default::default()),
         })))
     }
 
@@ -325,6 +327,26 @@ impl AndroidWindow {
 
     pub(crate) fn handle_host_event(&self, event: host::HostEvent) {
         match event {
+            host::HostEvent::InputState {
+                revision,
+                serial,
+                state,
+            } => {
+                self.sync_input_state(false);
+                let old = {
+                    let mut sync = self.0.input_sync.borrow_mut();
+                    if sync.accept(revision, serial) {
+                        sync.state.clone()
+                    } else {
+                        None
+                    }
+                };
+                if let Some(old) = old {
+                    self.with_input_handler(|handler| state.apply(&old, handler));
+                    self.0.input_sync.borrow_mut().state = Some(state);
+                }
+                self.sync_input_state(true);
+            }
             host::HostEvent::CommitText(text) => {
                 self.with_input_handler(|handler| {
                     handler.replace_text_in_range(None, &text);
@@ -388,6 +410,19 @@ impl AndroidWindow {
             callback(&mut handler);
             self.0.state.borrow_mut().input_handler = Some(handler);
             self.schedule_frame();
+        }
+    }
+
+    // Query outside GPUI's draw callback, when its window can be borrowed again.
+    fn sync_input_state(&self, force: bool) {
+        let mut handler = self.0.state.borrow_mut().input_handler.take();
+        let state = handler
+            .as_mut()
+            .and_then(crate::text_input::TextInputState::read);
+        self.0.state.borrow_mut().input_handler = handler;
+        let mut sync = self.0.input_sync.borrow_mut();
+        if sync.observe(state) || force {
+            host::sync_input(sync.revision, sync.serial, sync.state.clone());
         }
     }
 
@@ -572,6 +607,7 @@ impl AndroidWindow {
             });
             self.0.callbacks.borrow_mut().request_frame = Some(callback);
         }
+        self.sync_input_state(false);
         if let Some(position) = self.0.keyboard_tap.take() {
             self.with_input_handler(|handler| {
                 if handler

--- a/crates/platform/gpui-android/src/lib.rs
+++ b/crates/platform/gpui-android/src/lib.rs
@@ -9,12 +9,16 @@ use std::rc::Rc;
 mod text_input;
 
 #[cfg(target_os = "android")]
+pub use text_input::TextInputState;
+
+#[cfg(target_os = "android")]
 mod android;
 
 #[cfg(target_os = "android")]
 pub use android::{
     init_platform, insets, jni_commit_text, jni_delete_backward, jni_finish_composing_text,
-    jni_key_event, jni_on_back, jni_on_insets, jni_set_composing_text, set_back_callback, webview,
+    jni_input_state, jni_key_event, jni_on_back, jni_on_insets, jni_set_composing_text,
+    set_back_callback, webview,
 };
 
 #[cfg(not(target_os = "android"))]

--- a/crates/platform/gpui-android/src/text_input.rs
+++ b/crates/platform/gpui-android/src/text_input.rs
@@ -2,6 +2,133 @@ use gpui::{KeyDownEvent, Keystroke};
 use std::ops::Range;
 use unicode_segmentation::UnicodeSegmentation;
 
+/// Android's Editable and GPUI use UTF-16 for selections and composing ranges.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TextInputState {
+    pub text: String,
+    pub selection: Range<usize>,
+    pub marked: Option<Range<usize>>,
+}
+
+#[cfg(target_os = "android")]
+impl TextInputState {
+    pub(crate) fn read(handler: &mut gpui::PlatformInputHandler) -> Option<Self> {
+        let length = handler.text_length_utf16()?;
+        Some(Self {
+            text: handler.text_for_range(0..length, &mut None)?,
+            selection: handler.selected_text_range(true)?.range,
+            marked: handler.marked_text_range(),
+        })
+    }
+
+    pub(crate) fn apply(&self, old: &Self, handler: &mut gpui::PlatformInputHandler) {
+        let (old_range, new_range) = replacement_ranges(old, self);
+        let text = utf16_slice(&self.text, new_range.clone());
+        if self.marked.as_ref() == Some(&new_range)
+            && (self.text != old.text || self.marked != old.marked)
+        {
+            handler.replace_and_mark_text_in_range(Some(old_range), text, None);
+        } else {
+            if self.text != old.text {
+                handler.replace_text_in_range(Some(old_range), text);
+            }
+            if self.marked != handler.marked_text_range() {
+                if let Some(marked) = &self.marked {
+                    handler.replace_and_mark_text_in_range(
+                        Some(marked.clone()),
+                        utf16_slice(&self.text, marked.clone()),
+                        None,
+                    );
+                } else {
+                    handler.unmark_text();
+                }
+            }
+        }
+        handler.set_selected_text_range(self.selection.clone());
+    }
+}
+
+fn utf16_slice(text: &str, range: Range<usize>) -> &str {
+    let mut offset = 0;
+    let start = text
+        .char_indices()
+        .find_map(|(index, ch)| {
+            let found = (offset == range.start).then_some(index);
+            offset += ch.len_utf16();
+            found
+        })
+        .unwrap_or(text.len());
+    let length = range.end - range.start;
+    let mut offset = 0;
+    let end = text[start..]
+        .char_indices()
+        .find_map(|(index, ch)| {
+            let found = (offset == length).then_some(start + index);
+            offset += ch.len_utf16();
+            found
+        })
+        .unwrap_or(text.len());
+    &text[start..end]
+}
+
+// Include the whole preedit so each composing update stays in its IME transaction.
+fn replacement_ranges(old: &TextInputState, new: &TextInputState) -> (Range<usize>, Range<usize>) {
+    let old_length = old.text.encode_utf16().count();
+    let new_length = new.text.encode_utf16().count();
+    let mut prefix = old
+        .text
+        .chars()
+        .zip(new.text.chars())
+        .take_while(|(a, b)| a == b)
+        .map(|(ch, _)| ch.len_utf16())
+        .sum::<usize>();
+    if let Some(marked) = &old.marked {
+        prefix = prefix.min(marked.start);
+    }
+    if let Some(marked) = &new.marked {
+        prefix = prefix.min(marked.start);
+    }
+    let mut suffix_limit = (old_length - prefix).min(new_length - prefix);
+    if let Some(marked) = &old.marked {
+        suffix_limit = suffix_limit.min(old_length - marked.end);
+    }
+    if let Some(marked) = &new.marked {
+        suffix_limit = suffix_limit.min(new_length - marked.end);
+    }
+    let mut suffix = 0;
+    for (a, b) in old.text.chars().rev().zip(new.text.chars().rev()) {
+        if a != b || suffix + a.len_utf16() > suffix_limit {
+            break;
+        }
+        suffix += a.len_utf16();
+    }
+    (prefix..old_length - suffix, prefix..new_length - suffix)
+}
+
+/// A new revision invalidates queued IME edits after GPUI changes the draft or cursor.
+#[derive(Default)]
+pub(crate) struct InputSync {
+    pub revision: u64,
+    pub serial: u64,
+    pub state: Option<TextInputState>,
+}
+
+impl InputSync {
+    pub fn observe(&mut self, state: Option<TextInputState>) -> bool {
+        if self.state == state {
+            return false;
+        }
+        self.revision += 1;
+        self.state = state;
+        true
+    }
+
+    pub fn accept(&mut self, revision: u64, serial: u64) -> bool {
+        self.serial = self.serial.max(serial);
+        self.revision == revision
+    }
+}
+
 fn previous_grapheme_range(before_cursor: &str, cursor: usize) -> Range<usize> {
     let length = before_cursor
         .graphemes(true)
@@ -80,6 +207,71 @@ pub(crate) fn ime_key_down(mut keystroke: Keystroke, multi_line: bool) -> KeyDow
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn autocomplete_replaces_the_word_and_preserves_surrounding_unicode() {
+        for (before, after, old_marked, new_marked, expected_old, expected_new) in [
+            ("an exampl here", "an example here", None, None, 9..9, 9..10),
+            (
+                "an exmple here",
+                "an example here",
+                Some(3..9),
+                Some(3..10),
+                3..9,
+                3..10,
+            ),
+            (
+                "an exmple here",
+                "an example here",
+                Some(3..9),
+                None,
+                3..9,
+                3..10,
+            ),
+            ("😀 exampl", "😀 example", None, None, 9..9, 9..10),
+            ("😀word中", "😀中", None, None, 2..6, 2..2),
+        ] {
+            let old = TextInputState {
+                text: before.into(),
+                selection: 0..0,
+                marked: old_marked,
+            };
+            let new = TextInputState {
+                text: after.into(),
+                selection: 0..0,
+                marked: new_marked,
+            };
+            let (old_range, new_range) = replacement_ranges(&old, &new);
+            assert_eq!(old_range, expected_old);
+            assert_eq!(new_range, expected_new);
+            let mut result = before.encode_utf16().collect::<Vec<_>>();
+            result.splice(old_range, utf16_slice(after, new_range).encode_utf16());
+            assert_eq!(String::from_utf16(&result).unwrap(), after);
+        }
+    }
+
+    #[test]
+    fn app_clear_invalidates_queued_autocomplete_without_rejecting_ordinary_typing() {
+        let draft = TextInputState {
+            text: "exampl".into(),
+            selection: 6..6,
+            marked: None,
+        };
+        let mut sync = InputSync::default();
+        assert!(sync.observe(Some(draft.clone())));
+        let keyboard_revision = sync.revision;
+        assert!(sync.accept(keyboard_revision, 1));
+        assert!(!sync.observe(Some(draft)));
+        assert!(sync.accept(keyboard_revision, 2));
+        assert!(sync.observe(Some(TextInputState {
+            text: String::new(),
+            selection: 0..0,
+            marked: None
+        })));
+        assert!(!sync.accept(keyboard_revision, 3));
+        assert!(sync.accept(sync.revision, 4));
+        assert_eq!(sync.serial, 4);
+    }
 
     #[test]
     fn terminal_and_absent_text_fields_fall_back_to_control_keystrokes() {

--- a/crates/ui/src/widgets/input.rs
+++ b/crates/ui/src/widgets/input.rs
@@ -214,13 +214,11 @@ impl RenderOnce for Input {
                             let bounds = input_entity.read(cx).text_bounds().unwrap_or(bounds);
                             window.handle_input(
                                 &focus,
-                                input_configuration::ConfiguredInput {
-                                    inner: gpui::ElementInputHandler::new(
-                                        bounds,
-                                        input_entity.clone(),
-                                    ),
+                                input_configuration::ConfiguredInput::new(
+                                    bounds,
+                                    input_entity.clone(),
                                     multi_line,
-                                },
+                                ),
                                 cx,
                             );
                         },

--- a/crates/ui/src/widgets/input_configuration.rs
+++ b/crates/ui/src/widgets/input_configuration.rs
@@ -1,18 +1,33 @@
 //! Adds native keyboard intent to the upstream editor's input handler.
 use gpui::{
-    App, Bounds, ClipboardItem, ElementInputHandler, EntityInputHandler, InputHandler, Pixels,
-    Point, TextInputAction, TextInputConfiguration, UTF16Selection, Window,
+    App, Bounds, ClipboardItem, ElementInputHandler, Entity, InputHandler, Pixels, Point,
+    TextInputAction, TextInputConfiguration, UTF16Selection, Window,
 };
+use gpui_base::input::{InputBaseState, InputModeKind, RopeExt as _};
 use std::ops::Range;
 
-// The pinned gpui-base editor does not report keyboard configuration. Keep its
-// editing/selection implementation while supplying the field's native intent.
-pub(super) struct ConfiguredInput<V> {
-    pub inner: ElementInputHandler<V>,
-    pub multi_line: bool,
+// Supply the native selection/length hooks and keyboard intent missing upstream.
+pub(super) struct ConfiguredInput<M: InputModeKind> {
+    inner: ElementInputHandler<InputBaseState<M>>,
+    entity: Entity<InputBaseState<M>>,
+    multi_line: bool,
 }
 
-impl<V: EntityInputHandler> InputHandler for ConfiguredInput<V> {
+impl<M: InputModeKind> ConfiguredInput<M> {
+    pub fn new(
+        bounds: Bounds<Pixels>,
+        entity: Entity<InputBaseState<M>>,
+        multi_line: bool,
+    ) -> Self {
+        Self {
+            inner: ElementInputHandler::new(bounds, entity.clone()),
+            entity,
+            multi_line,
+        }
+    }
+}
+
+impl<M: InputModeKind> InputHandler for ConfiguredInput<M> {
     fn selected_text_range(
         &mut self,
         ignore_disabled_input: bool,
@@ -86,16 +101,23 @@ impl<V: EntityInputHandler> InputHandler for ConfiguredInput<V> {
     fn set_selected_text_range(
         &mut self,
         range_utf16: Range<usize>,
-        window: &mut Window,
+        _window: &mut Window,
         cx: &mut App,
     ) {
-        self.inner.set_selected_text_range(range_utf16, window, cx)
+        self.entity.update(cx, |state, cx| {
+            let text = state.text();
+            let range = text.offset_utf16_to_offset(range_utf16.start)
+                ..text.offset_utf16_to_offset(range_utf16.end);
+            if state.selected_range() != range {
+                state.set_selected_range(range, cx);
+            }
+        });
     }
     fn element_bounds(&mut self, window: &mut Window, cx: &mut App) -> Option<Bounds<Pixels>> {
         self.inner.element_bounds(window, cx)
     }
-    fn text_length_utf16(&mut self, window: &mut Window, cx: &mut App) -> Option<usize> {
-        self.inner.text_length_utf16(window, cx)
+    fn text_length_utf16(&mut self, _window: &mut Window, cx: &mut App) -> Option<usize> {
+        Some(self.entity.read(cx).text().len_utf16())
     }
     fn apple_press_and_hold_enabled(&mut self) -> bool {
         self.inner.apple_press_and_hold_enabled()
@@ -125,5 +147,31 @@ impl<V: EntityInputHandler> InputHandler for ConfiguredInput<V> {
             TextInputAction::Done
         };
         configuration
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::TestAppContext;
+    use gpui_base::input::TextareaState;
+
+    #[gpui::test]
+    fn native_selection_replaces_the_word_after_an_emoji(cx: &mut TestAppContext) {
+        cx.update(crate::theme::init);
+        let (input, cx) = cx.add_window_view(|window, cx| {
+            TextareaState::new(window, cx).default_value("😀 exmple here")
+        });
+        cx.update(|window, cx| {
+            let mut handler = ConfiguredInput::new(Bounds::default(), input.clone(), true);
+            assert_eq!(handler.text_length_utf16(window, cx), Some(14));
+            handler.set_selected_text_range(3..9, window, cx);
+            handler.replace_text_in_range(None, "example", window, cx);
+            assert_eq!(input.read(cx).value(), "😀 example here");
+            assert_eq!(
+                handler.selected_text_range(true, window, cx).unwrap().range,
+                10..10
+            );
+        });
     }
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -93,6 +93,10 @@ selection, including while an IME composing region is active. Multiline fields
 request a newline key from Android IMEs; plain Enter inserts a line break in
 the composer. Single-line fields keep a Done action that invokes their existing
 submit or next-step behavior. Modified hardware Enter bindings are unchanged.
+Android keyboard suggestions replace the complete word or composing region,
+including corrections after moving the cursor. The keyboard's text and selection
+follow composer clears, restored drafts and app edits; delayed keyboard updates
+must not restore text that was already sent.
 The centered chat/composer column is 720px wide at most. Desktop prose and
 composer text use 13.5px type with a 21px line height; metadata is smaller and
 muted, with monospace for paths, command text and numeric evidence.


### PR DESCRIPTION
Accepting an Android keyboard suggestion could leave the wrong word or duplicate text in the message box. An old keyboard update could also bring back a draft after it was cleared or sent.

The keyboard and Tcode now share the full text, cursor position, and word being edited. When a suggestion arrives as several edits, Tcode applies them together. Replacements account for emoji so they affect the intended text. Old keyboard updates cannot overwrite a newer draft.

The new tests cover accepting suggestions, replacing selected text, deleting text that includes emoji, and ignoring keyboard updates that arrive too late.

Implemented with GPT-6 Astra in Tcode

--- 

Tested manually on a real Android phone, it works great now 