### PR TITLE
Add smooth wheel scrolling through Tcode viewport handles

### DIFF
--- a/crates/ui/src/touch_scroll.rs
+++ b/crates/ui/src/touch_scroll.rs
@@ -1,4 +1,6 @@
-//! Element capture for native touch scrolling. GPUI still owns recognition and inertia.
+//! Shared viewport registration for wheel easing and native touch capture.
+//! GPUI still owns touch recognition and inertia.
+mod wheel;
 use std::{collections::HashMap, panic::Location};
 
 use gpui::{
@@ -63,6 +65,7 @@ struct Entry {
     id: GlobalElementId,
     parent: Option<GlobalElementId>,
     bounds: Bounds<Pixels>,
+    line_height: Pixels,
     handle: Handle,
     hitbox: Option<HitboxId>,
 }
@@ -105,6 +108,7 @@ struct Registry {
     pending: Option<Capture>,
     active: Option<Capture>,
     momentum: Option<Capture>,
+    wheel: wheel::Wheel,
 }
 
 impl Registry {
@@ -192,6 +196,7 @@ fn discard_occluded(window: &Window, cx: &mut App) {
 }
 
 fn install(window: &mut Window) {
+    wheel::install(window);
     if !cfg!(any(target_os = "android", target_os = "ios", test)) {
         return;
     }
@@ -363,6 +368,7 @@ impl<E: Element> Element for Registered<E> {
         cx: &mut App,
     ) -> Self::PrepaintState {
         if self.root {
+            wheel::will_prepaint(window, cx);
             let registry = registry(window, cx);
             registry.entries.clear();
             registry.frame = registry.frame.wrapping_add(1);
@@ -377,6 +383,7 @@ impl<E: Element> Element for Registered<E> {
                 id: id.clone(),
                 parent: registry.parents.last().cloned(),
                 bounds,
+                line_height: window.line_height(),
                 handle: handle.clone(),
                 hitbox: None,
             });
@@ -392,6 +399,9 @@ impl<E: Element> Element for Registered<E> {
             let registry = registry(window, cx);
             registry.entries[entry_index].hitbox = Some(hitbox.id);
             registry.parents.pop();
+        }
+        if self.root {
+            wheel::did_prepaint(window, cx);
         }
         result
     }
@@ -430,6 +440,7 @@ mod tests {
             id: id(name),
             parent: parent.map(id),
             bounds: Bounds::new(point(px(0.), px(y)), size(px(100.), px(height))),
+            line_height: px(20.),
             handle: Handle::Scroll(ScrollHandle::new()),
             hitbox: None,
         }
@@ -657,6 +668,17 @@ mod tests {
                     cx,
                 );
             }
+        });
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(50.), px(50.)),
+            delta: ScrollDelta::Lines(point(0., -3.)),
+            ..Default::default()
+        });
+        cx.executor()
+            .advance_clock(std::time::Duration::from_millis(150));
+        cx.update(|window, cx| {
+            window.simulate_next_frame(cx);
+            let _ = window.draw(cx);
         });
         assert_eq!(
             view.read_with(cx, |view, _| view.0.offset()),

--- a/crates/ui/src/touch_scroll/wheel.rs
+++ b/crates/ui/src/touch_scroll/wheel.rs
@@ -1,0 +1,270 @@
+//! Vertical wheel easing for Tcode's registered viewports, using stock GPUI handles.
+use super::{Handle, registry};
+use gpui::{
+    App, GlobalElementId, KeyDownEvent, MouseDownEvent, Pixels, ScrollDelta, ScrollWheelEvent,
+    Window, point, px,
+};
+use std::time::Duration;
+#[cfg(not(target_family = "wasm"))]
+use std::time::Instant;
+#[cfg(target_family = "wasm")]
+use web_time::Instant;
+
+const DURATION: Duration = Duration::from_millis(125);
+
+#[derive(Default)]
+pub(super) struct Wheel {
+    motion: Option<Motion>,
+    frame_pending: bool,
+}
+
+struct Motion {
+    id: GlobalElementId,
+    expected: Position,
+    started: Instant,
+    duration: Duration,
+    travel: Pixels,
+    applied: Pixels,
+}
+
+// Logical list anchors survive row remeasurement; absolute pixel targets don't.
+enum Position {
+    Scroll(Pixels),
+    List {
+        item: usize,
+        offset: Pixels,
+        count: usize,
+    },
+}
+
+impl Position {
+    fn read(handle: &Handle) -> Self {
+        match handle {
+            Handle::Scroll(handle) => Self::Scroll(handle.offset().y),
+            Handle::List(list) => {
+                let top = list.logical_scroll_top();
+                Self::List {
+                    item: top.item_ix,
+                    offset: top.offset_in_item,
+                    count: list.item_count(),
+                }
+            }
+            Handle::Textarea(_) => unreachable!("textareas retain their native wheel handler"),
+        }
+    }
+
+    fn matches(&self, handle: &Handle) -> bool {
+        match (self, Self::read(handle)) {
+            (Self::Scroll(old), Self::Scroll(new)) => *old == new,
+            (
+                Self::List {
+                    item,
+                    offset,
+                    count,
+                },
+                Self::List {
+                    item: new_item,
+                    offset: new_offset,
+                    count: new_count,
+                },
+            ) => {
+                // Prepending history shifts both indices equally without moving
+                // the reading anchor. Explicit positioning cancels the animation.
+                *offset == new_offset
+                    && (*item == new_item || *count - *item == new_count - new_item)
+            }
+            _ => false,
+        }
+    }
+}
+
+fn extent(handle: &Handle) -> Option<(Pixels, Pixels)> {
+    let (offset, max) = match handle {
+        Handle::Scroll(handle) => (handle.offset().y, handle.max_offset().y),
+        Handle::List(list) => (
+            list.scroll_px_offset_for_scrollbar().y,
+            list.max_offset_for_scrollbar().y,
+        ),
+        Handle::Textarea(_) => return None,
+    };
+    let max = max.max(px(0.));
+    Some((offset.clamp(-max, px(0.)), max))
+}
+
+pub(super) fn install(window: &mut Window) {
+    window.on_mouse_event(|_: &MouseDownEvent, phase, window, cx| {
+        if phase.capture() {
+            registry(window, cx).wheel.motion = None;
+        }
+    });
+    window.on_key_event(|_: &KeyDownEvent, phase, window, cx| {
+        if phase.capture() {
+            registry(window, cx).wheel.motion = None;
+        }
+    });
+    window.on_mouse_event(|event: &ScrollWheelEvent, phase, window, cx| {
+        if !phase.capture() {
+            return;
+        }
+        let ScrollDelta::Lines(lines) = event.delta else {
+            registry(window, cx).wheel.motion = None;
+            return;
+        };
+        if cx.reduce_motion()
+            || event.modifiers.shift
+            || lines.y == 0.
+            || lines.x.abs() >= lines.y.abs()
+        {
+            registry(window, cx).wheel.motion = None;
+            return;
+        }
+
+        let previous = registry(window, cx).wheel.motion.take();
+        let entries = &registry(window, cx).entries;
+        let mut entry = entries.iter().rev().find(|entry| {
+            entry.bounds.contains(&event.position)
+                && entry
+                    .hitbox
+                    .is_some_and(|hitbox| hitbox.should_handle_scroll(window))
+        });
+        // At a nested viewport's limit, let the registered parent take this notch.
+        let (entry, offset, max, delta) = loop {
+            let Some(target) = entry else { return };
+            let Some((offset, max)) = extent(&target.handle) else {
+                return;
+            };
+            let line_height = if matches!(target.handle, Handle::List(_)) {
+                px(20.)
+            } else {
+                target.line_height
+            };
+            let delta = line_height * lines.y;
+            if (offset + delta).clamp(-max, px(0.)) != offset {
+                break (target.clone(), offset, max, delta);
+            }
+            entry = target
+                .parent
+                .as_ref()
+                .and_then(|parent| entries.iter().find(|entry| &entry.id == parent));
+        };
+        let now = cx.background_executor().now();
+        let previous = previous
+            .filter(|motion| motion.id == entry.id && motion.expected.matches(&entry.handle));
+        let mut travel = delta;
+        let mut duration = DURATION;
+        if let Some(previous) = previous {
+            let remaining = previous.travel - previous.applied;
+            if f32::from(remaining) * f32::from(delta) > 0. {
+                travel += remaining;
+                // Preserve speed when retargeting a run of wheel notches (Zed #44827).
+                let progress = (now.duration_since(previous.started).as_secs_f32()
+                    / previous.duration.as_secs_f32())
+                .min(1.);
+                let speed = f32::from(previous.travel) * 3. * (1. - progress).powi(2)
+                    / previous.duration.as_secs_f32();
+                if speed.abs() > 1e-6 {
+                    duration = Duration::from_secs_f32(
+                        (3. * f32::from(travel) / speed)
+                            .clamp(DURATION.as_secs_f32() / 8., DURATION.as_secs_f32()),
+                    );
+                }
+            }
+        }
+        travel = travel.clamp(-max - offset, -offset);
+        if let Handle::List(list) = &entry.handle
+            && list.is_following_tail()
+            && travel > px(0.)
+        {
+            // GPUI re-engages tail following within 1px of the end. Move just
+            // beyond that threshold now so streaming can't reclaim the viewport
+            // before the first animation frame.
+            let release = travel.min(px(2.));
+            list.set_offset_from_scrollbar(point(px(0.), offset + release));
+            list.pause_following_tail();
+            travel -= release;
+        }
+        registry(window, cx).wheel.motion = Some(Motion {
+            id: entry.id,
+            expected: Position::read(&entry.handle),
+            started: now,
+            duration,
+            travel,
+            applied: px(0.),
+        });
+        schedule(window, cx);
+        window.refresh();
+        cx.stop_propagation();
+    });
+}
+
+fn schedule(window: &mut Window, cx: &mut App) {
+    let wheel = &mut registry(window, cx).wheel;
+    if wheel.frame_pending {
+        return;
+    }
+    wheel.frame_pending = true;
+    window.on_next_frame(|window, cx| {
+        registry(window, cx).wheel.frame_pending = false;
+        let Some(mut motion) = registry(window, cx).wheel.motion.take() else {
+            return;
+        };
+        let Some(handle) = registry(window, cx)
+            .entries
+            .iter()
+            .find(|entry| entry.id == motion.id)
+            .map(|entry| entry.handle.clone())
+        else {
+            return;
+        };
+        if !motion.expected.matches(&handle) {
+            return;
+        }
+        let progress = if cx.reduce_motion() {
+            1.
+        } else {
+            (cx.background_executor()
+                .now()
+                .duration_since(motion.started)
+                .as_secs_f32()
+                / motion.duration.as_secs_f32())
+            .min(1.)
+        };
+        let position = motion.travel * (1. - (1. - progress).powi(3));
+        let delta = position - motion.applied;
+        if delta != px(0.) {
+            handle.apply(point(px(0.), delta), cx);
+        }
+        motion.applied = position;
+        motion.expected = Position::read(&handle);
+        if progress < 1. {
+            registry(window, cx).wheel.motion = Some(motion);
+            schedule(window, cx);
+        }
+        window.refresh();
+    });
+}
+
+pub(super) fn will_prepaint(window: &Window, cx: &mut App) {
+    let registry = registry(window, cx);
+    if let Some(motion) = &registry.wheel.motion
+        && let Some(entry) = registry.entries.iter().find(|entry| entry.id == motion.id)
+        && !motion.expected.matches(&entry.handle)
+    {
+        registry.wheel.motion = None;
+    }
+}
+
+/// Accept layout's anchor adjustments, and retire animations when their view disappears.
+pub(super) fn did_prepaint(window: &Window, cx: &mut App) {
+    let registry = registry(window, cx);
+    if let Some(motion) = &mut registry.wheel.motion {
+        if let Some(entry) = registry.entries.iter().find(|entry| entry.id == motion.id) {
+            motion.expected = Position::read(&entry.handle);
+        } else {
+            registry.wheel.motion = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ui/src/touch_scroll/wheel/tests.rs
+++ b/crates/ui/src/touch_scroll/wheel/tests.rs
@@ -1,0 +1,301 @@
+//! Exercise Tcode viewport registration with unmodified GPUI.
+use crate::touch_scroll::{Handle, register, root};
+
+use gpui::{
+    Context, FollowMode, InteractiveElement, IntoElement, ListAlignment, ListState, ParentElement,
+    Pixels, Render, ScrollDelta, ScrollHandle, ScrollWheelEvent, StatefulInteractiveElement,
+    Styled, TestAppContext, VisualTestContext, Window, WindowHandle, div, list, point, px,
+};
+use std::time::Duration;
+use std::{cell::Cell, rc::Rc};
+
+#[derive(Clone)]
+enum Area {
+    Div(ScrollHandle),
+    List(ListState),
+}
+
+impl Area {
+    fn offset(&self) -> Pixels {
+        match self {
+            Self::Div(handle) => handle.offset().y,
+            Self::List(state) => state.scroll_px_offset_for_scrollbar().y,
+        }
+    }
+
+    fn set_offset(&self, y: Pixels) {
+        match self {
+            Self::Div(handle) => handle.set_offset(point(px(0.), y)),
+            Self::List(state) => {
+                state.scrollbar_drag_started();
+                state.set_offset_from_scrollbar(point(px(0.), y));
+                state.scrollbar_drag_ended();
+            }
+        }
+    }
+}
+
+struct ScrollView {
+    area: Area,
+    tail_height: Rc<Cell<Pixels>>,
+}
+
+impl Render for ScrollView {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        let element = match &self.area {
+            Area::Div(handle) => div()
+                .id("scroll")
+                .w(px(100.))
+                .h(px(100.))
+                .overflow_y_scroll()
+                .track_scroll(handle)
+                .child(div().h(px(1000.)).w_full().flex_none())
+                .into_any_element(),
+            Area::List(state) => {
+                let last = state.item_count() - 1;
+                let tail_height = self.tail_height.clone();
+                list(state.clone(), move |ix, _, _| {
+                    let height = if ix == last {
+                        tail_height.get()
+                    } else {
+                        px(100.)
+                    };
+                    div().h(height).w_full().into_any_element()
+                })
+                .w(px(100.))
+                .h(px(100.))
+                .into_any_element()
+            }
+        };
+        let handle = match &self.area {
+            Area::Div(handle) => Handle::Scroll(handle.clone()),
+            Area::List(state) => Handle::List(state.clone()),
+        };
+        root(register(element, handle))
+    }
+}
+
+fn frame(cx: &mut TestAppContext, window: WindowHandle<ScrollView>, millis: u64) {
+    cx.executor().advance_clock(Duration::from_millis(millis));
+    VisualTestContext::from_window(window.into(), cx).update(|window, cx| {
+        window.simulate_next_frame(cx);
+        window.draw(cx).clear(cx);
+    });
+    cx.executor().run_until_parked();
+}
+
+fn scroll(cx: &mut TestAppContext, window: WindowHandle<ScrollView>, delta: ScrollDelta) {
+    VisualTestContext::from_window(window.into(), cx).simulate_event(ScrollWheelEvent {
+        position: point(px(5.), px(5.)),
+        delta,
+        ..Default::default()
+    });
+    cx.executor().run_until_parked();
+}
+
+fn assert_near(actual: Pixels, expected: f32) {
+    assert!(
+        (f32::from(actual) - expected).abs() < 0.01,
+        "{actual:?} != {expected}"
+    );
+}
+
+#[gpui::test]
+fn wheel_scroll_accumulates_and_yields_to_direct_input(cx: &mut TestAppContext) {
+    for area in [
+        Area::Div(ScrollHandle::new()),
+        Area::List(ListState::new(10, ListAlignment::Top, px(0.)).measure_all()),
+    ] {
+        let window = cx.add_window(|_, _| ScrollView {
+            area: area.clone(),
+            tail_height: Rc::new(Cell::new(px(100.))),
+        });
+        // Div uses the window's line height, while List uses 20px per line.
+        let distance = window
+            .update(cx, |_, window, _| match &area {
+                Area::Div(_) => f32::from(window.line_height()) * 6.,
+                Area::List(_) => 120.,
+            })
+            .unwrap();
+        scroll(cx, window, ScrollDelta::Lines(point(0., -3.)));
+        assert_eq!(area.offset(), px(0.));
+        frame(cx, window, 32);
+        assert!(area.offset() < px(0.) && area.offset() > px(-distance / 2.));
+        scroll(cx, window, ScrollDelta::Lines(point(0., -3.)));
+        frame(cx, window, 150);
+        assert_near(area.offset(), -distance);
+
+        scroll(cx, window, ScrollDelta::Lines(point(0., -3.)));
+        scroll(cx, window, ScrollDelta::Pixels(point(px(0.), px(7.))));
+        assert_near(area.offset(), -distance + 7.);
+        frame(cx, window, 150);
+        assert_near(area.offset(), -distance + 7.);
+
+        scroll(cx, window, ScrollDelta::Lines(point(0., -3.)));
+        area.set_offset(px(-200.));
+        window.update(cx, |_, _, cx| cx.notify()).unwrap();
+        frame(cx, window, 150);
+        assert_near(area.offset(), -200.);
+
+        scroll(cx, window, ScrollDelta::Lines(point(0., -3.)));
+        VisualTestContext::from_window(window.into(), cx).simulate_event(gpui::MouseDownEvent {
+            position: point(px(95.), px(50.)),
+            button: gpui::MouseButton::Left,
+            ..Default::default()
+        });
+        frame(cx, window, 150);
+        assert_near(area.offset(), -200.);
+    }
+}
+
+#[gpui::test]
+fn wheel_scroll_preserves_chat_anchor_during_streaming_and_prepend(cx: &mut TestAppContext) {
+    let state = ListState::new(10, ListAlignment::Bottom, px(2000.)).measure_all();
+    state.set_follow_mode(FollowMode::Tail);
+    let tail_height = Rc::new(Cell::new(px(100.)));
+    let area = Area::List(state.clone());
+    let window = cx.add_window(|_, _| ScrollView {
+        area: area.clone(),
+        tail_height: tail_height.clone(),
+    });
+    assert_near(area.offset(), -900.);
+    scroll(cx, window, ScrollDelta::Lines(point(0., 3.)));
+    assert!(!state.is_following_tail());
+    // Streaming before the first animation frame must not re-engage follow.
+    tail_height.set(px(200.));
+    state.remeasure_items(9..10);
+    frame(cx, window, 32);
+    assert!(area.offset() > px(-900.) && area.offset() < px(-840.));
+    assert!(!state.is_following_tail());
+    state.splice(0..0, 2);
+    window.update(cx, |_, _, cx| cx.notify()).unwrap();
+    frame(cx, window, 150);
+    assert_near(area.offset(), -1040.);
+    assert!(!state.is_following_tail());
+
+    scroll(cx, window, ScrollDelta::Lines(point(0., -100.)));
+    frame(cx, window, 150);
+    assert_near(area.offset(), -1200.);
+    assert!(state.is_following_tail());
+}
+
+#[gpui::test]
+fn wheel_scroll_reverses_without_overscroll_and_respects_reduced_motion(cx: &mut TestAppContext) {
+    for area in [
+        Area::Div(ScrollHandle::new()),
+        Area::List(ListState::new(10, ListAlignment::Top, px(0.)).measure_all()),
+    ] {
+        let window = cx.add_window(|_, _| ScrollView {
+            area: area.clone(),
+            tail_height: Rc::new(Cell::new(px(100.))),
+        });
+        let line_height = window
+            .update(cx, |_, window, _| match area {
+                Area::Div(_) => f32::from(window.line_height()),
+                Area::List(_) => 20.,
+            })
+            .unwrap();
+        // Reversing before the first frame must also cancel a queued notch.
+        scroll(cx, window, ScrollDelta::Lines(point(0., -3.)));
+        scroll(cx, window, ScrollDelta::Lines(point(0., 3.)));
+        frame(cx, window, 150);
+        assert_near(area.offset(), 0.);
+
+        scroll(cx, window, ScrollDelta::Lines(point(0., -100.)));
+        frame(cx, window, 32);
+        let before = area.offset();
+        assert!(before < px(0.) && before > px(-900.));
+        scroll(cx, window, ScrollDelta::Lines(point(0., 1.)));
+        frame(cx, window, 16);
+        assert!(
+            area.offset() > before,
+            "reversing must discard the old destination"
+        );
+        frame(cx, window, 150);
+        assert_near(area.offset(), f32::from(before) + line_height);
+
+        scroll(cx, window, ScrollDelta::Lines(point(0., -100.)));
+        frame(cx, window, 150);
+        assert_near(area.offset(), -900.);
+        // Extra input against the limit must not accumulate invisible overscroll.
+        scroll(cx, window, ScrollDelta::Lines(point(0., -100.)));
+        scroll(cx, window, ScrollDelta::Lines(point(0., 1.)));
+        frame(cx, window, 150);
+        assert_near(area.offset(), -900. + line_height);
+
+        cx.update(|cx| cx.set_reduce_motion(true));
+        scroll(cx, window, ScrollDelta::Lines(point(0., 1.)));
+        assert_near(area.offset(), -900. + 2. * line_height);
+        frame(cx, window, 150);
+        assert_near(area.offset(), -900. + 2. * line_height);
+        cx.update(|cx| cx.set_reduce_motion(false));
+    }
+}
+
+#[gpui::test]
+fn wheel_scroll_only_moves_the_innermost_scrollable_viewport(cx: &mut TestAppContext) {
+    struct Nested {
+        inner: ListState,
+        outer: ScrollHandle,
+    }
+    impl Render for Nested {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            root(register(
+                div()
+                    .id("outer")
+                    .w(px(100.))
+                    .h(px(100.))
+                    .overflow_y_scroll()
+                    .track_scroll(&self.outer)
+                    .child(register(
+                        list(self.inner.clone(), |_, _, _| {
+                            div().w_full().h(px(100.)).into_any_element()
+                        })
+                        .w_full()
+                        .h(px(100.))
+                        .flex_none(),
+                        Handle::List(self.inner.clone()),
+                    ))
+                    .child(div().h(px(1000.)).flex_none()),
+                Handle::Scroll(self.outer.clone()),
+            ))
+        }
+    }
+    let inner = ListState::new(10, ListAlignment::Top, px(0.)).measure_all();
+    let outer = ScrollHandle::new();
+    let window = cx.add_window(|_, _| Nested {
+        inner: inner.clone(),
+        outer: outer.clone(),
+    });
+    let mut visual = VisualTestContext::from_window(window.into(), cx);
+    let wheel = ScrollWheelEvent {
+        position: point(px(5.), px(5.)),
+        delta: ScrollDelta::Lines(point(0., -3.)),
+        ..Default::default()
+    };
+    visual.simulate_event(wheel.clone());
+    cx.executor().advance_clock(Duration::from_millis(150));
+    visual.update(|window, cx| {
+        window.simulate_next_frame(cx);
+        window.draw(cx).clear(cx);
+    });
+    assert_near(inner.scroll_px_offset_for_scrollbar().y, -60.);
+    assert_eq!(outer.offset().y, px(0.));
+
+    inner.scroll_to_end();
+    visual.update(|window, cx| {
+        window.refresh();
+        window.draw(cx).clear(cx);
+    });
+    visual.simulate_event(wheel);
+    cx.executor().advance_clock(Duration::from_millis(150));
+    visual.update(|window, cx| {
+        window.simulate_next_frame(cx);
+        window.draw(cx).clear(cx);
+    });
+    assert_near(inner.scroll_px_offset_for_scrollbar().y, -900.);
+    assert!(
+        outer.offset().y < px(0.),
+        "the parent must receive wheel input at the child's limit"
+    );
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -256,6 +256,15 @@ scroll position; headers, search controls and footers stay outside its track.
 Virtualized lists estimate offscreen row heights so the thumb represents the
 whole list from the first frame; measured heights refine that estimate.
 
+Vertical mouse-wheel notches ease over about 125ms in Tcode's registered scroll
+views (chat, sidebars, settings, and diffs). Repeated input accumulates; reversing
+direction discards the previous direction's remaining movement. Trackpad pixels,
+native touch, textareas, and custom horizontal/terminal scrolling retain their
+existing input handling. Reduced motion uses direct scrolling. Pointer presses,
+keyboard input, and direct positioning interrupt wheel animation. Scrolling up
+releases chat tail-following immediately; animation uses relative movement so
+row remeasurement and prepended history preserve the reading anchor.
+
 Potentially unbounded content always has its own resolved-height viewport and a
 separate, non-shrinking content column. Headers, search fields, footers and
 actions stay outside that viewport. This applies to the sidebar project list,


### PR DESCRIPTION
Mouse-wheel scrolling currently moves in abrupt jumps. This change makes it move smoothly through chats, sidebars, settings, and file diffs. Inspired by this PR: https://github.com/zed-industries/zed/pull/44827

Turning the wheel again continues the movement. Reversing direction stops the old movement and starts scrolling the other way. Clicking, pressing a key, or moving the scrollbar stops the animation. Scrolling stays immediate when reduced motion is enabled.

Scrolling up in a chat stops it from jumping to the latest output. Your reading position stays steady as the agent adds text or older messages load. Trackpad scrolling, touch gestures, text fields, and terminal scrolling keep their existing behavior.

The new tests cover repeated scrolling, changing direction, stopping the animation, reduced motion, reaching the end of a scrollable area, and keeping your place in a chat.

Implemented with GPT-6 Astra in Tcode