### PR TITLE
Fix remote image viewing and better previews in threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,6 +1346,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cocoa"
@@ -2673,6 +2705,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3417,6 +3455,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpui-pre-http-client-tls"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10157341e736f024112d995fb89750aa8b4e80c9157b3dc22200127a64b27dc1"
+dependencies = [
+ "log",
+ "rustls",
+ "rustls-platform-verifier",
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
 name = "gpui-pre-linux"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3619,7 +3669,26 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.26.11",
  "windows-registry 0.4.0",
+]
+
+[[package]]
+name = "gpui-pre-reqwest-client"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfa3df55759b31177cc5c4abb302921844a89698cc91783685a2002200a6257d"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures",
+ "gpui-pre-http-client",
+ "gpui-pre-http-client-tls",
+ "gpui-pre-reqwest",
+ "gpui-pre-util",
+ "log",
+ "regex",
+ "tokio",
 ]
 
 [[package]]
@@ -4134,6 +4203,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -7536,6 +7606,7 @@ version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -7577,11 +7648,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -8886,6 +8985,8 @@ dependencies = [
  "gpui-kit-assets",
  "gpui-pre",
  "gpui-pre-platform",
+ "gpui-pre-reqwest",
+ "gpui-pre-reqwest-client",
  "gpui-wry",
  "image",
  "imara-diff",
@@ -8897,6 +8998,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "objc2-image-io",
  "objc2-web-kit",
+ "percent-encoding",
  "preview-mcp",
  "qrcode",
  "raw-window-handle",
@@ -10093,6 +10195,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/assets/icons/image.svg
+++ b/assets/icons/image.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="3"/><circle cx="8" cy="8" r="1.5"/><path d="m3 17 5-5 4 4 4-6 5 7"/></svg>

--- a/crates/remote/tests/proxy.rs
+++ b/crates/remote/tests/proxy.rs
@@ -145,10 +145,14 @@ fn connect_carries_verified_tls_bytes_without_interception() {
         // This self-signed localhost identity is trusted only by this test client.
         let certificate = CertificateDer::from(include_bytes!("fixtures/localhost.der").to_vec());
         let key = PrivatePkcs8KeyDer::from(include_bytes!("fixtures/localhost-key.der").to_vec());
-        let server_config = rustls::ServerConfig::builder()
-            .with_no_client_auth()
-            .with_single_cert(vec![certificate.clone()], key.into())
-            .unwrap();
+        let server_config = rustls::ServerConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .with_no_client_auth()
+        .with_single_cert(vec![certificate.clone()], key.into())
+        .unwrap();
         let origin = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = origin.local_addr().unwrap().port();
         let origin = std::thread::spawn(move || {
@@ -193,9 +197,13 @@ fn connect_carries_verified_tls_bytes_without_interception() {
         };
         let mut roots = rustls::RootCertStore::empty();
         roots.add(certificate).unwrap();
-        let config = rustls::ClientConfig::builder()
-            .with_root_certificates(roots)
-            .with_no_client_auth();
+        let config = rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
         let mut tls = rustls::StreamOwned::new(
             rustls::ClientConnection::new(
                 Arc::new(config),

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -55,6 +55,7 @@ pasteboard-image = ["dep:objc2-app-kit", "dep:objc2-foundation"]
 
 [dependencies]
 url = "2"
+percent-encoding = "2"
 agent = { path = "../agent", default-features = false }
 tcode-client = { path = "../client" }
 tcode-core = { path = "../core", default-features = false }
@@ -86,6 +87,9 @@ web-time = "1"
 # browser green even if a wasm-facing crate turns the feature on.
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tcode-remote = { path = "../remote", default-features = false, optional = true }
+reqwest-client = { package = "gpui-pre-reqwest-client", version = "=0.3.3" }
+# Android apps do not have the Unix certificate files used by native-roots discovery.
+reqwest = { package = "gpui-pre-reqwest", version = "0.12.15", default-features = false, features = ["rustls-tls-webpki-roots"] }
 
 # The preview backend exists only where a system webview can be embedded as a
 # child of the GPUI window, so its whole dependency set is target-scoped.

--- a/crates/ui/src/assets.rs
+++ b/crates/ui/src/assets.rs
@@ -22,6 +22,10 @@ const DM_SANS_PATH: &str = "fonts/DMSans[wght].ttf";
 /// Extra SVG icons bundled by tcode (not shipped by gpui-component).
 const EXTRA_ICONS: &[(&str, &[u8])] = &[
     (
+        "icons/image.svg",
+        include_bytes!("../../../assets/icons/image.svg"),
+    ),
+    (
         "icons/archive.svg",
         include_bytes!("../../../assets/icons/archive.svg"),
     ),

--- a/crates/ui/src/attachments.rs
+++ b/crates/ui/src/attachments.rs
@@ -8,7 +8,7 @@ use tcode_core::attachments::AttachError;
 /// Open an image as a window-level lightbox. The dialog lives on the Root
 /// layer, so its backdrop covers the whole window and it inherits
 /// backdrop-click / Escape / `x` dismissal. Shared by the composer's pending
-/// strip, sent-message thumbnails and Markdown image-link badges.
+/// strip, sent-message thumbnails, Markdown images and image-link badges.
 pub(crate) fn open_image_lightbox(
     source: ImageSource,
     title: String,

--- a/crates/ui/src/attachments.rs
+++ b/crates/ui/src/attachments.rs
@@ -1,22 +1,25 @@
 //! Attachment presentation with core-owned validation semantics and localized errors.
 
-use std::path::PathBuf;
-
 use crate::overlay::OverlayExt as _;
 use crate::theme::ActiveTheme as _;
-use gpui::{App, ParentElement as _, Styled as _, Window, div, img, px};
+use gpui::{App, ImageSource, ParentElement as _, Styled as _, Window, div, img, px};
 use tcode_core::attachments::AttachError;
 
 /// Open an image as a window-level lightbox. The dialog lives on the Root
 /// layer, so its backdrop covers the whole window and it inherits
 /// backdrop-click / Escape / `x` dismissal. Shared by the composer's pending
-/// strip and the chat timeline's sent-message thumbnails.
-pub(crate) fn open_image_lightbox(path: PathBuf, title: String, window: &mut Window, cx: &mut App) {
+/// strip, sent-message thumbnails and Markdown image-link badges.
+pub(crate) fn open_image_lightbox(
+    source: ImageSource,
+    title: String,
+    window: &mut Window,
+    cx: &mut App,
+) {
     window.open_dialog(cx, move |builder, window, cx| {
         let viewport = window.viewport_size();
         let width = (viewport.width - px(160.)).clamp(px(320.), px(760.));
         let max_h = viewport.height * 0.65;
-        let path = path.clone();
+        let source = source.clone();
         builder
             .w(width)
             .rounded(crate::material::radius_overlay())
@@ -28,7 +31,7 @@ pub(crate) fn open_image_lightbox(path: PathBuf, title: String, window: &mut Win
             .content(move |content_el, _, _| {
                 content_el.child(
                     div().w_full().flex().items_center().justify_center().child(
-                        img(crate::store::host_image(path.clone()))
+                        img(source.clone())
                             .max_w_full()
                             .max_h(max_h)
                             .rounded(crate::material::radius_card()),

--- a/crates/ui/src/attachments.rs
+++ b/crates/ui/src/attachments.rs
@@ -17,11 +17,11 @@ pub(crate) fn open_image_lightbox(
 ) {
     window.open_dialog(cx, move |builder, window, cx| {
         let viewport = window.viewport_size();
-        let width = (viewport.width - px(160.)).clamp(px(320.), px(760.));
-        let max_h = viewport.height * 0.65;
+        // Leave room for the dialog header, padding and bottom margin in short windows.
+        let max_h = (viewport.height * 0.75).min(viewport.height * 0.9 - px(96.));
         let source = source.clone();
         builder
-            .w(width)
+            .w(px(1200.))
             .rounded(crate::material::radius_overlay())
             .bg(cx.theme().popover)
             .border_1()

--- a/crates/ui/src/chat/mod.rs
+++ b/crates/ui/src/chat/mod.rs
@@ -1378,7 +1378,7 @@ impl ChatView {
                     .unwrap_or_else(|| "image".to_string());
                 Box::new(cx.listener(move |_, _, window, cx| {
                     crate::attachments::open_image_lightbox(
-                        path.clone(),
+                        crate::store::host_image(path.clone()),
                         title.clone(),
                         window,
                         cx,

--- a/crates/ui/src/composer/components/images.rs
+++ b/crates/ui/src/composer/components/images.rs
@@ -334,6 +334,11 @@ impl Composer {
         let Some(image) = self.pending_images.get(index) else {
             return;
         };
-        crate::attachments::open_image_lightbox(image.path.clone(), image.name.clone(), window, cx);
+        crate::attachments::open_image_lightbox(
+            crate::store::host_image(image.path.clone()),
+            image.name.clone(),
+            window,
+            cx,
+        );
     }
 }

--- a/crates/ui/src/markdown/image_link.rs
+++ b/crates/ui/src/markdown/image_link.rs
@@ -1,0 +1,88 @@
+use std::path::Path;
+
+use gpui::{
+    App, Div, Entity, InteractiveElement as _, ParentElement as _, SharedString,
+    StatefulInteractiveElement as _, Styled as _, Window, div, px,
+};
+use gpui_base::Button;
+
+use crate::{icon::Icon, sizing::Sizable as _, theme::ActiveTheme as _, widgets::Tooltip};
+
+use super::{
+    MarkdownState,
+    nodes::{InlineNode, LinkMark},
+};
+
+/// Image links are recognized by their destination, without probing the client's files.
+pub(super) fn for_node(node: &InlineNode) -> Option<&LinkMark> {
+    node.marks.iter().find_map(|(range, mark)| {
+        let link = mark.link.as_ref()?;
+        if *range != (0..node.text.len()) {
+            return None;
+        }
+        let parsed = url::Url::parse(&link.url).ok();
+        let path = match &parsed {
+            Some(url) if matches!(url.scheme(), "http" | "https" | "file") => url.path(),
+            Some(_) => return None,
+            None => link.url.as_ref(),
+        };
+        let extension = Path::new(path).extension()?.to_str()?.to_ascii_lowercase();
+        matches!(
+            extension.as_str(),
+            "png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "tif" | "tiff"
+        )
+        .then_some(link)
+    })
+}
+
+pub(super) fn badge(
+    ix: usize,
+    view: Entity<MarkdownState>,
+    url: SharedString,
+    label: SharedString,
+    window: &Window,
+    cx: &App,
+) -> Div {
+    let (row_height, badge_height) = if crate::window_seam::window_is_compact(window, cx) {
+        (44., 38.)
+    } else {
+        (28., 26.)
+    };
+    let hover = cx.theme().secondary_active;
+    let tooltip_url = url.clone();
+    let badge = Button::new(("markdown-image-link", ix))
+        .rounded(px(8.))
+        .h(px(badge_height))
+        .px_2()
+        .gap_1()
+        .flex_shrink_0()
+        .max_w_full()
+        .border_1()
+        .border_color(cx.theme().border)
+        .bg(crate::material::content_surface(cx))
+        .text_size(px(13.))
+        .text_color(cx.theme().foreground)
+        .hover(move |badge| badge.bg(hover))
+        .child(
+            Icon::default()
+                .path("icons/image.svg")
+                .small()
+                .text_color(cx.theme().link),
+        )
+        .accessibility_label(label.clone())
+        .tooltip(move |window, cx| Tooltip::new(tooltip_url.clone()).build(window, cx))
+        .child(div().min_w_0().truncate().child(label.clone()))
+        .on_click(move |_, window, cx| {
+            gpui_base::TextSelection::end(window, cx);
+            cx.stop_propagation();
+            let source = view.read(cx).image_source(&url.to_string().into());
+            crate::attachments::open_image_lightbox(source, label.to_string(), window, cx);
+        });
+    // Preserve the line's spacing while shortening only the visible badge.
+    div()
+        .flex()
+        .items_center()
+        .min_h(px(row_height))
+        .max_w(px(360.))
+        .child(badge)
+}

--- a/crates/ui/src/markdown/inline_flow.rs
+++ b/crates/ui/src/markdown/inline_flow.rs
@@ -1,4 +1,4 @@
-//! Mixed text/image inline layout adapted from gpui-component's Apache-2.0
+//! Mixed text, image and badge inline layout adapted from gpui-component's Apache-2.0
 //! `text/inline_flow.rs` implementation.
 
 use std::{
@@ -23,7 +23,7 @@ use super::{
     state::MarkdownState,
 };
 
-const IMAGE_LEN: usize = 1;
+const ELEMENT_LEN: usize = 1;
 const INLINE_CODE_PADDING_X: Pixels = px(3.);
 const INLINE_CODE_PADDING_Y: Pixels = px(1.);
 
@@ -61,6 +61,10 @@ pub(super) enum InlineFlowItem {
         link: Option<LinkMark>,
         title: String,
     },
+    ImageLink {
+        url: SharedString,
+        label: SharedString,
+    },
 }
 
 #[derive(Default)]
@@ -87,7 +91,7 @@ enum PositionedFragment {
         font_overrides: Vec<(Range<usize>, SharedString)>,
         code_style: Option<InlineCodeStyle>,
     },
-    Image {
+    Element {
         item_ix: usize,
         origin: gpui::Point<Pixels>,
         size: Size<Pixels>,
@@ -102,9 +106,8 @@ enum MeasureItem {
         font_overrides: Vec<(Range<usize>, SharedString)>,
         code_style: Option<InlineCodeStyle>,
     },
-    Image {
-        url: SharedUri,
-    },
+    Image,
+    ImageLink,
 }
 
 struct LineFragmentLayout {
@@ -122,7 +125,7 @@ enum LineFragmentKind {
         font_overrides: Vec<(Range<usize>, SharedString)>,
         code_style: Option<InlineCodeStyle>,
     },
-    Image,
+    Element,
 }
 
 impl InlineFlow {
@@ -199,15 +202,28 @@ impl Element for InlineFlow {
     ) -> (LayoutId, Self::RequestLayoutState) {
         let measure_items = self.items.iter().map(MeasureItem::from).collect::<Vec<_>>();
         let line_height = window.line_height();
-        let image_sizes = measure_items
+        let element_sizes = self
+            .items
             .iter()
             .enumerate()
             .map(|(ix, item)| match item {
-                MeasureItem::Image { url } => Some(inline_image_size_for_line(
+                InlineFlowItem::Image { url, .. } => Some(inline_image_size_for_line(
                     intrinsic_image_size(ix, url, &self.view, window, cx),
                     line_height,
                 )),
-                MeasureItem::Text { .. } => None,
+                InlineFlowItem::ImageLink { url, label } => {
+                    let mut badge = super::image_link::badge(
+                        ix,
+                        self.view.clone(),
+                        url.clone(),
+                        label.clone(),
+                        window,
+                        cx,
+                    )
+                    .into_any_element();
+                    Some(badge.layout_as_root(AvailableSpace::min_size(), window, cx))
+                }
+                InlineFlowItem::Text { .. } => None,
             })
             .collect::<Vec<_>>();
         let state = InlineFlowLayoutState::default();
@@ -223,9 +239,22 @@ impl Element for InlineFlow {
                 } else {
                     None
                 };
+                let element_sizes = element_sizes
+                    .iter()
+                    .enumerate()
+                    .map(|(ix, measured)| {
+                        let mut measured = *measured;
+                        if matches!(measure_items[ix], MeasureItem::ImageLink)
+                            && let (Some(size), Some(width)) = (&mut measured, wrap_width)
+                        {
+                            size.width = size.width.min(width);
+                        }
+                        measured
+                    })
+                    .collect::<Vec<_>>();
                 let layout = layout_flow(
                     &measure_items,
-                    &image_sizes,
+                    &element_sizes,
                     &text_style,
                     wrap_width,
                     window,
@@ -316,26 +345,34 @@ impl Element for InlineFlow {
                     );
                     elements.push(element);
                 }
-                PositionedFragment::Image {
+                PositionedFragment::Element {
                     item_ix,
                     origin,
                     size: fragment_size,
                 } => {
-                    let InlineFlowItem::Image {
-                        url, link, title, ..
-                    } = &self.items[item_ix]
-                    else {
-                        continue;
+                    let mut element = match &self.items[item_ix] {
+                        InlineFlowItem::Image { url, link, title } => Self::image_element(
+                            elements.len(),
+                            self.view.clone(),
+                            url,
+                            link,
+                            title,
+                            fragment_size,
+                            cx,
+                        ),
+                        InlineFlowItem::ImageLink { url, label } => super::image_link::badge(
+                            item_ix,
+                            self.view.clone(),
+                            url.clone(),
+                            label.clone(),
+                            window,
+                            cx,
+                        )
+                        .w(fragment_size.width)
+                        .h(fragment_size.height)
+                        .into_any_element(),
+                        InlineFlowItem::Text { .. } => unreachable!(),
                     };
-                    let mut element = Self::image_element(
-                        elements.len(),
-                        self.view.clone(),
-                        url,
-                        link,
-                        title,
-                        fragment_size,
-                        cx,
-                    );
                     element.prepaint_as_root(
                         bounds.origin + origin,
                         size(
@@ -385,7 +422,8 @@ impl From<&InlineFlowItem> for MeasureItem {
                 font_overrides: font_overrides.clone(),
                 code_style: code_style.clone(),
             },
-            InlineFlowItem::Image { url, .. } => Self::Image { url: url.clone() },
+            InlineFlowItem::Image { .. } => Self::Image,
+            InlineFlowItem::ImageLink { .. } => Self::ImageLink,
         }
     }
 }
@@ -394,14 +432,14 @@ impl MeasureItem {
     fn len(&self) -> usize {
         match self {
             Self::Text { text, .. } => text.len(),
-            Self::Image { .. } => IMAGE_LEN,
+            Self::Image | Self::ImageLink => ELEMENT_LEN,
         }
     }
 }
 
 fn layout_flow(
     items: &[MeasureItem],
-    image_sizes: &[Option<Size<Pixels>>],
+    element_sizes: &[Option<Size<Pixels>>],
     text_style: &TextStyle,
     wrap_width: Option<Pixels>,
     window: &mut Window,
@@ -415,7 +453,7 @@ fn layout_flow(
     let mut fragments = Vec::new();
     let mut max_width = Pixels::ZERO;
     let mut y = Pixels::ZERO;
-    for line_range in line_ranges(items, image_sizes, text_style, wrap_width, window) {
+    for line_range in line_ranges(items, element_sizes, text_style, wrap_width, window) {
         let mut line_fragments = Vec::new();
         let mut line_width = Pixels::ZERO;
         let mut actual_line_height = line_height;
@@ -489,17 +527,17 @@ fn layout_flow(
                         });
                     }
                 }
-                MeasureItem::Image { .. } => {
+                MeasureItem::Image | MeasureItem::ImageLink => {
                     if line_range.start <= item_start && item_end <= line_range.end {
                         let image_size =
-                            image_sizes[item_ix].unwrap_or(size(line_height, line_height));
+                            element_sizes[item_ix].unwrap_or(size(line_height, line_height));
                         line_width += image_size.width;
                         actual_line_height = actual_line_height.max(image_size.height);
                         line_fragments.push(LineFragmentLayout {
                             item_ix,
-                            kind: LineFragmentKind::Image,
+                            kind: LineFragmentKind::Element,
                             size: image_size,
-                            source_range: 0..IMAGE_LEN,
+                            source_range: 0..ELEMENT_LEN,
                         });
                     }
                 }
@@ -527,7 +565,7 @@ fn layout_flow(
                     font_overrides,
                     code_style,
                 },
-                LineFragmentKind::Image => PositionedFragment::Image {
+                LineFragmentKind::Element => PositionedFragment::Element {
                     item_ix: fragment.item_ix,
                     origin,
                     size: fragment.size,
@@ -547,7 +585,7 @@ fn layout_flow(
 
 fn line_ranges(
     items: &[MeasureItem],
-    image_sizes: &[Option<Size<Pixels>>],
+    element_sizes: &[Option<Size<Pixels>>],
     text_style: &TextStyle,
     wrap_width: Option<Pixels>,
     window: &mut Window,
@@ -575,8 +613,8 @@ fn line_ranges(
                 WrapLineFragment::element(width, text.len())
             }
             MeasureItem::Text { text, .. } => WrapLineFragment::text(text),
-            MeasureItem::Image { .. } => {
-                WrapLineFragment::element(image_sizes[ix].unwrap_or_default().width, IMAGE_LEN)
+            MeasureItem::Image | MeasureItem::ImageLink => {
+                WrapLineFragment::element(element_sizes[ix].unwrap_or_default().width, ELEMENT_LEN)
             }
         })
         .collect::<Vec<_>>();

--- a/crates/ui/src/markdown/inline_flow.rs
+++ b/crates/ui/src/markdown/inline_flow.rs
@@ -11,7 +11,7 @@ use gpui::{
     AbsoluteLength, AnyElement, App, AvailableSpace, Bounds, Element, ElementId, Entity,
     GlobalElementId, HighlightStyle, Hsla, InspectorElementId, InteractiveElement as _,
     IntoElement, LayoutId, LineFragment as WrapLineFragment, ObjectFit, ParentElement as _, Pixels,
-    ShapedLine, SharedString, SharedUri, Size, StatefulInteractiveElement as _, Styled as _,
+    Role, ShapedLine, SharedString, SharedUri, Size, StatefulInteractiveElement as _, Styled as _,
     StyledImage as _, TextRun, TextStyle, WhiteSpace, Window, div, img, point,
     prelude::FluentBuilder as _, px, relative, size,
 };
@@ -150,24 +150,49 @@ impl InlineFlow {
         size: Size<Pixels>,
         cx: &App,
     ) -> AnyElement {
-        img(view.read(cx).image_source(url))
-            .id(ix)
+        let source = view.read(cx).image_source(url);
+        let link = link.clone();
+        let title = title.to_string();
+        let tooltip_title = title.clone();
+        let label = if !title.trim().is_empty() {
+            title.clone()
+        } else if let Some(link) = &link {
+            link.url.to_string()
+        } else {
+            crate::tr!("markdown.open_image").into_owned()
+        };
+        let role = if link.is_some() {
+            Role::Link
+        } else {
+            Role::Button
+        };
+        crate::material::accessible_clickable(img(source.clone()), ix, role, label, cx)
             .object_fit(ObjectFit::Contain)
             .max_w(relative(1.))
             .w(size.width)
             .h(size.height)
-            .when_some(link.clone(), |this, link| {
-                let title = title.to_string();
-                this.cursor_pointer()
-                    .tooltip(move |window, cx| Tooltip::new(title.clone()).build(window, cx))
-                    .on_click(move |_, window, cx| {
-                        gpui_base::TextSelection::end(window, cx);
-                        cx.stop_propagation();
-                        match view.read(cx).resolve_link(&link.url) {
-                            LinkTarget::Web(url) => cx.open_url(&url),
-                            LinkTarget::Local(path) => cx.open_with_system(&path),
-                        }
-                    })
+            .cursor_pointer()
+            .when(link.is_some(), |image| {
+                image.tooltip(move |window, cx| {
+                    Tooltip::new(tooltip_title.clone()).build(window, cx)
+                })
+            })
+            .on_click(move |_, window, cx| {
+                gpui_base::TextSelection::end(window, cx);
+                cx.stop_propagation();
+                if let Some(link) = &link {
+                    match view.read(cx).resolve_link(&link.url) {
+                        LinkTarget::Web(url) => cx.open_url(&url),
+                        LinkTarget::Local(path) => cx.open_with_system(&path),
+                    }
+                } else {
+                    crate::attachments::open_image_lightbox(
+                        source.clone(),
+                        title.clone(),
+                        window,
+                        cx,
+                    );
+                }
             })
             .into_any_element()
     }

--- a/crates/ui/src/markdown/inline_flow.rs
+++ b/crates/ui/src/markdown/inline_flow.rs
@@ -145,8 +145,9 @@ impl InlineFlow {
         link: &Option<LinkMark>,
         title: &str,
         size: Size<Pixels>,
+        cx: &App,
     ) -> AnyElement {
-        img(url.clone())
+        img(view.read(cx).image_source(url))
             .id(ix)
             .object_fit(ObjectFit::Contain)
             .max_w(relative(1.))
@@ -203,7 +204,7 @@ impl Element for InlineFlow {
             .enumerate()
             .map(|(ix, item)| match item {
                 MeasureItem::Image { url } => Some(inline_image_size_for_line(
-                    intrinsic_image_size(ix, url, window, cx),
+                    intrinsic_image_size(ix, url, &self.view, window, cx),
                     line_height,
                 )),
                 MeasureItem::Text { .. } => None,
@@ -333,6 +334,7 @@ impl Element for InlineFlow {
                         link,
                         title,
                         fragment_size,
+                        cx,
                     );
                     element.prepaint_as_root(
                         bounds.origin + origin,
@@ -602,10 +604,11 @@ fn line_ranges(
 fn intrinsic_image_size(
     ix: usize,
     url: &SharedUri,
+    view: &Entity<MarkdownState>,
     window: &mut Window,
     cx: &mut App,
 ) -> Option<Size<Pixels>> {
-    let mut image = img(url.clone())
+    let mut image = img(view.read(cx).image_source(url))
         .id(ix)
         .object_fit(ObjectFit::Contain)
         .max_w(relative(1.))

--- a/crates/ui/src/markdown/mod.rs
+++ b/crates/ui/src/markdown/mod.rs
@@ -4,6 +4,7 @@
 //! `crates/ui/src/text` implementation. Parsing and highlighting use tcode's
 //! rushdown IR and syntect bridge.
 
+mod image_link;
 mod inline;
 mod inline_flow;
 mod link_target;

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -495,10 +495,11 @@ fn render_paragraph(
             .children(images.enumerate().map(move |(ix, image)| {
                 let title = image.title();
                 let view = view.clone();
-                img(image.url.clone())
+                img(view.read(cx).image_source(&image.url))
                     .id(ix)
                     .object_fit(ObjectFit::Contain)
                     .max_w(relative(1.))
+                    .max_h(px(240.))
                     .min_w(px(15.))
                     .min_h(px(15.))
                     .when_some(image.link.clone(), |this, link| {

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -19,10 +19,10 @@ use crate::widgets::tooltip::Tooltip;
 use gpui::{
     AnyElement, App, AvailableSpace, Bounds, Element, ElementId, Entity, FontStyle, FontWeight,
     GlobalElementId, HighlightStyle, InspectorElementId, InteractiveElement as _, IntoElement,
-    LayoutId, ListSizingBehavior, ListState, ObjectFit, ParentElement as _, Pixels, ScrollHandle,
-    ScrollWheelEvent, SharedString, StatefulInteractiveElement as _, Style, Styled as _,
-    StyledImage as _, TouchPhase, Window, div, img, prelude::FluentBuilder as _, px, relative,
-    rems, size,
+    LayoutId, ListSizingBehavior, ListState, ObjectFit, ParentElement as _, Pixels, Role,
+    ScrollHandle, ScrollWheelEvent, SharedString, StatefulInteractiveElement as _, Style,
+    Styled as _, StyledImage as _, TouchPhase, Window, div, img, prelude::FluentBuilder as _, px,
+    relative, rems, size,
 };
 use gpui_base::{h_flex, v_flex};
 
@@ -498,28 +498,50 @@ fn render_paragraph(
             .gap_1()
             .children(images.enumerate().map(move |(ix, image)| {
                 let title = image.title();
+                let tooltip_title = title.clone();
                 let view = view.clone();
-                img(view.read(cx).image_source(&image.url))
-                    .id(ix)
+                let source = view.read(cx).image_source(&image.url);
+                let link = image.link.clone();
+                let label = if !title.trim().is_empty() {
+                    title.clone()
+                } else if let Some(link) = &link {
+                    link.url.to_string()
+                } else {
+                    crate::tr!("markdown.open_image").into_owned()
+                };
+                let role = if link.is_some() {
+                    Role::Link
+                } else {
+                    Role::Button
+                };
+                crate::material::accessible_clickable(img(source.clone()), ix, role, label, cx)
                     .object_fit(ObjectFit::Contain)
                     .max_w(relative(1.))
                     .max_h(px(720.))
                     .min_w(px(15.))
                     .min_h(px(15.))
-                    .when_some(image.link.clone(), |this, link| {
-                        let title = title.clone();
-                        this.cursor_pointer()
-                            .tooltip(move |window, cx| {
-                                Tooltip::new(title.clone()).build(window, cx)
-                            })
-                            .on_click(move |_, window, cx| {
-                                gpui_base::TextSelection::end(window, cx);
-                                cx.stop_propagation();
-                                match view.read(cx).resolve_link(&link.url) {
-                                    LinkTarget::Web(url) => cx.open_url(&url),
-                                    LinkTarget::Local(path) => cx.open_with_system(&path),
-                                }
-                            })
+                    .cursor_pointer()
+                    .when(link.is_some(), |image| {
+                        image.tooltip(move |window, cx| {
+                            Tooltip::new(tooltip_title.clone()).build(window, cx)
+                        })
+                    })
+                    .on_click(move |_, window, cx| {
+                        gpui_base::TextSelection::end(window, cx);
+                        cx.stop_propagation();
+                        if let Some(link) = &link {
+                            match view.read(cx).resolve_link(&link.url) {
+                                LinkTarget::Web(url) => cx.open_url(&url),
+                                LinkTarget::Local(path) => cx.open_with_system(&path),
+                            }
+                        } else {
+                            crate::attachments::open_image_lightbox(
+                                source.clone(),
+                                title.clone(),
+                                window,
+                                cx,
+                            );
+                        }
                     })
             }))
             .into_any_element();

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -474,7 +474,11 @@ fn render_paragraph(
         .children
         .iter()
         .any(|child| !child.text.is_empty());
-    if has_image && has_text {
+    let has_image_link = paragraph
+        .children
+        .iter()
+        .any(|child| super::image_link::for_node(child).is_some());
+    if (has_image && has_text) || has_image_link {
         return InlineFlow::new(
             id.to_string(),
             view.clone(),
@@ -621,6 +625,21 @@ fn inline_flow_items(paragraph: &Paragraph, cx: &mut App) -> Vec<InlineFlowItem>
             });
         };
     for child in &paragraph.children {
+        if let Some(link) = super::image_link::for_node(child) {
+            flush_text(
+                &mut items,
+                &mut text,
+                &mut links,
+                &mut highlights,
+                &mut fonts,
+                &mut segment_state,
+            );
+            items.push(InlineFlowItem::ImageLink {
+                url: link.url.clone(),
+                label: child.text.clone(),
+            });
+            continue;
+        }
         if let Some(image) = &child.image {
             flush_text(
                 &mut items,

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -503,7 +503,7 @@ fn render_paragraph(
                     .id(ix)
                     .object_fit(ObjectFit::Contain)
                     .max_w(relative(1.))
-                    .max_h(px(240.))
+                    .max_h(px(720.))
                     .min_w(px(15.))
                     .min_h(px(15.))
                     .when_some(image.link.clone(), |this, link| {

--- a/crates/ui/src/markdown/state.rs
+++ b/crates/ui/src/markdown/state.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use gpui::{
-    Bounds, Context, FocusHandle, IntoElement, ListAlignment, ListState, ParentElement as _,
-    Pixels, Point, Render, SharedString, Styled as _, Window, px,
+    Bounds, Context, FocusHandle, ImageSource, IntoElement, ListAlignment, ListState,
+    ParentElement as _, Pixels, Point, Render, SharedString, SharedUri, Styled as _, Window, px,
 };
 use gpui_base::{ElementExt as _, v_flex};
 
@@ -169,6 +169,37 @@ impl MarkdownState {
 
     pub(super) fn resolve_link(&self, url: &str) -> LinkTarget {
         self.link_targets.resolve(url, self.base_dir())
+    }
+
+    /// Markdown file images belong to the attached host, including relative paths.
+    /// Do not check the client's filesystem before asking that host for the bytes.
+    pub(super) fn image_source(&self, uri: &SharedUri) -> ImageSource {
+        let path = PathBuf::from(uri.as_ref());
+        if path.is_absolute() {
+            return crate::store::host_image(path);
+        }
+        if let Ok(url) = url::Url::parse(uri.as_ref()) {
+            if url.scheme() == "file"
+                && let Ok(path) = percent_encoding::percent_decode_str(url.path()).decode_utf8()
+            {
+                // Decode the host's path without the viewing platform's filesystem rules.
+                let path = match url.host_str() {
+                    Some(host) => format!("//{host}{path}"),
+                    None => path.into_owned(),
+                };
+                let path = path
+                    .strip_prefix('/')
+                    .filter(|path| path.as_bytes().get(1) == Some(&b':'))
+                    .unwrap_or(&path);
+                return crate::store::host_image(PathBuf::from(path));
+            }
+            return uri.clone().into();
+        }
+        let path = match self.base_dir() {
+            Some(base_dir) => base_dir.join(path),
+            None => path,
+        };
+        crate::store::host_image(path)
     }
 
     pub(super) fn set_pending_context_link(

--- a/crates/ui/src/material.rs
+++ b/crates/ui/src/material.rs
@@ -399,16 +399,16 @@ pub(crate) fn tracked_uppercase(text: &str) -> Div {
 
 /// Gives a raw clickable surface the same keyboard and accessibility treatment
 /// as the component-library controls. GPUI automatically maps Enter/Space to
-/// `on_click` for a focused clickable div; this helper supplies the tab stop,
+/// `on_click` for a focused clickable element; this helper supplies the tab stop,
 /// semantic role/name, and a keyboard-only outline that remains legible in
 /// both themes without changing layout.
-pub fn accessible_clickable(
-    el: Div,
+pub fn accessible_clickable<E: gpui::Element + gpui::InteractiveElement>(
+    el: E,
     id: impl Into<ElementId>,
     role: Role,
     label: impl Into<SharedString>,
     cx: &App,
-) -> Stateful<Div> {
+) -> Stateful<E> {
     let ring = cx.theme().ring.opacity(if cx.theme().mode.is_dark() {
         0.72
     } else {

--- a/crates/ui/src/material.rs
+++ b/crates/ui/src/material.rs
@@ -212,9 +212,9 @@ pub fn brand_wordmark(cx: &App) -> impl IntoElement {
     )
 }
 
-/// The scrim behind a bottom sheet, at the `overlay` token's values
+/// The scrim behind modal overlays, at the `overlay` token's values
 /// (`themes/tcode.json`: `#1F232852` light, `#00000080` dark). Passing the ink
-/// `foreground` through in dark mode would *lighten* the page behind the sheet
+/// `foreground` through in dark mode would *lighten* the page behind the overlay
 /// instead of pushing it back, so the dark scrim is black.
 pub fn scrim(progress: f32, cx: &App) -> Hsla {
     if cx.theme().mode.is_dark() {

--- a/crates/ui/src/overlay/dialog.rs
+++ b/crates/ui/src/overlay/dialog.rs
@@ -371,13 +371,10 @@ impl RenderOnce for Dialog {
         let content = self
             .content
             .map(|builder| builder(DialogContent::new(), window, cx));
-        let backdrop = div().absolute().size_full().when(self.overlay, |el| {
-            el.bg(cx.theme().foreground.opacity(if cx.theme().mode.is_dark() {
-                0.32
-            } else {
-                0.18
-            }))
-        });
+        let backdrop = div()
+            .absolute()
+            .size_full()
+            .when(self.overlay, |el| el.bg(crate::material::scrim(1., cx)));
         let popup = div()
             .id(("tcode-dialog", self.layer))
             .absolute()

--- a/crates/ui/src/overlay/mod.rs
+++ b/crates/ui/src/overlay/mod.rs
@@ -143,6 +143,39 @@ impl Render for OverlayHost {
         div()
             .relative()
             .size_full()
+            .on_key_down(|event, window, cx| {
+                let modifiers = event.keystroke.modifiers;
+                if event.keystroke.key == "tab"
+                    && !modifiers.control
+                    && !modifiers.alt
+                    && !modifiers.platform
+                    && !modifiers.function
+                {
+                    let step = |window: &mut Window, cx: &mut App| {
+                        if modifiers.shift {
+                            window.focus_prev(cx);
+                        } else {
+                            window.focus_next(cx);
+                        }
+                    };
+                    let before = window.focused(cx);
+                    let trap = gpui_base::active_focus_trap(window, cx);
+                    step(window, cx);
+                    if let Some(trap) = trap {
+                        let first = window.focused(cx);
+                        while !trap.contains_focused(window, cx) {
+                            step(window, cx);
+                            if window.focused(cx) == first {
+                                if let Some(before) = before {
+                                    before.focus(window, cx);
+                                }
+                                break;
+                            }
+                        }
+                    }
+                    cx.stop_propagation();
+                }
+            })
             .bg(cx.theme().background)
             .text_color(cx.theme().foreground)
             .font_family(cx.theme().font_family.clone())

--- a/crates/ui/src/run.rs
+++ b/crates/ui/src/run.rs
@@ -103,6 +103,18 @@ pub fn run_shell(
     seam: WindowSeam,
     options: ShellOptions,
 ) -> (WindowHandle<OverlayHost>, Entity<AppShell>) {
+    // Browser bootstrap supplies its Fetch client; native image URLs need an HTTP client too.
+    #[cfg(not(target_family = "wasm"))]
+    {
+        let client = reqwest::Client::builder()
+            .use_rustls_tls()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .build()
+            .expect("failed to initialize image HTTP client");
+        cx.set_http_client(std::sync::Arc::new(reqwest_client::ReqwestClient::from(
+            client,
+        )));
+    }
     crate::i18n::set_platform_system_locale(options.system_locale.as_deref());
     let language = host.load_preferences().language;
     crate::i18n::apply_locale(match language.as_deref() {

--- a/crates/ui/src/store/images.rs
+++ b/crates/ui/src/store/images.rs
@@ -57,9 +57,10 @@ pub(crate) fn host_image(path: PathBuf) -> ImageSource {
 mod tests {
     use super::*;
     use crate::markdown::{MarkdownState, MarkdownView};
+    use crate::overlay::OverlayExt as _;
     use gpui::{
-        AppContext as _, Context, Entity, IntoElement, ParentElement as _, Render, Styled as _,
-        TestAppContext, Window, div, px,
+        AppContext as _, Context, Entity, InteractiveElement as _, IntoElement, KeyUpEvent,
+        Keystroke, ParentElement as _, Render, Styled as _, TestAppContext, Window, div, px,
     };
     use tcode_protocol::{ClientPayload, HostMessage, decode_client_line, encode_line};
 
@@ -71,6 +72,8 @@ mod tests {
     impl Render for ImageMessage {
         fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
             div()
+                .id("image-message")
+                .tab_index(0)
                 .w(px(320.))
                 .child(MarkdownView::new(&self.markdown).base_dir(self.cwd.clone()))
         }
@@ -157,6 +160,54 @@ mod tests {
                     )
                     .unwrap();
                 cx.run_until_parked();
+            }
+
+            cx.update(|window, cx| {
+                window.blur(cx);
+                window.focus_next(cx);
+            });
+            cx.simulate_keystrokes("tab");
+            let image_focus = cx.update(|window, cx| {
+                _ = window.draw(cx);
+                window
+                    .focused(cx)
+                    .expect("the displayed image is a tab stop")
+            });
+            cx.simulate_keystrokes("shift-tab");
+            cx.update(|window, _| assert!(!image_focus.is_focused(window)));
+            cx.simulate_keystrokes("tab");
+            cx.update(|window, _| assert!(image_focus.is_focused(window)));
+            for key in ["enter", "space"] {
+                cx.simulate_keystrokes(key);
+                cx.simulate_event(KeyUpEvent {
+                    keystroke: Keystroke::parse(key).unwrap(),
+                });
+                cx.run_until_parked();
+                cx.update(|window, _| {
+                    assert!(
+                        !image_focus.is_focused(window),
+                        "{key} must move focus into the image lightbox"
+                    );
+                });
+                for navigation in ["tab", "shift-tab"] {
+                    cx.simulate_keystrokes(navigation);
+                    cx.update(|window, cx| {
+                        assert!(
+                            gpui_base::active_focus_trap(window, cx)
+                                .expect("the lightbox traps focus")
+                                .contains_focused(window, cx),
+                            "{navigation} must keep focus inside the lightbox"
+                        );
+                    });
+                }
+                cx.update(|window, cx| {
+                    window.close_dialog(cx);
+                    assert!(
+                        image_focus.is_focused(window),
+                        "closing the lightbox must restore image focus"
+                    );
+                    _ = window.draw(cx);
+                });
             }
         }
 

--- a/crates/ui/src/store/images.rs
+++ b/crates/ui/src/store/images.rs
@@ -52,3 +52,106 @@ pub(crate) fn host_image(path: PathBuf) -> ImageSource {
         }
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::markdown::{MarkdownState, MarkdownView};
+    use gpui::{
+        AppContext as _, Context, Entity, IntoElement, ParentElement as _, Render, Styled as _,
+        TestAppContext, Window, div, px,
+    };
+    use tcode_protocol::{ClientPayload, HostMessage, decode_client_line, encode_line};
+
+    struct ImageMessage {
+        markdown: Entity<MarkdownState>,
+        cwd: PathBuf,
+    }
+
+    impl Render for ImageMessage {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .w(px(320.))
+                .child(MarkdownView::new(&self.markdown).base_dir(self.cwd.clone()))
+        }
+    }
+
+    #[gpui::test]
+    fn markdown_block_and_inline_images_read_files_from_the_host(cx: &mut TestAppContext) {
+        cx.update(crate::theme::init);
+        cx.update(crate::markdown::init);
+        let (to_host, requests) = async_channel::unbounded();
+        let (replies, from_host) = async_channel::unbounded();
+        let link = HostLink::new(to_host, from_host);
+        cx.update(|cx| {
+            cx.set_global(HostImages {
+                link: Some(link.clone()),
+                namespace: 1,
+            });
+        });
+        let executor = cx.background_executor.clone();
+        let _pump = cx.background_executor.spawn(async move {
+            link.pump_with_timer(|| executor.timer(std::time::Duration::from_millis(25)))
+                .await;
+        });
+        // These paths exist only on the scripted host, never on the viewing client.
+        let cwd = std::env::current_dir().unwrap().join("host-only-images");
+        let (view, cx) = cx.add_window_view(|_, cx| ImageMessage {
+            markdown: cx.new(|cx| MarkdownState::new("", cx)),
+            cwd: cwd.clone(),
+        });
+        for inline in [false, true] {
+            let suffix = if inline { "inline" } else { "block" };
+            let absolute = cwd.join(format!("absolute-{suffix}.png"));
+            let relative = format!("relative-{suffix}.png");
+            let file_url_path = cwd.join(format!("file image-{suffix}.png"));
+            let cases = [
+                (absolute.display().to_string(), absolute),
+                (relative.clone(), cwd.join(relative)),
+                (
+                    url::Url::from_file_path(&file_url_path).unwrap().into(),
+                    file_url_path,
+                ),
+            ];
+            for (uri, expected_path) in cases {
+                let mut markdown = format!("![sample](<{uri}>)");
+                if inline {
+                    markdown = format!("Before {markdown} after");
+                }
+                view.update(cx, |view, cx| {
+                    view.markdown
+                        .update(cx, |state, cx| state.set_text(&markdown, cx));
+                });
+                cx.update(|window, cx| {
+                    let _ = window.draw(cx);
+                });
+                cx.run_until_parked();
+                let request = decode_client_line(
+                    &requests
+                        .try_recv()
+                        .expect("Markdown image must query its host"),
+                )
+                .unwrap();
+                assert_eq!(
+                    request.payload,
+                    ClientPayload::Query(Query::ReadFileBytes {
+                        path: expected_path
+                    }),
+                    "{markdown}",
+                );
+                replies
+                    .send_blocking(
+                        encode_line(&HostMessage::QueryResult {
+                            id: request.id,
+                            result: Ok(QueryResponse::FileBytes(
+                                include_bytes!("../../../../assets/icons/app/tcode.png").to_vec(),
+                            )),
+                        })
+                        .unwrap(),
+                    )
+                    .unwrap();
+                cx.run_until_parked();
+            }
+        }
+    }
+}

--- a/crates/ui/src/store/images.rs
+++ b/crates/ui/src/store/images.rs
@@ -77,7 +77,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn markdown_block_and_inline_images_read_files_from_the_host(cx: &mut TestAppContext) {
+    fn markdown_images_and_badge_previews_read_files_from_the_host(cx: &mut TestAppContext) {
         cx.update(crate::theme::init);
         cx.update(crate::markdown::init);
         let (to_host, requests) = async_channel::unbounded();
@@ -96,10 +96,16 @@ mod tests {
         });
         // These paths exist only on the scripted host, never on the viewing client.
         let cwd = std::env::current_dir().unwrap().join("host-only-images");
-        let (view, cx) = cx.add_window_view(|_, cx| ImageMessage {
-            markdown: cx.new(|cx| MarkdownState::new("", cx)),
-            cwd: cwd.clone(),
+        let mut message = None;
+        let (_, cx) = cx.add_window_view(|window, cx| {
+            let view = cx.new(|cx| ImageMessage {
+                markdown: cx.new(|cx| MarkdownState::new("", cx)),
+                cwd: cwd.clone(),
+            });
+            message = Some(view.clone());
+            crate::overlay::OverlayHost::new(view, window, cx)
         });
+        let view = message.unwrap();
         for inline in [false, true] {
             let suffix = if inline { "inline" } else { "block" };
             let absolute = cwd.join(format!("absolute-{suffix}.png"));
@@ -153,5 +159,37 @@ mod tests {
                 cx.run_until_parked();
             }
         }
+
+        view.update(cx, |view, cx| {
+            view.markdown.update(cx, |state, cx| {
+                state.set_text("[Screenshot](preview.png)", cx);
+            });
+        });
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            requests.is_empty(),
+            "a badge loads its image only when opened"
+        );
+        cx.simulate_click(gpui::point(px(40.), px(14.)), gpui::Modifiers::default());
+        cx.run_until_parked();
+        let request = decode_client_line(
+            &requests
+                .try_recv()
+                .expect("clicking the image badge must read its host image"),
+        )
+        .unwrap();
+        assert_eq!(
+            request.payload,
+            ClientPayload::Query(Query::ReadFileBytes {
+                path: cwd.join("preview.png")
+            })
+        );
+        assert!(
+            cx.opened_url().is_none(),
+            "host image badges must open in the app"
+        );
     }
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -657,6 +657,13 @@ platform pays that inset.
   standalone images and images mixed with text. Standalone images fit within
   the available width and a 240pt height limit, preserving their aspect ratio
   without cropping. Images mixed with text retain their line-height sizing.
+  Links to image files render as rounded badges with a leading image icon and
+  the link label, the same subtle background as changed-file badges, a border,
+  and a hover state. Badges wrap with surrounding prose; long labels truncate
+  to the available width. Badges are
+  26pt high in 28pt rows, or 38pt high in 44pt rows in compact layouts, leaving
+  space between stacked badges. They open the shared image lightbox,
+  loading host files through the attached host. Other links retain prose styling.
 - User messages: right-aligned bubble, muted bg, radius 12, max-width 75%.
 - A confirmed provider handoff inserts a subtle centered divider chip before
   the next user bubble: “Relayed from X to Y”. The injected handoff transcript

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -651,6 +651,12 @@ platform pays that inset.
   disclosure rather than disappearing.
 - Assistant Markdown follows the prose typography above. Streaming follows the
   latest output only while the reader remains near the bottom.
+  File images load from the attached host on every client, resolving relative
+  paths against the thread's working directory. File URLs use the same loader;
+  HTTP(S) images load through the client's HTTP implementation. This applies to
+  standalone images and images mixed with text. Standalone images fit within
+  the available width and a 240pt height limit, preserving their aspect ratio
+  without cropping. Images mixed with text retain their line-height sizing.
 - User messages: right-aligned bubble, muted bg, radius 12, max-width 75%.
 - A confirmed provider handoff inserts a subtle centered divider chip before
   the next user bubble: “Relayed from X to Y”. The injected handoff transcript

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -120,6 +120,9 @@ the shell, dialogs and toasts. Overlay text inherits these defaults, including
 when switching between light and dark mode; explicit semantic colors and
 monospace text override them where needed.
 
+Dialog backdrops, including the image lightbox, use the shared dimming scrim
+from the command palette and sheets. They darken the page in both themes.
+
 ## Window material
 
 The persistent main window uses native backdrop material: macOS keeps its
@@ -655,7 +658,7 @@ platform pays that inset.
   paths against the thread's working directory. File URLs use the same loader;
   HTTP(S) images load through the client's HTTP implementation. This applies to
   standalone images and images mixed with text. Standalone images fit within
-  the available width and a 240pt height limit, preserving their aspect ratio
+  the available width and a 720pt height limit, preserving their aspect ratio
   without cropping. Images mixed with text retain their line-height sizing.
   Links to image files render as rounded badges with a leading image icon and
   the link label, the same subtle background as changed-file badges, a border,
@@ -664,6 +667,9 @@ platform pays that inset.
   26pt high in 28pt rows, or 38pt high in 44pt rows in compact layouts, leaving
   space between stacked badges. They open the shared image lightbox,
   loading host files through the attached host. Other links retain prose styling.
+  The lightbox is up to 1200pt wide, capped to the viewport with at least 16pt side
+  margins, and its image is limited to 75% of the window height. Short windows
+  shrink the image further to leave room for the dialog header and padding.
 - User messages: right-aligned bubble, muted bg, radius 12, max-width 75%.
 - A confirmed provider handoff inserts a subtle centered divider chip before
   the next user bubble: “Relayed from X to Y”. The injected handoff transcript

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -660,6 +660,11 @@ platform pays that inset.
   standalone images and images mixed with text. Standalone images fit within
   the available width and a 720pt height limit, preserving their aspect ratio
   without cropping. Images mixed with text retain their line-height sizing.
+  Clicking a displayed image opens the shared image lightbox, for both standalone
+  images and images mixed with text. Images wrapped in a link keep their link action.
+  Images are keyboard-focusable controls with the shared focus ring. Enter and
+  Space activate them; their accessible name uses the image title or alt text,
+  falling back to the link destination or a localized “Open image” label.
   Links to image files render as rounded badges with a leading image icon and
   the link label, the same subtle background as changed-file badges, a border,
   and a hover state. Badges wrap with surrounding prose; long labels truncate
@@ -1186,6 +1191,9 @@ so it remains legible over both paper and carbon surfaces without shifting
 layout. Component-library controls retain their native focus treatment. Hidden
 row actions must enter the normal tab order and reveal themselves when focused,
 not depend on pointer hover.
+
+Tab and Shift+Tab move through focusable controls when the focused surface does
+not handle the key itself. Navigation stays within the active popup's focus trap.
 
 Interactive surfaces expose the semantic role that matches their behavior
 (button, tab, switch, menu item, option, or terminal) and a localized accessible

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -94,6 +94,7 @@ chat:
   rewind_conversation_done: "Claude Code restored the conversation. The original prompt is ready to edit."
   rewind_files_done: "Claude Code restored the tracked files."
 markdown:
+  open_image: "Open image"
   link_open: "Open link"
   link_copy_address: "Copy link address"
   link_copy_text: "Copy link text"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -94,6 +94,7 @@ chat:
   rewind_conversation_done: "Claude Code 已恢复对话，原始提示已放回输入框，可编辑后重发。"
   rewind_files_done: "Claude Code 已恢复其跟踪的文件。"
 markdown:
+  open_image: "打开图片"
   link_open: "打开链接"
   link_copy_address: "复制链接地址"
   link_copy_text: "复制链接文字"


### PR DESCRIPTION
Images in agent replies could fail to appear when viewing a thread from another device. Tcode was looking for those files on the viewing device instead of the machine running the thread. It now reads them from that machine and uses the thread’s working folder to find files whose paths do not include a full location.

Web images still load on the viewing device, using the new reqwest library. Images stored on the machine running the thread use Tcode’s existing file reader.

Images fit within the available space and open in a larger viewer when clicked. Images that link somewhere still open their link. Links to image files get a preview button, and the image only loads when you open it. You can reach and open images with the keyboard. While the viewer is open, keyboard navigation stays inside it and returns to the original control when it closes.

The new test covers different file locations, previews loading only when opened, and keyboard navigation into and out of the image viewer.

| Before | After |
| --- | --- |
|<img width="1100" height="850" alt="image" src="https://github.com/user-attachments/assets/9d807d46-1c31-4a63-9e58-0ce07a56df83" />| <img width="1100" height="850" alt="image" src="https://github.com/user-attachments/assets/5b2036a1-110c-4407-8855-156948c8abda" /> |

Implemented with GPT-6 Astra in Tcode